### PR TITLE
[codex] Add weak elite creature adjustments

### DIFF
--- a/pf2e-creature-types-spec.md
+++ b/pf2e-creature-types-spec.md
@@ -331,6 +331,7 @@ Applied at combatant creation time to the deep-cloned creature data. The creatur
 
 | Adjustment | Elite | Weak |
 |---|---|---|
+| Level | +1, or +2 if starting level is -1 or 0 | -1, or -2 if starting level is 1 |
 | AC | +2 | -2 |
 | Fortitude | +2 | -2 |
 | Reflex | +2 | -2 |
@@ -340,24 +341,31 @@ Applied at combatant creation time to the deep-cloned creature data. The creatur
 | Attack modifiers | +2 | -2 |
 | Spell DCs | +2 | -2 |
 | Spell attack modifiers | +2 | -2 |
-| All DCs (abilities) | +2 | -2 |
-| HP | +(level × 2) | -(level × 2) |
-| Damage (per Strike) | see §6.2 | see §6.2 |
+| Ability DCs embedded in descriptions | GM adjusts mentally | GM adjusts mentally |
+| Strike damage | +2 to the first structured damage component bonus | -2 to the first structured damage component bonus |
+| HP | see §6.2 | see §6.2 |
 
 **HP floor:** Weak adjustment cannot reduce HP below 1.
 
-### 6.2 Damage Adjustment Table
+### 6.2 Hit Point Adjustment Tables
 
-Damage adjustment per Strike varies by creature level.
+Hit Point adjustment uses the creature's starting level, before the weak/elite level change.
 
-| Creature Level | Elite (per Strike) | Weak (per Strike) |
-|---|---|---|
-| 1–2 | +2 | -2 |
-| 3–4 | +2 | -2 |
-| 5–19 | +4 | -4 |
-| 20–25 | +6 | -6 |
+| Starting Level | Elite HP Increase |
+|---|---|
+| 1 or lower | +10 |
+| 2-4 | +15 |
+| 5-19 | +20 |
+| 20+ | +30 |
 
-> **Verification note:** This table should be verified against *GM Core* (2023 remaster) before implementation. The numbers above are from the pre-remaster CRB. If the remaster changed them, update accordingly.
+| Starting Level | Weak HP Decrease |
+|---|---|
+| 1-2 | -10 |
+| 3-5 | -15 |
+| 6-20 | -20 |
+| 21+ | -30 |
+
+For starting levels below 1, use the 1-2 weak HP band and still apply the HP floor.
 
 ### 6.3 Where Adjustments Are Applied
 
