### PR TITLE
[codex] Add combat state commands

### DIFF
--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -241,3 +241,206 @@ describe('applyCommand turn advancement slice', () => {
     expectRejected(result, 'END_TURN', 'END_TURN requires a valid current combatant', state);
   });
 });
+
+describe('applyCommand combat state slice', () => {
+  test('marks and manually resets a combatant reaction', () => {
+    const state = activeEncounter();
+
+    const marked = applyCommand(state, command('MARK_REACTION_USED', { combatantId: 'fighter-1' }), emptyEffects);
+    const reset = applyCommand(marked.newState, command('RESET_REACTION', { combatantId: 'fighter-1' }), emptyEffects);
+
+    expect(marked.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(true);
+    expectEvents(marked, [{ type: 'reaction-used', combatantId: 'fighter-1' }]);
+    expect(reset.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(reset, [{ type: 'reaction-reset', combatantId: 'fighter-1', cause: 'manual' }]);
+  });
+
+  test('rejects reaction commands for invalid targets', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'fallen-1': combatant('fallen-1', { isAlive: false })
+      }
+    });
+
+    expectRejected(
+      applyCommand(state, command('MARK_REACTION_USED', { combatantId: 'fallen-1' }), emptyEffects),
+      'MARK_REACTION_USED',
+      'Combatant fallen-1 is not alive',
+      state
+    );
+    expectRejected(
+      applyCommand(state, command('RESET_REACTION', { combatantId: 'missing-1' }), emptyEffects),
+      'RESET_REACTION',
+      'Combatant missing-1 not found',
+      state
+    );
+  });
+
+  test('sets and clears combatant notes', () => {
+    const state = activeEncounter();
+
+    const noted = applyCommand(state, command('SET_NOTE', { combatantId: 'goblin-1', note: 'Grabbed by the bridge.' }), emptyEffects);
+    const cleared = applyCommand(noted.newState, command('SET_NOTE', { combatantId: 'goblin-1', note: null }), emptyEffects);
+
+    expect(noted.newState.combatants['goblin-1'].notes).toBe('Grabbed by the bridge.');
+    expectEvents(noted, [{ type: 'note-changed', combatantId: 'goblin-1' }]);
+    expect(cleared.newState.combatants['goblin-1']).not.toHaveProperty('notes');
+    expectEvents(cleared, [{ type: 'note-changed', combatantId: 'goblin-1' }]);
+  });
+
+  test('rejects setting a note for an unknown combatant', () => {
+    const state = activeEncounter();
+
+    const result = applyCommand(state, command('SET_NOTE', { combatantId: 'missing-1', note: 'Hidden' }), emptyEffects);
+
+    expectRejected(result, 'SET_NOTE', 'Combatant missing-1 not found', state);
+  });
+
+  test('marks a non-current combatant dead without advancing the turn', () => {
+    const state = activeEncounter();
+
+    const result = applyCommand(state, command('MARK_DEAD', { combatantId: 'fighter-1' }), emptyEffects);
+
+    expect(result.newState.combatants['fighter-1'].isAlive).toBe(false);
+    expect(result.newState.initiative.currentIndex).toBe(0);
+    expect(result.newState.round).toBe(1);
+    expectEvents(result, [{ type: 'combatant-died', combatantId: 'fighter-1', cause: 'marked-dead' }]);
+  });
+
+  test('marks the current combatant dead and advances to the next live combatant', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fallen-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fallen-1': combatant('fallen-1', { isAlive: false }),
+        'fighter-1': combatant('fighter-1', { reactionUsedThisRound: true })
+      }
+    });
+
+    const result = applyCommand(state, command('MARK_DEAD', { combatantId: 'goblin-1' }), emptyEffects);
+
+    expect(result.newState.combatants['goblin-1'].isAlive).toBe(false);
+    expect(result.newState.initiative.currentIndex).toBe(2);
+    expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'combatant-died', combatantId: 'goblin-1', cause: 'marked-dead' },
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('marks the current combatant dead and wraps to the next round', () => {
+    const state = activeEncounter({
+      round: 2,
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: 1,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
+        'fighter-1': combatant('fighter-1')
+      }
+    });
+
+    const result = applyCommand(state, command('MARK_DEAD', { combatantId: 'fighter-1' }), emptyEffects);
+
+    expect(result.newState.combatants['fighter-1'].isAlive).toBe(false);
+    expect(result.newState.initiative.currentIndex).toBe(0);
+    expect(result.newState.round).toBe(3);
+    expect(result.newState.combatants['goblin-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'combatant-died', combatantId: 'fighter-1', cause: 'marked-dead' },
+      { type: 'turn-ended', combatantId: 'fighter-1' },
+      { type: 'reaction-reset', combatantId: 'goblin-1', cause: 'auto' },
+      { type: 'round-started', round: 3 },
+      { type: 'turn-started', combatantId: 'goblin-1', round: 3 }
+    ]);
+  });
+
+  test('emits all-combatants-dead when marking the final live combatant dead', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1', { isAlive: false })
+      }
+    });
+
+    const result = applyCommand(state, command('MARK_DEAD', { combatantId: 'goblin-1' }), emptyEffects);
+
+    expect(result.newState.combatants['goblin-1'].isAlive).toBe(false);
+    expect(result.newState.phase).toBe('ACTIVE');
+    expectEvents(result, [
+      { type: 'combatant-died', combatantId: 'goblin-1', cause: 'marked-dead' },
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'all-combatants-dead' }
+    ]);
+  });
+
+  test('rejects invalid mark dead commands', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'fallen-1': combatant('fallen-1', { isAlive: false })
+      }
+    });
+
+    expectRejected(
+      applyCommand(state, command('MARK_DEAD', { combatantId: 'missing-1' }), emptyEffects),
+      'MARK_DEAD',
+      'Combatant missing-1 not found',
+      state
+    );
+    expectRejected(
+      applyCommand(state, command('MARK_DEAD', { combatantId: 'fallen-1' }), emptyEffects),
+      'MARK_DEAD',
+      'Combatant fallen-1 is not alive',
+      state
+    );
+  });
+
+  test('revives a dead combatant without changing HP', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1', { currentHp: 0, isAlive: false })
+      }
+    });
+
+    const result = applyCommand(state, command('REVIVE', { combatantId: 'fighter-1' }), emptyEffects);
+
+    expect(result.newState.combatants['fighter-1'].isAlive).toBe(true);
+    expect(result.newState.combatants['fighter-1'].currentHp).toBe(0);
+    expectEvents(result, [{ type: 'combatant-revived', combatantId: 'fighter-1' }]);
+  });
+
+  test('rejects invalid revive commands', () => {
+    const state = activeEncounter();
+
+    expectRejected(
+      applyCommand(state, command('REVIVE', { combatantId: 'missing-1' }), emptyEffects),
+      'REVIVE',
+      'Combatant missing-1 not found',
+      state
+    );
+    expectRejected(
+      applyCommand(state, command('REVIVE', { combatantId: 'fighter-1' }), emptyEffects),
+      'REVIVE',
+      'Combatant fighter-1 is already alive',
+      state
+    );
+  });
+});

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -76,6 +76,16 @@ export function applyCommand(state: EncounterState, command: Command, _effectLib
       return setTempHp(state, command.payload.combatantId, command.payload.amount);
     case 'SET_HP':
       return setHp(state, command.payload.combatantId, command.payload.amount);
+    case 'MARK_REACTION_USED':
+      return markReactionUsed(state, command.payload.combatantId);
+    case 'RESET_REACTION':
+      return resetReaction(state, command.payload.combatantId);
+    case 'SET_NOTE':
+      return setNote(state, command.payload.combatantId, command.payload.note);
+    case 'MARK_DEAD':
+      return markDead(state, command.payload.combatantId);
+    case 'REVIVE':
+      return revive(state, command.payload.combatantId);
     default:
       return reject(state, command.type, `${command.type} is not implemented in the first domain slice`);
   }
