### PR TITLE
[codex] Add creature combatant factory

### DIFF
--- a/src/domain/creatures/clone.test.ts
+++ b/src/domain/creatures/clone.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'vitest';
+import { expectSerializable } from '../test-support';
+import type { Creature } from '../types';
+import { createCombatantFromCreature } from './clone';
+
+describe('createCombatantFromCreature', () => {
+  test('creates mutable encounter state from a creature template', () => {
+    const creature = creatureTemplate();
+
+    const combatant = createCombatantFromCreature({
+      creature,
+      combatantId: 'goblin-1',
+      name: 'Goblin Warrior 1'
+    });
+
+    expect(combatant).toMatchObject({
+      id: 'goblin-1',
+      creatureId: 'goblin-warrior',
+      name: 'Goblin Warrior 1',
+      sourceType: 'creature',
+      baseStats: {
+        hp: 18,
+        ac: 16,
+        fortitude: 6,
+        reflex: 8,
+        will: 5,
+        perception: 7,
+        speed: 25,
+        skills: { acrobatics: 8, stealth: 10 }
+      },
+      currentHp: 18,
+      tempHp: 0,
+      appliedEffects: [],
+      reactionUsedThisRound: false,
+      isAlive: true,
+      traits: ['goblin', 'humanoid'],
+      size: 'small',
+      level: 1
+    });
+    expect(combatant.attacks).toHaveLength(1);
+    expect(combatant.passiveAbilities).toHaveLength(1);
+    expect(combatant.reactiveAbilities).toHaveLength(1);
+    expect(combatant.activeAbilities).toHaveLength(1);
+    expectSerializable(combatant);
+  });
+
+  test('defaults the combatant name to the creature name', () => {
+    const combatant = createCombatantFromCreature({
+      creature: creatureTemplate(),
+      combatantId: 'goblin-1'
+    });
+
+    expect(combatant.name).toBe('Goblin Warrior');
+  });
+
+  test('deep-clones creature display data and skills', () => {
+    const creature = creatureTemplate();
+
+    const combatant = createCombatantFromCreature({
+      creature,
+      combatantId: 'goblin-1'
+    });
+
+    combatant.baseStats.skills.stealth = 99;
+    combatant.traits?.push('elite');
+    combatant.attacks[0].traits.push('backswing');
+    combatant.attacks[0].damage[0].bonus = 99;
+    combatant.passiveAbilities[0].description = 'Changed on combatant only';
+
+    expect(creature.skills.stealth).toBe(10);
+    expect(creature.traits).toEqual(['goblin', 'humanoid']);
+    expect(creature.attacks[0].traits).toEqual(['agile', 'finesse']);
+    expect(creature.attacks[0].damage[0].bonus).toBe(2);
+    expect(creature.passiveAbilities[0].description).toBe('Goblins are hard to pin down.');
+  });
+
+  test('hydrates spellcasting usage fields without mutating spellcasting templates', () => {
+    const creature = creatureTemplate({
+      spellcasting: [
+        {
+          blockId: 'arcane-prepared',
+          name: 'Arcane Prepared Spells',
+          tradition: 'arcane',
+          type: 'prepared',
+          dc: 18,
+          attackModifier: 10,
+          slots: { 1: 3 },
+          entries: [{ spellSlug: 'force-barrage', name: 'Force Barrage', level: 1, count: 2 }]
+        },
+        {
+          blockId: 'focus',
+          name: 'Focus Spells',
+          tradition: 'occult',
+          type: 'focus',
+          dc: 17,
+          focusPoints: 1,
+          entries: [{ spellSlug: 'phase-bolt', name: 'Phase Bolt', level: 1 }]
+        },
+        {
+          blockId: 'innate',
+          name: 'Primal Innate Spells',
+          tradition: 'primal',
+          type: 'innate',
+          dc: 16,
+          entries: [
+            { spellSlug: 'detect-magic', name: 'Detect Magic', level: 1, frequency: { type: 'atWill' } },
+            { spellSlug: 'fear', name: 'Fear', level: 1, frequency: { type: 'perDay', uses: 1 } }
+          ]
+        }
+      ]
+    });
+
+    const combatant = createCombatantFromCreature({
+      creature,
+      combatantId: 'caster-1'
+    });
+
+    expect(combatant.spellcasting).toEqual([
+      expect.objectContaining({ blockId: 'arcane-prepared', usedSlots: {}, usedFocusPoints: undefined, usedEntries: undefined }),
+      expect.objectContaining({ blockId: 'focus', usedSlots: undefined, usedFocusPoints: 0, usedEntries: undefined }),
+      expect.objectContaining({ blockId: 'innate', usedSlots: undefined, usedFocusPoints: undefined, usedEntries: {} })
+    ]);
+
+    expect(combatant.spellcasting).toBeDefined();
+    combatant.spellcasting![0].entries[0].name = 'Changed';
+    expect(creature.spellcasting?.[0].entries[0].name).toBe('Force Barrage');
+  });
+
+  test('falls back to the first available speed when land speed is absent', () => {
+    const combatant = createCombatantFromCreature({
+      creature: creatureTemplate({ speed: { fly: 40, swim: 20 } }),
+      combatantId: 'sprite-1'
+    });
+
+    expect(combatant.baseStats.speed).toBe(40);
+  });
+});
+
+function creatureTemplate(overrides: Partial<Creature> = {}): Creature {
+  return {
+    id: 'goblin-warrior',
+    name: 'Goblin Warrior',
+    level: 1,
+    traits: ['goblin', 'humanoid'],
+    size: 'small',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 6,
+    reflex: 8,
+    will: 5,
+    perception: 7,
+    hp: 18,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [
+      {
+        name: 'dogslicer',
+        type: 'melee',
+        modifier: 8,
+        traits: ['agile', 'finesse'],
+        damage: [{ dice: 1, dieSize: 6, bonus: 2, type: 'slashing' }]
+      }
+    ],
+    passiveAbilities: [
+      {
+        name: 'Goblin Scuttle',
+        description: 'Goblins are hard to pin down.'
+      }
+    ],
+    reactiveAbilities: [
+      {
+        name: 'Reactive Strike',
+        actions: 'reaction',
+        trigger: 'A creature within reach uses a manipulate action.',
+        description: 'Strike the triggering creature.'
+      }
+    ],
+    activeAbilities: [
+      {
+        name: 'Slash',
+        actions: 1,
+        description: 'Make a dogslicer Strike.'
+      }
+    ],
+    skills: { acrobatics: 8, stealth: 10 },
+    tags: [],
+    ...overrides
+  };
+}