@@ -370,9 +378,9 @@ function applyEliteWeak(
 
 The function modifies:
 
-1. **Numeric stats** — AC, saves, perception, skills, HP (on the top-level Creature fields)
+1. **Numeric stats** — level, AC, saves, perception, skills, HP (on the top-level Creature fields)
 2. **Attack modifiers** — each `Attack.modifier` adjusted
-3. **Attack damage** — each `DamageComponent.bonus` adjusted by level-based table. If no `bonus` exists on the primary component, add one.
+3. **Attack damage** — the first `DamageComponent.bonus` on each Strike adjusted by 2. If no `bonus` exists on the primary component, add one.
 4. **Spellcasting DCs and attack modifiers** — each `SpellcastingBlock.dc` and `.attackModifier` adjusted
 5. **Ability DCs** — not automatically parseable. DCs embedded in `Ability.description` text are not modified. The GM adjusts mentally (+2/-2). This is a known limitation — flagged in the UI when elite/weak is applied.
 

--- a/pf2e-tracker-v2-architecture-spec.md
+++ b/pf2e-tracker-v2-architecture-spec.md
@@ -444,12 +444,12 @@ interface CombatantState {
 
 ### 10.3 Weak/Elite Templates
 
-Applied mechanically at combatant creation time (deep clone stage). The standard PF2e adjustments:
+Applied mechanically at combatant creation time (deep clone stage). Monster Core weak/elite adjustments:
 
-- **Elite:** +2 to AC, saves, attacks, DCs, perception, skills; +2 HP per level; damage adjustment per creature level table
-- **Weak:** -2 to AC, saves, attacks, DCs, perception, skills; -2 HP per level; damage adjustment per creature level table
+- **Elite:** raise level by 1, or by 2 if the starting level is -1 or 0; add +2 to AC, saves, attacks, DCs, perception, skills, and structured Strike damage; increase HP by starting-level band.
+- **Weak:** lower level by 1, or by 2 if the starting level is 1; subtract 2 from AC, saves, attacks, DCs, perception, skills, and structured Strike damage; decrease HP by starting-level band, floored at 1 HP.
 
-These are applied to the `baseStats` of the combatant. The creature library template is never modified. If the published creature deviates from the mechanical template, the GM can manually edit the combatant's values after creation — the combatant is a mutable deep clone, not a live reference.
+These are applied to the adjusted combatant display data and `baseStats`. The creature library template is never modified. If the published creature deviates from the mechanical template, the GM can manually edit the combatant's values after creation — the combatant is a mutable deep clone, not a live reference.
 
 ---
 

--- a/src/domain/creatures/clone.test.ts
+++ b/src/domain/creatures/clone.test.ts
@@ -126,6 +126,85 @@ describe('createCombatantFromCreature', () => {
     expect(creature.spellcasting?.[0].entries[0].name).toBe('Force Barrage');
   });
 
+  test('creates an elite combatant from adjusted creature data without mutating the creature template', () => {
+    const creature = creatureTemplate({
+      spellcasting: [
+        {
+          blockId: 'arcane-prepared',
+          name: 'Arcane Prepared Spells',
+          tradition: 'arcane',
+          type: 'prepared',
+          dc: 18,
+          attackModifier: 10,
+          slots: { 1: 3 },
+          entries: [{ spellSlug: 'force-barrage', name: 'Force Barrage', level: 1, count: 2 }]
+        }
+      ]
+    });
+
+    const combatant = createCombatantFromCreature({
+      creature,
+      combatantId: 'elite-goblin-1',
+      adjustment: 'elite'
+    });
+
+    expect(combatant).toMatchObject({
+      id: 'elite-goblin-1',
+      creatureId: 'goblin-warrior',
+      name: 'Goblin Warrior',
+      baseStats: {
+        hp: 28,
+        ac: 18,
+        fortitude: 8,
+        reflex: 10,
+        will: 7,
+        perception: 9,
+        speed: 25,
+        skills: { acrobatics: 10, stealth: 12 }
+      },
+      currentHp: 28,
+      level: 2,
+      templateAdjustment: 'elite'
+    });
+    expect(combatant.attacks[0]).toMatchObject({
+      modifier: 10,
+      damage: [{ dice: 1, dieSize: 6, bonus: 4, type: 'slashing' }]
+    });
+    expect(combatant.spellcasting?.[0]).toMatchObject({ dc: 20, attackModifier: 12, usedSlots: {} });
+    expect(creature.hp).toBe(18);
+    expect(creature.attacks[0].damage[0].bonus).toBe(2);
+    expect(creature.spellcasting?.[0].dc).toBe(18);
+    expectSerializable(combatant);
+  });
+
+  test('creates a weak combatant with adjusted current HP, display data, and template marker', () => {
+    const combatant = createCombatantFromCreature({
+      creature: creatureTemplate({ level: 3, hp: 30 }),
+      combatantId: 'weak-goblin-1',
+      adjustment: 'weak'
+    });
+
+    expect(combatant).toMatchObject({
+      baseStats: {
+        hp: 15,
+        ac: 14,
+        fortitude: 4,
+        reflex: 6,
+        will: 3,
+        perception: 5,
+        speed: 25,
+        skills: { acrobatics: 6, stealth: 8 }
+      },
+      currentHp: 15,
+      level: 2,
+      templateAdjustment: 'weak'
+    });
+    expect(combatant.attacks[0]).toMatchObject({
+      modifier: 6,
+      damage: [{ dice: 1, dieSize: 6, bonus: 0, type: 'slashing' }]
+    });
+  });
+
   test('falls back to the first available speed when land speed is absent', () => {
     const combatant = createCombatantFromCreature({
       creature: creatureTemplate({ speed: { fly: 40, swim: 20 } }),

--- a/src/domain/creatures/clone.ts
+++ b/src/domain/creatures/clone.ts
@@ -1,44 +1,50 @@
 import type { CombatantState, CombatantSpellcasting, Creature, SpellcastingBlock } from '../types';
+import { applyEliteWeak, type CreatureTemplateAdjustment } from './templates';
 
 export interface CreateCombatantFromCreatureInput {
   creature: Creature;
   combatantId: string;
   name?: string;
+  adjustment?: CreatureTemplateAdjustment;
 }
 
 export function createCombatantFromCreature({
   creature,
   combatantId,
-  name
+  name,
+  adjustment
 }: CreateCombatantFromCreatureInput): CombatantState {
+  const combatantCreature = adjustment ? applyEliteWeak(creature, adjustment) : creature;
+
   return {
     id: combatantId,
     creatureId: creature.id,
-    name: name ?? creature.name,
+    name: name ?? combatantCreature.name,
     sourceType: 'creature',
     baseStats: {
-      hp: creature.hp,
-      ac: creature.ac,
-      fortitude: creature.fortitude,
-      reflex: creature.reflex,
-      will: creature.will,
-      perception: creature.perception,
-      speed: primarySpeed(creature.speed),
-      skills: cloneValue(creature.skills)
+      hp: combatantCreature.hp,
+      ac: combatantCreature.ac,
+      fortitude: combatantCreature.fortitude,
+      reflex: combatantCreature.reflex,
+      will: combatantCreature.will,
+      perception: combatantCreature.perception,
+      speed: primarySpeed(combatantCreature.speed),
+      skills: cloneValue(combatantCreature.skills)
     },
-    currentHp: creature.hp,
+    currentHp: combatantCreature.hp,
     tempHp: 0,
     appliedEffects: [],
     reactionUsedThisRound: false,
     isAlive: true,
-    attacks: cloneValue(creature.attacks),
-    passiveAbilities: cloneValue(creature.passiveAbilities),
-    reactiveAbilities: cloneValue(creature.reactiveAbilities),
-    activeAbilities: cloneValue(creature.activeAbilities),
-    spellcasting: creature.spellcasting ? hydrateSpellcasting(creature.spellcasting) : undefined,
-    traits: cloneValue(creature.traits),
-    size: creature.size,
-    level: creature.level
+    attacks: cloneValue(combatantCreature.attacks),
+    passiveAbilities: cloneValue(combatantCreature.passiveAbilities),
+    reactiveAbilities: cloneValue(combatantCreature.reactiveAbilities),
+    activeAbilities: cloneValue(combatantCreature.activeAbilities),
+    spellcasting: combatantCreature.spellcasting ? hydrateSpellcasting(combatantCreature.spellcasting) : undefined,
+    traits: cloneValue(combatantCreature.traits),
+    size: combatantCreature.size,
+    level: combatantCreature.level,
+    templateAdjustment: adjustment
   };
 }
 

--- a/src/domain/creatures/templates.test.ts
+++ b/src/domain/creatures/templates.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'vitest';
+import { expectSerializable } from '../test-support';
+import type { Creature } from '../types';
+import { applyEliteWeak } from './templates';
+
+describe('applyEliteWeak', () => {
+  test('applies elite numeric, strike, and spellcasting adjustments without mutating the source creature', () => {
+    const creature = creatureTemplate();
+
+    const adjusted = applyEliteWeak(creature, 'elite');
+
+    expect(adjusted).toMatchObject({
+      id: 'test-creature',
+      level: 6,
+      hp: 62,
+      ac: 22,
+      fortitude: 16,
+      reflex: 14,
+      will: 12,
+      perception: 15,
+      skills: { athletics: 17, stealth: 13 }
+    });
+    expect(adjusted.attacks).toEqual([
+      expect.objectContaining({
+        name: 'claw',
+        modifier: 17,
+        damage: [
+          { dice: 2, dieSize: 8, bonus: 7, type: 'slashing' },
+          { dice: 1, dieSize: 6, type: 'fire' }
+        ]
+      }),
+      expect.objectContaining({
+        name: 'spike',
+        modifier: 15,
+        damage: [{ dice: 1, dieSize: 10, bonus: 2, type: 'piercing' }]
+      })
+    ]);
+    expect(adjusted.spellcasting).toEqual([
+      expect.objectContaining({ dc: 22, attackModifier: 14 }),
+      expect.objectContaining({ dc: 21, attackModifier: undefined })
+    ]);
+    expect(creature).toEqual(creatureTemplate());
+    expectSerializable(adjusted);
+  });
+
+  test('applies weak numeric, strike, and spellcasting adjustments with an HP floor', () => {
+    const adjusted = applyEliteWeak(creatureTemplate({ level: 2, hp: 6 }), 'weak');
+
+    expect(adjusted).toMatchObject({
+      level: 1,
+      hp: 1,
+      ac: 18,
+      fortitude: 12,
+      reflex: 10,
+      will: 8,
+      perception: 11,
+      skills: { athletics: 13, stealth: 9 }
+    });
+    expect(adjusted.attacks[0]).toMatchObject({
+      modifier: 13,
+      damage: [
+        { dice: 2, dieSize: 8, bonus: 3, type: 'slashing' },
+        { dice: 1, dieSize: 6, type: 'fire' }
+      ]
+    });
+    expect(adjusted.attacks[1]).toMatchObject({
+      modifier: 11,
+      damage: [{ dice: 1, dieSize: 10, bonus: -2, type: 'piercing' }]
+    });
+    expect(adjusted.spellcasting?.[0]).toMatchObject({ dc: 18, attackModifier: 10 });
+  });
+
+  test('uses Monster Core HP bands from the starting level', () => {
+    expect(applyEliteWeak(creatureTemplate({ level: -1, hp: 8 }), 'elite').hp).toBe(18);
+    expect(applyEliteWeak(creatureTemplate({ level: 1, hp: 18 }), 'elite').hp).toBe(28);
+    expect(applyEliteWeak(creatureTemplate({ level: 2, hp: 30 }), 'elite').hp).toBe(45);
+    expect(applyEliteWeak(creatureTemplate({ level: 5, hp: 70 }), 'elite').hp).toBe(90);
+    expect(applyEliteWeak(creatureTemplate({ level: 20, hp: 360 }), 'elite').hp).toBe(390);
+
+    expect(applyEliteWeak(creatureTemplate({ level: 0, hp: 12 }), 'weak').hp).toBe(2);
+    expect(applyEliteWeak(creatureTemplate({ level: 2, hp: 30 }), 'weak').hp).toBe(20);
+    expect(applyEliteWeak(creatureTemplate({ level: 3, hp: 45 }), 'weak').hp).toBe(30);
+    expect(applyEliteWeak(creatureTemplate({ level: 6, hp: 90 }), 'weak').hp).toBe(70);
+    expect(applyEliteWeak(creatureTemplate({ level: 21, hp: 400 }), 'weak').hp).toBe(370);
+  });
+
+  test('handles level edge cases', () => {
+    expect(applyEliteWeak(creatureTemplate({ level: -1 }), 'elite').level).toBe(1);
+    expect(applyEliteWeak(creatureTemplate({ level: 0 }), 'elite').level).toBe(2);
+    expect(applyEliteWeak(creatureTemplate({ level: 1 }), 'elite').level).toBe(2);
+
+    expect(applyEliteWeak(creatureTemplate({ level: 1 }), 'weak').level).toBe(-1);
+    expect(applyEliteWeak(creatureTemplate({ level: 2 }), 'weak').level).toBe(1);
+  });
+});
+
+function creatureTemplate(overrides: Partial<Creature> = {}): Creature {
+  return {
+    id: 'test-creature',
+    name: 'Test Creature',
+    level: 5,
+    traits: ['beast'],
+    size: 'medium',
+    rarity: 'common',
+    ac: 20,
+    fortitude: 14,
+    reflex: 12,
+    will: 10,
+    perception: 13,
+    hp: 42,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 30 },
+    attacks: [
+      {
+        name: 'claw',
+        type: 'melee',
+        modifier: 15,
+        traits: ['agile'],
+        damage: [
+          { dice: 2, dieSize: 8, bonus: 5, type: 'slashing' },
+          { dice: 1, dieSize: 6, type: 'fire' }
+        ]
+      },
+      {
+        name: 'spike',
+        type: 'ranged',
+        modifier: 13,
+        traits: ['range-30'],
+        damage: [{ dice: 1, dieSize: 10, type: 'piercing' }]
+      }
+    ],
+    spellcasting: [
+      {
+        blockId: 'arcane',
+        name: 'Arcane Innate Spells',
+        tradition: 'arcane',
+        type: 'innate',
+        dc: 20,
+        attackModifier: 12,
+        entries: [{ spellSlug: 'ignition', name: 'Ignition', level: 1, frequency: { type: 'atWill' } }]
+      },
+      {
+        blockId: 'primal',
+        name: 'Primal Prepared Spells',
+        tradition: 'primal',
+        type: 'prepared',
+        dc: 19,
+        slots: { 1: 2 },
+        entries: [{ spellSlug: 'heal', name: 'Heal', level: 1 }]
+      }
+    ],
+    passiveAbilities: [{ name: 'Aura', description: 'DC 20 text remains unmodified.' }],
+    reactiveAbilities: [],
+    activeAbilities: [{ name: 'Limited Blast', frequency: 'once per day', actions: 2, description: '4d6 fire, basic Reflex DC 20.' }],
+    skills: { athletics: 15, stealth: 11 },
+    tags: [],
+    ...overrides
+  };
+}

--- a/src/domain/creatures/templates.ts
+++ b/src/domain/creatures/templates.ts
@@ -1,0 +1,84 @@
+import type { Creature, DamageComponent } from '../types';
+
+export type CreatureTemplateAdjustment = 'elite' | 'weak';
+
+export function applyEliteWeak(creature: Creature, adjustment: CreatureTemplateAdjustment): Creature {
+  const adjusted = structuredClone(creature);
+  const statDelta = adjustment === 'elite' ? 2 : -2;
+
+  adjusted.level = adjustedLevel(creature.level, adjustment);
+  adjusted.hp = adjustedHp(creature.hp, creature.level, adjustment);
+  adjusted.ac += statDelta;
+  adjusted.fortitude += statDelta;
+  adjusted.reflex += statDelta;
+  adjusted.will += statDelta;
+  adjusted.perception += statDelta;
+  adjusted.skills = adjustRecord(creature.skills, statDelta);
+  adjusted.attacks = adjusted.attacks.map((attack) => ({
+    ...attack,
+    modifier: attack.modifier + statDelta,
+    damage: adjustStrikeDamage(attack.damage, statDelta)
+  }));
+  adjusted.spellcasting = adjusted.spellcasting?.map((block) => ({
+    ...block,
+    dc: block.dc + statDelta,
+    attackModifier: block.attackModifier === undefined ? undefined : block.attackModifier + statDelta
+  }));
+
+  return adjusted;
+}
+
+function adjustedLevel(level: number, adjustment: CreatureTemplateAdjustment): number {
+  if (adjustment === 'elite') {
+    return level <= 0 ? level + 2 : level + 1;
+  }
+
+  return level === 1 ? level - 2 : level - 1;
+}
+
+function adjustedHp(hp: number, level: number, adjustment: CreatureTemplateAdjustment): number {
+  if (adjustment === 'elite') {
+    return hp + eliteHpIncrease(level);
+  }
+
+  return Math.max(1, hp - weakHpDecrease(level));
+}
+
+function eliteHpIncrease(level: number): number {
+  if (level <= 1) {
+    return 10;
+  }
+  if (level <= 4) {
+    return 15;
+  }
+  if (level <= 19) {
+    return 20;
+  }
+  return 30;
+}
+
+function weakHpDecrease(level: number): number {
+  if (level <= 2) {
+    return 10;
+  }
+  if (level <= 5) {
+    return 15;
+  }
+  if (level <= 20) {
+    return 20;
+  }
+  return 30;
+}
+
+function adjustRecord(record: Record<string, number>, delta: number): Record<string, number> {
+  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, value + delta]));
+}
+
+function adjustStrikeDamage(damage: DamageComponent[], delta: number): DamageComponent[] {
+  if (damage.length === 0) {
+    return damage;
+  }
+
+  const [primary, ...rest] = damage;
+  return [{ ...primary, bonus: (primary.bonus ?? 0) + delta }, ...rest];
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,5 +1,7 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
+export { applyEliteWeak } from './creatures/templates';
+export type { CreatureTemplateAdjustment } from './creatures/templates';
 export type {
   Ability,
   AppliedEffect,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -158,6 +158,7 @@ export interface CombatantState {
   traits?: string[];
   size?: CreatureSize;
   level?: number;
+  templateAdjustment?: 'elite' | 'weak';
 }
 
 export interface Prompt {


### PR DESCRIPTION
## Summary
- Correct the canonical weak/elite creature spec to Monster Core/AoN rules.
- Add a pure domain `applyEliteWeak` helper and thread optional weak/elite adjustment through `createCombatantFromCreature`.
- Cover template adjustments and factory integration with focused domain tests.

## Impact
- Creature templates remain unmodified; adjusted combatants receive adjusted base stats, display attacks, spellcasting DCs/attacks, current HP, level, and `templateAdjustment` metadata.
- Ability description text remains unchanged, matching the documented limitation for embedded DCs/damage text.
- Follow-up UI work is tracked in #19.

## Validation
- `npm run test:run`
- `npm run check`
- `npm run build`
- `npm run audit`