### PR TITLE
Add turn advancement flow

### DIFF
--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { applyCommand } from './reducer';
-import { combatant, command, emptyEffects, encounter, expectEvents, expectRejected } from './test-support';
+import { activeEncounter, combatant, command, emptyEffects, encounter, expectEvents, expectRejected } from './test-support';
 
 describe('applyCommand lifecycle and initiative slice', () => {
   test('adds combatants and starts an encounter with the first turn active', () => {
@@ -145,5 +145,99 @@ describe('applyCommand HP slice', () => {
         cause: 'set-temp'
       }
     ]);
+  });
+});
+
+describe('applyCommand turn advancement slice', () => {
+  test('ends the current turn and advances to the next live combatant', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fallen-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fallen-1': combatant('fallen-1', { isAlive: false }),
+        'fighter-1': combatant('fighter-1', { reactionUsedThisRound: true })
+      }
+    });
+
+    const result = applyCommand(state, command('END_TURN'), emptyEffects);
+
+    expect(result.newState.initiative.currentIndex).toBe(2);
+    expect(result.newState.round).toBe(1);
+    expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('wraps to the next round when advancement passes the end of initiative', () => {
+    const state = activeEncounter({
+      round: 3,
+      initiative: {
+        order: ['goblin-1', 'fallen-1', 'fighter-1'],
+        currentIndex: 2,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
+        'fallen-1': combatant('fallen-1', { isAlive: false }),
+        'fighter-1': combatant('fighter-1')
+      }
+    });
+
+    const result = applyCommand(state, command('END_TURN'), emptyEffects);
+
+    expect(result.newState.initiative.currentIndex).toBe(0);
+    expect(result.newState.round).toBe(4);
+    expect(result.newState.combatants['goblin-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'fighter-1' },
+      { type: 'reaction-reset', combatantId: 'goblin-1', cause: 'auto' },
+      { type: 'round-started', round: 4 },
+      { type: 'turn-started', combatantId: 'goblin-1', round: 4 }
+    ]);
+  });
+
+  test('emits all-combatants-dead without completing the encounter when no live combatants remain', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1', { isAlive: false }),
+        'fighter-1': combatant('fighter-1', { isAlive: false })
+      }
+    });
+
+    const result = applyCommand(state, command('END_TURN'), emptyEffects);
+
+    expect(result.newState.phase).toBe('ACTIVE');
+    expect(result.newState.initiative.currentIndex).toBe(0);
+    expect(result.newState.round).toBe(1);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'all-combatants-dead' }
+    ]);
+  });
+
+  test('rejects END_TURN when the current initiative pointer is invalid', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: 8,
+        delaying: []
+      }
+    });
+
+    const result = applyCommand(state, command('END_TURN'), emptyEffects);
+
+    expectRejected(result, 'END_TURN', 'END_TURN requires a valid current combatant', state);
   });
 });

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -62,6 +62,8 @@ export function applyCommand(state: EncounterState, command: Command, _effectLib
       return setInitiativeOrder(state, command.payload.order);
     case 'START_ENCOUNTER':
       return startEncounter(state);
+    case 'END_TURN':
+      return endTurn(state);
     case 'COMPLETE_ENCOUNTER':
       return completeEncounter(state);
     case 'RESET_ENCOUNTER':
@@ -196,6 +198,78 @@ function completeEncounter(state: EncounterState): CommandResult {
       { type: 'phase-changed', from: 'ACTIVE', to: 'COMPLETED' }
     ]
   };
+}
+
+function endTurn(state: EncounterState): CommandResult {
+  const currentCombatantId = state.initiative.order[state.initiative.currentIndex];
+  if (!currentCombatantId || !state.combatants[currentCombatantId]) {
+    return reject(state, 'END_TURN', 'END_TURN requires a valid current combatant');
+  }
+
+  const nextTurn = findNextLiveTurn(state);
+  if (!nextTurn) {
+    return {
+      newState: state,
+      events: [
+        { type: 'turn-ended', combatantId: currentCombatantId },
+        { type: 'all-combatants-dead' }
+      ]
+    };
+  }
+
+  const nextCombatant = state.combatants[nextTurn.combatantId];
+  const events: DomainEvent[] = [
+    { type: 'turn-ended', combatantId: currentCombatantId },
+    { type: 'reaction-reset', combatantId: nextTurn.combatantId, cause: 'auto' }
+  ];
+
+  if (nextTurn.round !== state.round) {
+    events.push({ type: 'round-started', round: nextTurn.round });
+  }
+
+  events.push({ type: 'turn-started', combatantId: nextTurn.combatantId, round: nextTurn.round });
+
+  return {
+    newState: {
+      ...state,
+      round: nextTurn.round,
+      initiative: {
+        ...state.initiative,
+        currentIndex: nextTurn.index
+      },
+      combatants: {
+        ...state.combatants,
+        [nextTurn.combatantId]: {
+          ...nextCombatant,
+          reactionUsedThisRound: false
+        }
+      }
+    },
+    events
+  };
+}
+
+function findNextLiveTurn(
+  state: EncounterState
+): { combatantId: CombatantId; index: number; round: number } | undefined {
+  const { order, currentIndex } = state.initiative;
+
+  for (let offset = 1; offset <= order.length; offset += 1) {
+    const rawIndex = currentIndex + offset;
+    const index = rawIndex % order.length;
+    const combatantId = order[index];
+    const combatant = combatantId ? state.combatants[combatantId] : undefined;
+
+    if (combatant?.isAlive) {
+      return {
+        combatantId,
+        index,
+        round: rawIndex >= order.length ? state.round + 1 : state.round
+      };
+    }
+  }
+
+  return undefined;
 }
 
 function resetEncounter(state: EncounterState): CommandResult {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -279,6 +279,7 @@ export type DomainEvent =
   | { type: 'initiative-changed'; combatantId: CombatantId; newIndex: number }
   | { type: 'turn-started'; combatantId: CombatantId; round: number }
   | { type: 'turn-ended'; combatantId: CombatantId }
+  | { type: 'reaction-reset'; combatantId: CombatantId; cause: 'auto' | 'manual' }
   | {
       type: 'hp-changed';
       combatantId: CombatantId;


### PR DESCRIPTION
## Summary
- Implements END_TURN in the pure domain reducer.
- Advances to the next live combatant, wraps rounds, and emits turn/round events.
- Auto-resets the next combatant reaction and emits all-combatants-dead without completing the encounter.

## Test Plan
- npm run test:run -- src/domain/reducer.test.ts
- npm run check
- npm run test:run
- npm run build
- npm run audit

Refs #6