@@ -206,6 +216,10 @@ function endTurn(state: EncounterState): CommandResult {
     return reject(state, 'END_TURN', 'END_TURN requires a valid current combatant');
   }
 
+  return advanceTurn(state, currentCombatantId);
+}
+
+function advanceTurn(state: EncounterState, currentCombatantId: CombatantId): CommandResult {
   const nextTurn = findNextLiveTurn(state);
   if (!nextTurn) {
     return {
@@ -395,6 +409,94 @@ function setHp(state: EncounterState, combatantId: CombatantId, amount: number):
   });
 }
 
+function markReactionUsed(state: EncounterState, combatantId: CombatantId): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'MARK_REACTION_USED', `Combatant ${combatantId} not found`);
+  }
+
+  if (!combatant.isAlive) {
+    return reject(state, 'MARK_REACTION_USED', `Combatant ${combatantId} is not alive`);
+  }
+
+  return updateCombatant(state, { ...combatant, reactionUsedThisRound: true }, [
+    { type: 'reaction-used', combatantId }
+  ]);
+}
+
+function resetReaction(state: EncounterState, combatantId: CombatantId): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'RESET_REACTION', `Combatant ${combatantId} not found`);
+  }
+
+  return updateCombatant(state, { ...combatant, reactionUsedThisRound: false }, [
+    { type: 'reaction-reset', combatantId, cause: 'manual' }
+  ]);
+}
+
+function setNote(state: EncounterState, combatantId: CombatantId, note: string | null): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'SET_NOTE', `Combatant ${combatantId} not found`);
+  }
+
+  const updatedCombatant = { ...combatant };
+  if (note === null) {
+    delete updatedCombatant.notes;
+  } else {
+    updatedCombatant.notes = note;
+  }
+
+  return updateCombatant(state, updatedCombatant, [{ type: 'note-changed', combatantId }]);
+}
+
+function markDead(state: EncounterState, combatantId: CombatantId): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'MARK_DEAD', `Combatant ${combatantId} not found`);
+  }
+
+  if (!combatant.isAlive) {
+    return reject(state, 'MARK_DEAD', `Combatant ${combatantId} is not alive`);
+  }
+
+  const stateWithDeadCombatant: EncounterState = {
+    ...state,
+    combatants: {
+      ...state.combatants,
+      [combatantId]: {
+        ...combatant,
+        isAlive: false
+      }
+    }
+  };
+  const events: DomainEvent[] = [{ type: 'combatant-died', combatantId, cause: 'marked-dead' }];
+
+  if (state.phase !== 'ACTIVE' || state.initiative.order[state.initiative.currentIndex] !== combatantId) {
+    return { newState: stateWithDeadCombatant, events };
+  }
+
+  const advancement = advanceTurn(stateWithDeadCombatant, combatantId);
+  return {
+    newState: advancement.newState,
+    events: [...events, ...advancement.events]
+  };
+}
+
+function revive(state: EncounterState, combatantId: CombatantId): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'REVIVE', `Combatant ${combatantId} not found`);
+  }
+
+  if (combatant.isAlive) {
+    return reject(state, 'REVIVE', `Combatant ${combatantId} is already alive`);
+  }
+
+  return updateCombatant(state, { ...combatant, isAlive: true }, [{ type: 'combatant-revived', combatantId }]);
+}
+
 function updateHp(
   state: EncounterState,
   combatant: CombatantState,
@@ -415,6 +517,19 @@ function updateHp(
       combatants: {
         ...state.combatants,
         [combatant.id]: updatedCombatant
+      }
+    },
+    events
+  };
+}
+
+function updateCombatant(state: EncounterState, combatant: CombatantState, events: DomainEvent[]): CommandResult {
+  return {
+    newState: {
+      ...state,
+      combatants: {
+        ...state.combatants,
+        [combatant.id]: combatant
       }
     },
     events

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -279,7 +279,11 @@ export type DomainEvent =
   | { type: 'initiative-changed'; combatantId: CombatantId; newIndex: number }
   | { type: 'turn-started'; combatantId: CombatantId; round: number }
   | { type: 'turn-ended'; combatantId: CombatantId }
+  | { type: 'combatant-died'; combatantId: CombatantId; cause: 'marked-dead' | 'dying-threshold' }
+  | { type: 'combatant-revived'; combatantId: CombatantId }
+  | { type: 'reaction-used'; combatantId: CombatantId }
   | { type: 'reaction-reset'; combatantId: CombatantId; cause: 'auto' | 'manual' }
+  | { type: 'note-changed'; combatantId: CombatantId }
   | {
       type: 'hp-changed';
       combatantId: CombatantId;


### PR DESCRIPTION
## Summary
- Implement combat state domain commands for reactions, notes, death marking, and revive.
- Add canonical domain events for combat state changes.
- Cover happy paths, rejection paths, active-turn death advancement, round wrap, all-dead handling, and revive without HP changes.

## Scope
- Refs #8.
- Delay/resume initiative commands remain intentionally out of scope; existing issue #7 can be revisited once the desired table behavior is clearer.
- No new issue was created because the postponed delay/resume topic is already tracked by #7.

## Validation
- `npm run test:run -- src/domain/reducer.test.ts`
- `npm run test:run`
- `npm run check`
- `npm run build`