--- a/src/domain/creatures/clone.ts
+++ b/src/domain/creatures/clone.ts
@@ -1,0 +1,64 @@
+import type { CombatantState, CombatantSpellcasting, Creature, SpellcastingBlock } from '../types';
+
+export interface CreateCombatantFromCreatureInput {
+  creature: Creature;
+  combatantId: string;
+  name?: string;
+}
+
+export function createCombatantFromCreature({
+  creature,
+  combatantId,
+  name
+}: CreateCombatantFromCreatureInput): CombatantState {
+  return {
+    id: combatantId,
+    creatureId: creature.id,
+    name: name ?? creature.name,
+    sourceType: 'creature',
+    baseStats: {
+      hp: creature.hp,
+      ac: creature.ac,
+      fortitude: creature.fortitude,
+      reflex: creature.reflex,
+      will: creature.will,
+      perception: creature.perception,
+      speed: primarySpeed(creature.speed),
+      skills: cloneValue(creature.skills)
+    },
+    currentHp: creature.hp,
+    tempHp: 0,
+    appliedEffects: [],
+    reactionUsedThisRound: false,
+    isAlive: true,
+    attacks: cloneValue(creature.attacks),
+    passiveAbilities: cloneValue(creature.passiveAbilities),
+    reactiveAbilities: cloneValue(creature.reactiveAbilities),
+    activeAbilities: cloneValue(creature.activeAbilities),
+    spellcasting: creature.spellcasting ? hydrateSpellcasting(creature.spellcasting) : undefined,
+    traits: cloneValue(creature.traits),
+    size: creature.size,
+    level: creature.level
+  };
+}
+
+function hydrateSpellcasting(blocks: SpellcastingBlock[]): CombatantSpellcasting[] {
+  return blocks.map((block) => ({
+    ...cloneValue(block),
+    usedSlots: block.slots ? {} : undefined,
+    usedFocusPoints: block.type === 'focus' ? 0 : undefined,
+    usedEntries: hasInnatePerDayEntries(block) ? {} : undefined
+  }));
+}
+
+function hasInnatePerDayEntries(block: SpellcastingBlock): boolean {
+  return block.type === 'innate' && block.entries.some((entry) => entry.frequency?.type === 'perDay');
+}
+
+function primarySpeed(speed: Record<string, number>): number {
+  return speed.land ?? Object.values(speed)[0] ?? 0;
+}
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,12 +1,22 @@
 export { applyCommand } from './reducer';
