### PR TITLE
Update combat state roadmap status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,10 +19,10 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 
 ## M2 Initiative and Combat State
 
-- [ ] Implement `END_TURN`, round advancement, and reaction reset.
+- [x] Implement `END_TURN`, round advancement, and reaction reset.
 - [ ] Implement `DELAY` and `RESUME_FROM_DELAY`.
-- [ ] Implement `MARK_DEAD`, `REVIVE`, `MARK_REACTION_USED`, `RESET_REACTION`, and `SET_NOTE`.
-- [ ] Add all-dead edge case handling.
+- [x] Implement `MARK_DEAD`, `REVIVE`, `MARK_REACTION_USED`, `RESET_REACTION`, and `SET_NOTE`.
+- [x] Add all-dead edge case handling.
 
 ## M3 Effects and Conditions
 


### PR DESCRIPTION
## Summary

- mark completed M2 initiative/combat-state backend items in `ROADMAP.md`
- keep `DELAY` and `RESUME_FROM_DELAY` open for the next backend slice

## Context

PR #24 already merged the combat-state domain implementation. This PR is the follow-up roadmap bookkeeping so the backlog reflects what has landed.

## Verification

- `npm run test:run`
- `npm run check`
- `npm run build`
- `npm run audit`