### PR TITLE
Configure Cloudflare Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,24 @@ The first implementation slice is intentionally domain-first. `src/domain/` is p
 
 The app is configured for static Cloudflare Pages hosting using `@sveltejs/adapter-static`.
 
-- Build command: `npm run build`
+- Pages project: `pf2e-tracker-v2`
+- Production branch: `master`
+- Build command: `npm run check && npm run test:run && npm run audit && npm run build`
 - Output directory: `build`
+- Node version: `22`
+- Custom domain: `pf2etracker.app`
 - Runtime services required: none
 
 Keep the deployed app within Cloudflare's free static hosting model by avoiding Pages Functions, Workers, KV, D1, R2, Workers AI, and server-side endpoints unless a future task explicitly changes the architecture.
+
+The initial deployment is intended to be unlisted, not access-gated. `static/_headers` sends `X-Robots-Tag: noindex, nofollow`, and `static/robots.txt` asks crawlers not to index the app while it is only being shared directly with friends.
+
+Create the production deployment through Cloudflare Pages Git integration:
+
+- Connect Cloudflare Pages to `mbednarski/pf2e-encounter-tracker-v2`.
+- Set the production branch to `master`.
+- Disable preview branch deployments for now.
+- Attach `pf2etracker.app` as the custom domain.
 
 Manual deployment after Cloudflare login:
 

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex, nofollow

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- Add Cloudflare Pages noindex headers and robots hints for the initial unlisted deployment.
- Document the Pages Git setup for deploying master to pf2etracker.app.
- Keep the project on the static Cloudflare Pages path with no runtime services.

## Test Plan
- npm run check
- npm run test:run
- npm run audit
- npm run build
- Confirmed build/_headers and build/robots.txt are emitted.