+export { createCombatantFromCreature } from './creatures/clone';
 export type {
+  Ability,
   AppliedEffect,
+  Attack,
+  AttackType,
+  ActionCost,
   CombatantId,
+  CombatantSpellcasting,
   CombatantState,
   Command,
   CommandResult,
   CommandType,
+  Creature,
   CreatureBaseStats,
+  CreatureRarity,
+  CreatureSize,
+  DamageComponent,
   DomainEvent,
   Duration,
   EffectLibrary,
@@ -15,5 +25,10 @@ export type {
   InitiativeState,
   LogEntry,
   Prompt,
-  SourceType
+  SourceType,
+  SpellcastingBlock,
+  SpellcastingType,
+  SpellFrequency,
+  SpellListEntry,
+  SpellTradition
 } from './types';

--- a/src/domain/test-support.ts
+++ b/src/domain/test-support.ts
@@ -39,6 +39,10 @@ export function combatant(id: string, overrides: Partial<CombatantState> = {}): 
     appliedEffects: [],
     reactionUsedThisRound: false,
     isAlive: true,
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
     ...overrides
   };
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -21,6 +21,104 @@ export interface CreatureBaseStats {
 
 export type SourceType = 'creature' | 'partyMember' | 'companion' | 'hazard';
 
+export type CreatureSize = 'tiny' | 'small' | 'medium' | 'large' | 'huge' | 'gargantuan';
+
+export type CreatureRarity = 'common' | 'uncommon' | 'rare' | 'unique';
+
+export type AttackType = 'melee' | 'ranged';
+
+export interface DamageComponent {
+  dice?: number;
+  dieSize?: number;
+  bonus?: number;
+  type: string;
+  persistent?: boolean;
+  conditional?: string;
+}
+
+export interface Attack {
+  name: string;
+  type: AttackType;
+  modifier: number;
+  traits: string[];
+  damage: DamageComponent[];
+  effects?: string[];
+}
+
+export type ActionCost = 1 | 2 | 3 | 'free' | 'reaction';
+
+export interface Ability {
+  name: string;
+  actions?: ActionCost;
+  traits?: string[];
+  trigger?: string;
+  frequency?: string;
+  requirements?: string;
+  description: string;
+}
+
+export type SpellTradition = 'arcane' | 'divine' | 'occult' | 'primal';
+
+export type SpellcastingType = 'prepared' | 'spontaneous' | 'innate' | 'focus';
+
+export type SpellFrequency = { type: 'atWill' } | { type: 'constant' } | { type: 'perDay'; uses: number };
+
+export interface SpellListEntry {
+  spellSlug: string;
+  name: string;
+  level: number;
+  isCantrip?: boolean;
+  frequency?: SpellFrequency;
+  count?: number;
+}
+
+export interface SpellcastingBlock {
+  blockId: string;
+  name: string;
+  tradition: SpellTradition;
+  type: SpellcastingType;
+  dc: number;
+  attackModifier?: number;
+  focusPoints?: number;
+  slots?: Record<number, number>;
+  entries: SpellListEntry[];
+}
+
+export interface CombatantSpellcasting extends SpellcastingBlock {
+  usedSlots?: Record<number, number>;
+  usedFocusPoints?: number;
+  usedEntries?: Record<string, number>;
+}
+
+export interface Creature {
+  id: string;
+  name: string;
+  level: number;
+  traits: string[];
+  size: CreatureSize;
+  alignment?: string;
+  rarity: CreatureRarity;
+  ac: number;
+  fortitude: number;
+  reflex: number;
+  will: number;
+  perception: number;
+  hp: number;
+  immunities: string[];
+  resistances: { type: string; value: number }[];
+  weaknesses: { type: string; value: number }[];
+  speed: Record<string, number>;
+  attacks: Attack[];
+  spellcasting?: SpellcastingBlock[];
+  passiveAbilities: Ability[];
+  reactiveAbilities: Ability[];
+  activeAbilities: Ability[];
+  skills: Record<string, number>;
+  source?: string;
+  tags: string[];
+  notes?: string;
+}
+
 export type Duration =
   | { type: 'untilTurnEnd'; combatantId: CombatantId }
   | { type: 'untilTurnStart'; combatantId: CombatantId }
@@ -52,6 +150,14 @@ export interface CombatantState {
   reactionUsedThisRound: boolean;
   isAlive: boolean;
   notes?: string;
+  attacks: Attack[];
+  passiveAbilities: Ability[];
+  reactiveAbilities: Ability[];
+  activeAbilities: Ability[];
+  spellcasting?: CombatantSpellcasting[];
+  traits?: string[];
+  size?: CreatureSize;
+  level?: number;
 }
 
 export interface Prompt {

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -65,7 +65,11 @@ export function makeCombatant(input: ManualCombatantInput): CombatantState {
     tempHp: 0,
     appliedEffects: [],
     reactionUsedThisRound: false,
-    isAlive: true
+    isAlive: true,
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: []
   };
 }
 


### PR DESCRIPTION
## Summary
- Add the pure domain creature-to-combatant factory for issue #3.
- Add creature, attack, ability, and spellcasting domain types needed for cloned combatants.
- Update existing combatant helpers to satisfy the enriched combatant display-data shape.

## Validation
- npm run test:run
- npm run check
- npm run build
- npm run audit