### PR TITLE
[codex] Expose weak elite setup UI

### DIFF
--- a/src/lib/creature-library.ts
+++ b/src/lib/creature-library.ts
@@ -1,0 +1,138 @@
+import type { Creature } from '../domain';
+
+export const creatureLibrary: Creature[] = [
+  {
+    id: 'goblin-warrior',
+    name: 'Goblin Warrior',
+    level: 1,
+    traits: ['goblin', 'humanoid'],
+    size: 'small',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 6,
+    reflex: 8,
+    will: 5,
+    perception: 7,
+    hp: 18,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [
+      {
+        name: 'dogslicer',
+        type: 'melee',
+        modifier: 8,
+        traits: ['agile', 'finesse'],
+        damage: [{ dice: 1, dieSize: 6, bonus: 2, type: 'slashing' }]
+      }
+    ],
+    passiveAbilities: [
+      {
+        name: 'Goblin Scuttle',
+        description: 'Step quickly through the melee when an enemy creates an opening.'
+      }
+    ],
+    reactiveAbilities: [],
+    activeAbilities: [
+      {
+        name: 'Slash',
+        actions: 1,
+        description: 'Make a dogslicer Strike.'
+      }
+    ],
+    skills: { acrobatics: 8, stealth: 10 },
+    source: 'Seeded sample',
+    tags: ['sample']
+  },
+  {
+    id: 'skeleton-guard',
+    name: 'Skeleton Guard',
+    level: 1,
+    traits: ['mindless', 'skeleton', 'undead'],
+    size: 'medium',
+    rarity: 'common',
+    ac: 17,
+    fortitude: 7,
+    reflex: 8,
+    will: 5,
+    perception: 6,
+    hp: 20,
+    immunities: ['death effects', 'disease', 'mental', 'paralyzed', 'poison', 'unconscious'],
+    resistances: [{ type: 'piercing', value: 5 }],
+    weaknesses: [{ type: 'bludgeoning', value: 5 }],
+    speed: { land: 25 },
+    attacks: [
+      {
+        name: 'scimitar',
+        type: 'melee',
+        modifier: 8,
+        traits: ['forceful', 'sweep'],
+        damage: [{ dice: 1, dieSize: 6, bonus: 3, type: 'slashing' }]
+      },
+      {
+        name: 'claw',
+        type: 'melee',
+        modifier: 8,
+        traits: ['agile', 'finesse'],
+        damage: [{ dice: 1, dieSize: 4, bonus: 3, type: 'slashing' }]
+      }
+    ],
+    passiveAbilities: [
+      {
+        name: 'Bone Rattle',
+        description: 'Creatures that first see the guard in dim light may need to steady themselves against fear.'
+      }
+    ],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    skills: { athletics: 7, intimidation: 5 },
+    source: 'Seeded sample',
+    tags: ['sample']
+  },
+  {
+    id: 'cave-wolf',
+    name: 'Cave Wolf',
+    level: 2,
+    traits: ['animal'],
+    size: 'medium',
+    rarity: 'common',
+    ac: 18,
+    fortitude: 9,
+    reflex: 11,
+    will: 6,
+    perception: 10,
+    hp: 32,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 35 },
+    attacks: [
+      {
+        name: 'jaws',
+        type: 'melee',
+        modifier: 11,
+        traits: ['unarmed'],
+        damage: [{ dice: 1, dieSize: 8, bonus: 4, type: 'piercing' }],
+        effects: ['knockdown']
+      }
+    ],
+    passiveAbilities: [
+      {
+        name: 'Pack Hunter',
+        description: 'The wolf gains tactical advantage when an ally threatens the same prey.'
+      }
+    ],
+    reactiveAbilities: [],
+    activeAbilities: [
+      {
+        name: 'Terrifying Howl',
+        actions: 2,
+        description: 'Creatures in a 30-foot emanation attempt a DC 18 Will save.'
+      }
+    ],
+    skills: { athletics: 9, stealth: 11, survival: 8 },
+    source: 'Seeded sample',
+    tags: ['sample']
+  }
+];

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -1,7 +1,79 @@
 import { describe, expect, test } from 'vitest';
-import { dispatchEncounterCommand, makeCombatant, newEncounterState, toCommand } from './encounter-app';
+import { dispatchEncounterCommand, makeCombatant, makeCreatureCombatant, newEncounterState, toCommand } from './encounter-app';
+import type { Creature } from '../domain';
 
 describe('encounter app boundary', () => {
+  test('creates a normal creature combatant through the app boundary', () => {
+    const combatant = makeCreatureCombatant({
+      creature: creatureTemplate(),
+      combatantId: 'goblin-1',
+      name: 'Goblin Scout',
+      adjustment: 'normal'
+    });
+
+    expect(combatant).toMatchObject({
+      id: 'goblin-1',
+      creatureId: 'goblin-warrior',
+      name: 'Goblin Scout',
+      currentHp: 18,
+      baseStats: {
+        hp: 18,
+        ac: 16,
+        fortitude: 6,
+        reflex: 8,
+        will: 5,
+        perception: 7,
+        speed: 25
+      },
+      templateAdjustment: undefined
+    });
+  });
+
+  test('creates weak and elite creature combatants with adjusted stats and template markers', () => {
+    const creature = creatureTemplate();
+
+    const elite = makeCreatureCombatant({
+      creature,
+      combatantId: 'elite-goblin-1',
+      adjustment: 'elite'
+    });
+    const weak = makeCreatureCombatant({
+      creature,
+      combatantId: 'weak-goblin-1',
+      adjustment: 'weak'
+    });
+
+    expect(elite).toMatchObject({
+      id: 'elite-goblin-1',
+      name: 'Goblin Warrior',
+      currentHp: 28,
+      baseStats: {
+        hp: 28,
+        ac: 18,
+        fortitude: 8,
+        reflex: 10,
+        will: 7,
+        perception: 9
+      },
+      level: 2,
+      templateAdjustment: 'elite'
+    });
+    expect(weak).toMatchObject({
+      id: 'weak-goblin-1',
+      currentHp: 8,
+      baseStats: {
+        hp: 8,
+        ac: 14,
+        fortitude: 4,
+        reflex: 6,
+        will: 3,
+        perception: 5
+      },
+      level: -1,
+      templateAdjustment: 'weak'
+    });
+  });
+
   test('dispatches domain commands and appends readable event feedback', () => {
     const goblin = makeCombatant({
       id: 'goblin-1',
@@ -69,3 +141,39 @@ describe('encounter app boundary', () => {
     ]);
   });
 });
+
+function creatureTemplate(overrides: Partial<Creature> = {}): Creature {
+  return {
+    id: 'goblin-warrior',
+    name: 'Goblin Warrior',
+    level: 1,
+    traits: ['goblin', 'humanoid'],
+    size: 'small',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 6,
+    reflex: 8,
+    will: 5,
+    perception: 7,
+    hp: 18,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [
+      {
+        name: 'dogslicer',
+        type: 'melee',
+        modifier: 8,
+        traits: ['agile', 'finesse'],
+        damage: [{ dice: 1, dieSize: 6, bonus: 2, type: 'slashing' }]
+      }
+    ],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    skills: { acrobatics: 8, stealth: 10 },
+    tags: [],
+    ...overrides
+  };
+}

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -1,5 +1,5 @@
-import { applyCommand } from '../domain';
-import type { CombatantState, Command, CommandType, DomainEvent, EncounterState } from '../domain';
+import { applyCommand, createCombatantFromCreature } from '../domain';
+import type { CombatantState, Command, CommandType, Creature, CreatureTemplateAdjustment, DomainEvent, EncounterState } from '../domain';
 
 export interface ManualCombatantInput {
   id: string;
@@ -11,6 +11,15 @@ export interface ManualCombatantInput {
   will: number;
   perception: number;
   speed: number;
+}
+
+export type TemplateAdjustmentChoice = 'normal' | CreatureTemplateAdjustment;
+
+export interface CreatureCombatantInput {
+  creature: Creature;
+  combatantId: string;
+  name?: string;
+  adjustment: TemplateAdjustmentChoice;
 }
 
 export interface FeedbackEntry {
@@ -71,6 +80,15 @@ export function makeCombatant(input: ManualCombatantInput): CombatantState {
     reactiveAbilities: [],
     activeAbilities: []
   };
+}
+
+export function makeCreatureCombatant(input: CreatureCombatantInput): CombatantState {
+  return createCombatantFromCreature({
+    creature: input.creature,
+    combatantId: input.combatantId,
+    name: input.name,
+    adjustment: input.adjustment === 'normal' ? undefined : input.adjustment
+  });
 }
 
 export function toCommand<T extends CommandType>(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,19 +1,26 @@
 <script lang="ts">
-  import type { Command, CombatantState } from '../domain';
+  import type { Command, CombatantState, Creature } from '../domain';
+  import { creatureLibrary } from '$lib/creature-library';
   import {
     currentCombatant,
     dispatchEncounterCommand,
     makeCombatant,
+    makeCreatureCombatant,
     newEncounterState,
     toCommand,
     type FeedbackEntry,
-    type ManualCombatantInput
+    type TemplateAdjustmentChoice
   } from '$lib/encounter-app';
 
   let encounter = newEncounterState();
   let feedback: FeedbackEntry[] = [];
   let commandCounter = 1;
   let combatantCounter = 1;
+
+  let selectedCreatureId = creatureLibrary[0]?.id ?? '';
+  let selectedAdjustment: TemplateAdjustmentChoice = 'normal';
+  let creatureQuantity = 1;
+  let creatureNamePrefix = '';
 
   let manualName = 'Goblin Warrior';
   let manualHp = 18;
@@ -26,48 +33,20 @@
   let hpAmount = 5;
   let tempHpAmount = 0;
 
-  const sampleCombatants: ManualCombatantInput[] = [
-    {
-      id: 'goblin-warrior',
-      name: 'Goblin Warrior',
-      maxHp: 18,
-      ac: 16,
-      fortitude: 6,
-      reflex: 8,
-      will: 5,
-      perception: 7,
-      speed: 25
-    },
-    {
-      id: 'skeleton-guard',
-      name: 'Skeleton Guard',
-      maxHp: 20,
-      ac: 17,
-      fortitude: 7,
-      reflex: 8,
-      will: 5,
-      perception: 6,
-      speed: 25
-    },
-    {
-      id: 'fighter',
-      name: 'Fighter',
-      maxHp: 26,
-      ac: 18,
-      fortitude: 9,
-      reflex: 7,
-      will: 6,
-      perception: 8,
-      speed: 25
-    }
-  ];
-
   $: orderedCombatants = encounter.initiative.order
     .map((id) => encounter.combatants[id])
     .filter((combatant): combatant is CombatantState => Boolean(combatant));
   $: unorderedCombatants = Object.values(encounter.combatants).filter((combatant) => !encounter.initiative.order.includes(combatant.id));
   $: activeCombatant = currentCombatant(encounter);
   $: canStart = encounter.phase === 'PREPARING' && encounter.initiative.order.length >= 2;
+  $: selectedCreature = creatureLibrary.find((creature) => creature.id === selectedCreatureId) ?? creatureLibrary[0];
+  $: previewCombatant = selectedCreature
+    ? makeCreatureCombatant({
+        creature: selectedCreature,
+        combatantId: 'preview',
+        adjustment: selectedAdjustment
+      })
+    : undefined;
 
   function runCommand(command: Command) {
     const result = dispatchEncounterCommand(encounter, feedback, command);
@@ -81,7 +60,7 @@
 
   function addManualCombatant() {
     const id = `${slugify(manualName)}-${combatantCounter++}`;
-    addCombatant({
+    const combatant = makeCombatant({
       id,
       name: manualName.trim() || `Combatant ${combatantCounter}`,
       maxHp: numberOrDefault(manualHp, 1),
@@ -92,18 +71,27 @@
       perception: numberOrDefault(manualPerception, 0),
       speed: numberOrDefault(manualSpeed, 25)
     });
+    addCombatant(combatant);
   }
 
-  function addSamples() {
-    for (const sample of sampleCombatants) {
-      if (!encounter.combatants[sample.id]) {
-        addCombatant(sample);
-      }
+  function addSelectedCreatures() {
+    if (!selectedCreature) {
+      return;
+    }
+
+    const count = Math.max(1, numberOrDefault(creatureQuantity, 1));
+    for (let index = 1; index <= count; index += 1) {
+      const combatant = makeCreatureCombatant({
+        creature: selectedCreature,
+        combatantId: `${selectedCreature.id}-${combatantCounter++}`,
+        name: creatureCombatantName(selectedCreature, index, count),
+        adjustment: selectedAdjustment
+      });
+      addCombatant(combatant);
     }
   }
 
-  function addCombatant(input: ManualCombatantInput) {
-    const combatant = makeCombatant(input);
+  function addCombatant(combatant: CombatantState) {
     runCommand(toCommand('ADD_COMBATANT', { combatant }, nextCommandId()));
     const nextOrder = [...encounter.initiative.order, combatant.id];
     runCommand(toCommand('SET_INITIATIVE_ORDER', { order: nextOrder }, nextCommandId()));
@@ -147,10 +135,36 @@
     feedback = [];
     commandCounter = 1;
     combatantCounter = 1;
+    selectedAdjustment = 'normal';
+    creatureQuantity = 1;
+    creatureNamePrefix = '';
   }
 
   function hpPercent(combatant: CombatantState) {
     return Math.max(0, Math.min(100, (combatant.currentHp / combatant.baseStats.hp) * 100));
+  }
+
+  function creatureCombatantName(creature: Creature, index: number, count: number) {
+    const prefix = creatureNamePrefix.trim();
+    if (prefix) {
+      return count > 1 ? `${prefix} ${index}` : prefix;
+    }
+
+    return count > 1 ? `${creature.name} ${index}` : creature.name;
+  }
+
+  function templateLabel(adjustment: TemplateAdjustmentChoice | undefined) {
+    if (adjustment === 'elite') {
+      return 'Elite';
+    }
+    if (adjustment === 'weak') {
+      return 'Weak';
+    }
+    return 'Normal';
+  }
+
+  function formatTraits(creature: Creature) {
+    return [creature.rarity, creature.size, ...creature.traits].join(' · ');
   }
 
   function numberOrDefault(value: number, fallback: number) {
@@ -189,49 +203,156 @@
     <aside class="panel setup-panel" aria-labelledby="setup-title">
       <div class="panel-heading">
         <h2 id="setup-title">Encounter Setup</h2>
-        <button type="button" class="secondary" onclick={addSamples}>Add Samples</button>
+        <span>{creatureLibrary.length} creatures</span>
       </div>
 
-      <form class="manual-form" onsubmit={(event) => {
+      <form class="creature-form" onsubmit={(event) => {
+        event.preventDefault();
+        addSelectedCreatures();
+      }}>
+        <label>
+          Creature
+          <select bind:value={selectedCreatureId}>
+            {#each creatureLibrary as creature (creature.id)}
+              <option value={creature.id}>{creature.name}</option>
+            {/each}
+          </select>
+        </label>
+
+        {#if selectedCreature && previewCombatant}
+          <section class="creature-preview" aria-label="Selected creature preview">
+            <div class="preview-heading">
+              <div>
+                <strong>{selectedCreature.name}</strong>
+                <span>Level {selectedCreature.level} · {formatTraits(selectedCreature)}</span>
+              </div>
+              <span class:adjusted={selectedAdjustment !== 'normal'}>{templateLabel(selectedAdjustment)}</span>
+            </div>
+            <dl class="preview-stats">
+              <div>
+                <dt>HP</dt>
+                <dd>{previewCombatant.baseStats.hp}</dd>
+              </div>
+              <div>
+                <dt>AC</dt>
+                <dd>{previewCombatant.baseStats.ac}</dd>
+              </div>
+              <div>
+                <dt>Fort</dt>
+                <dd>+{previewCombatant.baseStats.fortitude}</dd>
+              </div>
+              <div>
+                <dt>Ref</dt>
+                <dd>+{previewCombatant.baseStats.reflex}</dd>
+              </div>
+              <div>
+                <dt>Will</dt>
+                <dd>+{previewCombatant.baseStats.will}</dd>
+              </div>
+              <div>
+                <dt>Per</dt>
+                <dd>+{previewCombatant.baseStats.perception}</dd>
+              </div>
+            </dl>
+            <p class="preview-line">
+              {selectedCreature.attacks.length} attack{selectedCreature.attacks.length === 1 ? '' : 's'}
+              {selectedCreature.spellcasting ? ` · ${selectedCreature.spellcasting.length} spell block${selectedCreature.spellcasting.length === 1 ? '' : 's'}` : ''}
+            </p>
+          </section>
+        {/if}
+
+        <fieldset class="template-picker">
+          <legend>Template</legend>
+          <div class="segmented">
+            <button
+              type="button"
+              class:active={selectedAdjustment === 'normal'}
+              aria-pressed={selectedAdjustment === 'normal'}
+              onclick={() => (selectedAdjustment = 'normal')}
+            >
+              Normal
+            </button>
+            <button
+              type="button"
+              class:active={selectedAdjustment === 'weak'}
+              aria-pressed={selectedAdjustment === 'weak'}
+              onclick={() => (selectedAdjustment = 'weak')}
+            >
+              Weak
+            </button>
+            <button
+              type="button"
+              class:active={selectedAdjustment === 'elite'}
+              aria-pressed={selectedAdjustment === 'elite'}
+              onclick={() => (selectedAdjustment = 'elite')}
+            >
+              Elite
+            </button>
+          </div>
+        </fieldset>
+
+        {#if selectedAdjustment !== 'normal'}
+          <p class="template-warning">
+            {templateLabel(selectedAdjustment)} adjusts structured stats, attacks, spell DCs, and HP. DCs or damage written only inside ability text are not adjusted automatically.
+          </p>
+        {/if}
+
+        <div class="add-grid">
+          <label>
+            Quantity
+            <input type="number" min="1" max="12" bind:value={creatureQuantity} />
+          </label>
+          <label>
+            Name prefix
+            <input bind:value={creatureNamePrefix} autocomplete="off" placeholder={selectedCreature?.name ?? 'Combatant'} />
+          </label>
+        </div>
+        <button type="submit">Add Creature</button>
+      </form>
+
+      <details class="custom-combatant">
+        <summary>Custom Combatant</summary>
+        <form class="manual-form" onsubmit={(event) => {
         event.preventDefault();
         addManualCombatant();
       }}>
-        <label>
-          Name
-          <input bind:value={manualName} autocomplete="off" />
-        </label>
-        <div class="stat-grid">
           <label>
-            HP
-            <input type="number" min="1" bind:value={manualHp} />
+            Name
+            <input bind:value={manualName} autocomplete="off" />
           </label>
+          <div class="stat-grid">
+            <label>
+              HP
+              <input type="number" min="1" bind:value={manualHp} />
+            </label>
+            <label>
+              AC
+              <input type="number" bind:value={manualAc} />
+            </label>
+            <label>
+              Fort
+              <input type="number" bind:value={manualFortitude} />
+            </label>
+            <label>
+              Ref
+              <input type="number" bind:value={manualReflex} />
+            </label>
+            <label>
+              Will
+              <input type="number" bind:value={manualWill} />
+            </label>
+            <label>
+              Per
+              <input type="number" bind:value={manualPerception} />
+            </label>
+          </div>
           <label>
-            AC
-            <input type="number" bind:value={manualAc} />
+            Speed
+            <input type="number" min="0" bind:value={manualSpeed} />
           </label>
-          <label>
-            Fort
-            <input type="number" bind:value={manualFortitude} />
-          </label>
-          <label>
-            Ref
-            <input type="number" bind:value={manualReflex} />
-          </label>
-          <label>
-            Will
-            <input type="number" bind:value={manualWill} />
-          </label>
-          <label>
-            Per
-            <input type="number" bind:value={manualPerception} />
-          </label>
-        </div>
-        <label>
-          Speed
-          <input type="number" min="0" bind:value={manualSpeed} />
-        </label>
-        <button type="submit">Add Combatant</button>
-      </form>
+          <button type="submit">Add Custom</button>
+        </form>
+      </details>
 
       <div class="control-row">
         <button type="button" disabled={!canStart} onclick={startEncounter}>Start Encounter</button>
@@ -253,6 +374,9 @@
             <li class:current={combatant.id === activeCombatant?.id}>
               <div>
                 <strong>{combatant.name}</strong>
+                {#if combatant.templateAdjustment}
+                  <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
+                {/if}
                 <span>HP {combatant.currentHp}/{combatant.baseStats.hp}</span>
               </div>
               <div class="icon-actions">
@@ -298,7 +422,12 @@
           <article class:current-card={combatant.id === activeCombatant?.id} class="combatant-card">
             <div class="card-heading">
               <div>
-                <h2>{combatant.name}</h2>
+                <div class="card-title">
+                  <h2>{combatant.name}</h2>
+                  {#if combatant.templateAdjustment}
+                    <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
+                  {/if}
+                </div>
                 <p>AC {combatant.baseStats.ac} · Fort +{combatant.baseStats.fortitude} · Ref +{combatant.baseStats.reflex} · Will +{combatant.baseStats.will}</p>
               </div>
               <span>{combatant.id === activeCombatant?.id ? 'Turn' : encounter.phase}</span>
@@ -357,7 +486,8 @@
   }
 
   :global(button),
-  :global(input) {
+  :global(input),
+  :global(select) {
     font: inherit;
   }
 
@@ -467,6 +597,7 @@
     font-size: 14px;
   }
 
+  .creature-form,
   .manual-form,
   .cards,
   .feedback-list,
@@ -484,6 +615,15 @@
   }
 
   input {
+    min-width: 0;
+    border: 1px solid #b8c3be;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #1d2528;
+    padding: 9px 10px;
+  }
+
+  select {
     min-width: 0;
     border: 1px solid #b8c3be;
     border-radius: 6px;
@@ -520,6 +660,160 @@
     gap: 8px;
   }
 
+  .add-grid {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .creature-preview {
+    display: grid;
+    gap: 10px;
+    border: 1px solid #d8ddd9;
+    border-radius: 7px;
+    background: #ffffff;
+    padding: 12px;
+  }
+
+  .preview-heading,
+  .card-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .preview-heading strong,
+  .preview-heading span {
+    display: block;
+  }
+
+  .preview-heading span,
+  .preview-line,
+  .custom-combatant summary {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .preview-heading > span,
+  .template-badge {
+    border-radius: 999px;
+    background: #eef1ee;
+    color: #334143;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    padding: 5px 7px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .preview-heading > span.adjusted,
+  .template-badge.elite {
+    background: #f4e6d7;
+    color: #7c3d1f;
+  }
+
+  .template-badge.weak {
+    background: #e6eef6;
+    color: #275171;
+  }
+
+  .preview-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    margin: 0;
+  }
+
+  .preview-stats div {
+    border-radius: 6px;
+    background: #eef1ee;
+    padding: 8px;
+  }
+
+  .preview-stats dt,
+  .preview-stats dd,
+  .preview-line {
+    margin: 0;
+  }
+
+  .preview-stats dt {
+    color: #627171;
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .preview-stats dd {
+    color: #1d2528;
+    font-size: 18px;
+    font-weight: 800;
+  }
+
+  .template-picker {
+    display: grid;
+    gap: 6px;
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  .template-picker legend {
+    color: #526061;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 0;
+  }
+
+  .segmented {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border: 1px solid #b8c3be;
+    border-radius: 7px;
+    overflow: hidden;
+  }
+
+  .segmented button {
+    min-height: 36px;
+    border: 0;
+    border-radius: 0;
+    background: #ffffff;
+    color: #334143;
+  }
+
+  .segmented button + button {
+    border-left: 1px solid #d8ddd9;
+  }
+
+  .segmented button.active {
+    background: #28494c;
+    color: #ffffff;
+  }
+
+  .template-warning {
+    border-left: 4px solid #b6652e;
+    border-radius: 6px;
+    background: #fff7ee;
+    color: #5f3c23;
+    font-size: 13px;
+    line-height: 1.4;
+    margin: 0;
+    padding: 10px;
+  }
+
+  .custom-combatant {
+    border-top: 1px solid #d8ddd9;
+    margin-top: 14px;
+    padding-top: 12px;
+  }
+
+  .custom-combatant summary {
+    cursor: pointer;
+    font-weight: 800;
+    margin-bottom: 10px;
+  }
+
   .control-row {
     margin-top: 12px;
   }
@@ -550,6 +844,11 @@
   .initiative-list strong,
   .initiative-list span {
     display: block;
+  }
+
+  .initiative-list .template-badge {
+    display: inline-block;
+    margin: 5px 0 1px;
   }
 
   .initiative-list span,
@@ -593,6 +892,11 @@
 
   .card-heading {
     align-items: start;
+  }
+
+  .card-title {
+    justify-content: start;
+    flex-wrap: wrap;
   }
 
   .card-heading p {


### PR DESCRIPTION
## Summary
- Add a seeded in-app creature library for encounter setup.
- Add an app-boundary helper that creates creature combatants through the existing domain factory with Normal, Weak, or Elite adjustment choices.
- Redesign the setup panel with a creature picker, preview stats, quantity/name controls, weak/elite badges, and the required warning for unadjusted ability-description text.

## Validation
- `npm run check`
- `npm run test:run`
- `npm run build`
- `npm run audit` (exit 0; reports existing low-severity `cookie` advisory under the current moderate threshold)
- `git diff --check`