### PR TITLE
[codex] Add delay and resume initiative commands

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 ## M2 Initiative and Combat State
 
 - [x] Implement `END_TURN`, round advancement, and reaction reset.
-- [ ] Implement `DELAY` and `RESUME_FROM_DELAY`.
+- [x] Implement `DELAY` and `RESUME_FROM_DELAY`.
 - [x] Implement `MARK_DEAD`, `REVIVE`, `MARK_REACTION_USED`, `RESET_REACTION`, and `SET_NOTE`.
 - [x] Add all-dead edge case handling.
 

--- a/pf2e-command-vocabulary-spec.md
+++ b/pf2e-command-vocabulary-spec.md
@@ -387,10 +387,13 @@ interface DelayPayload {
 - Remove current combatant from `initiative.order`
 - Add to `initiative.delaying`
 - Advance `initiative.currentIndex` to next combatant (wrapping and incrementing round if needed)
+- Auto-reset reaction for the new current combatant
 - Emit turn-started for the new current combatant
 
 **Events:**
+- `{ type: "turn-ended", combatantId }`
 - `{ type: "combatant-delayed", combatantId }`
+- `{ type: "reaction-reset", combatantId: nextCombatant, cause: "auto" }`
 - `{ type: "turn-started", combatantId: nextCombatant, round }`
 - Start-of-turn effects processing for next combatant
 
@@ -412,7 +415,7 @@ interface ResumeFromDelayPayload {
 - Cannot resume during another combatant's RESOLVING phase
 
 **State changes:**
-- END_TURN must be dispatched for the currently active combatant first (their turn is interrupted by the delaying combatant's re-entry). The orchestrator handles this — RESUME_FROM_DELAY itself assumes the current turn has been properly ended.
+- End the currently active combatant's turn. `RESUME_FROM_DELAY` is self-contained in the reducer; the orchestrator must not dispatch a separate `END_TURN` first.
 - Remove from `initiative.delaying`
 - Insert into `initiative.order` at `insertIndex`
 - Set `initiative.currentIndex → insertIndex`
@@ -421,7 +424,9 @@ interface ResumeFromDelayPayload {
 - Generate start-of-turn prompts (if any → phase → RESOLVING)
 
 **Events:**
+- `{ type: "turn-ended", combatantId: interruptedCombatant }`
 - `{ type: "combatant-resumed-from-delay", combatantId, insertIndex }`
+- `{ type: "reaction-reset", combatantId, cause: "auto" }`
 - `{ type: "turn-started", combatantId, round }`
 - Start-of-turn effect events (if any)
 

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -242,6 +242,256 @@ describe('applyCommand turn advancement slice', () => {
   });
 });
 
+describe('applyCommand delay and resume slice', () => {
+  test('delays the middle combatant and starts the next live turn', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1', 'cleric-1'],
+        currentIndex: 1,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'cleric-1': combatant('cleric-1', { reactionUsedThisRound: true })
+      }
+    });
+
+    const result = applyCommand(state, command('DELAY'), emptyEffects);
+
+    expect(result.newState.initiative).toEqual({
+      order: ['goblin-1', 'cleric-1'],
+      currentIndex: 1,
+      delaying: ['fighter-1']
+    });
+    expect(result.newState.round).toBe(1);
+    expect(result.newState.combatants['cleric-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'fighter-1' },
+      { type: 'combatant-delayed', combatantId: 'fighter-1' },
+      { type: 'reaction-reset', combatantId: 'cleric-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'cleric-1', round: 1 }
+    ]);
+  });
+
+  test('delays the first combatant without advancing the round', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1', 'cleric-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'cleric-1': combatant('cleric-1')
+      }
+    });
+
+    const result = applyCommand(state, command('DELAY'), emptyEffects);
+
+    expect(result.newState.initiative).toEqual({
+      order: ['fighter-1', 'cleric-1'],
+      currentIndex: 0,
+      delaying: ['goblin-1']
+    });
+    expect(result.newState.round).toBe(1);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'combatant-delayed', combatantId: 'goblin-1' },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('delays the final combatant and wraps to the next round', () => {
+    const state = activeEncounter({
+      round: 4,
+      initiative: {
+        order: ['goblin-1', 'fighter-1', 'cleric-1'],
+        currentIndex: 2,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
+        'fighter-1': combatant('fighter-1'),
+        'cleric-1': combatant('cleric-1')
+      }
+    });
+
+    const result = applyCommand(state, command('DELAY'), emptyEffects);
+
+    expect(result.newState.initiative).toEqual({
+      order: ['goblin-1', 'fighter-1'],
+      currentIndex: 0,
+      delaying: ['cleric-1']
+    });
+    expect(result.newState.round).toBe(5);
+    expect(result.newState.combatants['goblin-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'cleric-1' },
+      { type: 'combatant-delayed', combatantId: 'cleric-1' },
+      { type: 'reaction-reset', combatantId: 'goblin-1', cause: 'auto' },
+      { type: 'round-started', round: 5 },
+      { type: 'turn-started', combatantId: 'goblin-1', round: 5 }
+    ]);
+  });
+
+  test('delay skips dead combatants after removing the current combatant', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fallen-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fallen-1': combatant('fallen-1', { isAlive: false }),
+        'fighter-1': combatant('fighter-1', { reactionUsedThisRound: true })
+      }
+    });
+
+    const result = applyCommand(state, command('DELAY'), emptyEffects);
+
+    expect(result.newState.initiative).toEqual({
+      order: ['fallen-1', 'fighter-1'],
+      currentIndex: 1,
+      delaying: ['goblin-1']
+    });
+    expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'combatant-delayed', combatantId: 'goblin-1' },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('rejects delay when the current initiative pointer is invalid', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: -1,
+        delaying: []
+      }
+    });
+
+    const result = applyCommand(state, command('DELAY'), emptyEffects);
+
+    expectRejected(result, 'DELAY', 'DELAY requires a valid current combatant', state);
+  });
+
+  test('resumes a delaying combatant at the requested index and starts their turn', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'cleric-1'],
+        currentIndex: 0,
+        delaying: ['fighter-1']
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1', { reactionUsedThisRound: true }),
+        'cleric-1': combatant('cleric-1')
+      }
+    });
+
+    const result = applyCommand(
+      state,
+      command('RESUME_FROM_DELAY', { combatantId: 'fighter-1', insertIndex: 1 }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative).toEqual({
+      order: ['goblin-1', 'fighter-1', 'cleric-1'],
+      currentIndex: 1,
+      delaying: []
+    });
+    expect(result.newState.round).toBe(1);
+    expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'goblin-1' },
+      { type: 'combatant-resumed-from-delay', combatantId: 'fighter-1', insertIndex: 1 },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('resumes at the end of initiative with deterministic insertion', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'cleric-1'],
+        currentIndex: 1,
+        delaying: ['fighter-1', 'ranger-1']
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'cleric-1': combatant('cleric-1'),
+        'ranger-1': combatant('ranger-1')
+      }
+    });
+
+    const result = applyCommand(
+      state,
+      command('RESUME_FROM_DELAY', { combatantId: 'fighter-1', insertIndex: 2 }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative).toEqual({
+      order: ['goblin-1', 'cleric-1', 'fighter-1'],
+      currentIndex: 2,
+      delaying: ['ranger-1']
+    });
+    expectEvents(result, [
+      { type: 'turn-ended', combatantId: 'cleric-1' },
+      { type: 'combatant-resumed-from-delay', combatantId: 'fighter-1', insertIndex: 2 },
+      { type: 'reaction-reset', combatantId: 'fighter-1', cause: 'auto' },
+      { type: 'turn-started', combatantId: 'fighter-1', round: 1 }
+    ]);
+  });
+
+  test('rejects resume for combatants that are not delaying', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'fighter-1'],
+        currentIndex: 0,
+        delaying: []
+      }
+    });
+
+    const result = applyCommand(
+      state,
+      command('RESUME_FROM_DELAY', { combatantId: 'fighter-1', insertIndex: 1 }),
+      emptyEffects
+    );
+
+    expectRejected(result, 'RESUME_FROM_DELAY', 'Combatant fighter-1 is not delaying', state);
+  });
+
+  test('rejects resume when the insert index is out of range', () => {
+    const state = activeEncounter({
+      initiative: {
+        order: ['goblin-1', 'cleric-1'],
+        currentIndex: 0,
+        delaying: ['fighter-1']
+      },
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'cleric-1': combatant('cleric-1')
+      }
+    });
+
+    const result = applyCommand(
+      state,
+      command('RESUME_FROM_DELAY', { combatantId: 'fighter-1', insertIndex: 3 }),
+      emptyEffects
+    );
+
+    expectRejected(result, 'RESUME_FROM_DELAY', 'RESUME_FROM_DELAY insertIndex must be between 0 and 2', state);
+  });
+});
+
 describe('applyCommand combat state slice', () => {
   test('marks and manually resets a combatant reaction', () => {
     const state = activeEncounter();

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -64,6 +64,10 @@ export function applyCommand(state: EncounterState, command: Command, _effectLib
       return startEncounter(state);
     case 'END_TURN':
       return endTurn(state);
+    case 'DELAY':
+      return delayTurn(state);
+    case 'RESUME_FROM_DELAY':
+      return resumeFromDelay(state, command.payload.combatantId, command.payload.insertIndex);
     case 'COMPLETE_ENCOUNTER':
       return completeEncounter(state);
     case 'RESET_ENCOUNTER':
@@ -266,10 +270,17 @@ function advanceTurn(state: EncounterState, currentCombatantId: CombatantId): Co
 function findNextLiveTurn(
   state: EncounterState
 ): { combatantId: CombatantId; index: number; round: number } | undefined {
-  const { order, currentIndex } = state.initiative;
+  return findNextLiveTurnFrom(state, state.initiative.currentIndex + 1);
+}
 
-  for (let offset = 1; offset <= order.length; offset += 1) {
-    const rawIndex = currentIndex + offset;
+function findNextLiveTurnFrom(
+  state: EncounterState,
+  startIndex: number
+): { combatantId: CombatantId; index: number; round: number } | undefined {
+  const { order } = state.initiative;
+
+  for (let offset = 0; offset < order.length; offset += 1) {
+    const rawIndex = startIndex + offset;
     const index = rawIndex % order.length;
     const combatantId = order[index];
     const combatant = combatantId ? state.combatants[combatantId] : undefined;
@@ -284,6 +295,123 @@ function findNextLiveTurn(
   }
 
   return undefined;
+}
+
+function delayTurn(state: EncounterState): CommandResult {
+  const currentCombatantId = state.initiative.order[state.initiative.currentIndex];
+  if (!currentCombatantId || !state.combatants[currentCombatantId]) {
+    return reject(state, 'DELAY', 'DELAY requires a valid current combatant');
+  }
+
+  const nextOrder = state.initiative.order.filter((combatantId) => combatantId !== currentCombatantId);
+  const stateWithDelay: EncounterState = {
+    ...state,
+    initiative: {
+      ...state.initiative,
+      order: nextOrder,
+      delaying: [...state.initiative.delaying, currentCombatantId]
+    }
+  };
+  const nextTurn = findNextLiveTurnFrom(stateWithDelay, state.initiative.currentIndex);
+
+  if (!nextTurn) {
+    return {
+      newState: stateWithDelay,
+      events: [
+        { type: 'turn-ended', combatantId: currentCombatantId },
+        { type: 'combatant-delayed', combatantId: currentCombatantId },
+        { type: 'all-combatants-dead' }
+      ]
+    };
+  }
+
+  const nextCombatant = state.combatants[nextTurn.combatantId];
+  const events: DomainEvent[] = [
+    { type: 'turn-ended', combatantId: currentCombatantId },
+    { type: 'combatant-delayed', combatantId: currentCombatantId },
+    { type: 'reaction-reset', combatantId: nextTurn.combatantId, cause: 'auto' }
+  ];
+
+  if (nextTurn.round !== state.round) {
+    events.push({ type: 'round-started', round: nextTurn.round });
+  }
+
+  events.push({ type: 'turn-started', combatantId: nextTurn.combatantId, round: nextTurn.round });
+
+  return {
+    newState: {
+      ...stateWithDelay,
+      round: nextTurn.round,
+      initiative: {
+        ...stateWithDelay.initiative,
+        currentIndex: nextTurn.index
+      },
+      combatants: {
+        ...state.combatants,
+        [nextTurn.combatantId]: {
+          ...nextCombatant,
+          reactionUsedThisRound: false
+        }
+      }
+    },
+    events
+  };
+}
+
+function resumeFromDelay(state: EncounterState, combatantId: CombatantId, insertIndex: number): CommandResult {
+  const currentCombatantId = state.initiative.order[state.initiative.currentIndex];
+  if (!currentCombatantId || !state.combatants[currentCombatantId]) {
+    return reject(state, 'RESUME_FROM_DELAY', 'RESUME_FROM_DELAY requires a valid current combatant');
+  }
+
+  const resumingCombatant = state.combatants[combatantId];
+  if (!resumingCombatant) {
+    return reject(state, 'RESUME_FROM_DELAY', `Combatant ${combatantId} not found`);
+  }
+
+  if (!state.initiative.delaying.includes(combatantId)) {
+    return reject(state, 'RESUME_FROM_DELAY', `Combatant ${combatantId} is not delaying`);
+  }
+
+  if (!resumingCombatant.isAlive) {
+    return reject(state, 'RESUME_FROM_DELAY', `Combatant ${combatantId} is not alive`);
+  }
+
+  if (!Number.isInteger(insertIndex) || insertIndex < 0 || insertIndex > state.initiative.order.length) {
+    return reject(
+      state,
+      'RESUME_FROM_DELAY',
+      `RESUME_FROM_DELAY insertIndex must be between 0 and ${state.initiative.order.length}`
+    );
+  }
+
+  const nextOrder = [...state.initiative.order];
+  nextOrder.splice(insertIndex, 0, combatantId);
+
+  return {
+    newState: {
+      ...state,
+      initiative: {
+        ...state.initiative,
+        order: nextOrder,
+        currentIndex: insertIndex,
+        delaying: state.initiative.delaying.filter((delayingCombatantId) => delayingCombatantId !== combatantId)
+      },
+      combatants: {
+        ...state.combatants,
+        [combatantId]: {
+          ...resumingCombatant,
+          reactionUsedThisRound: false
+        }
+      }
+    },
+    events: [
+      { type: 'turn-ended', combatantId: currentCombatantId },
+      { type: 'combatant-resumed-from-delay', combatantId, insertIndex },
+      { type: 'reaction-reset', combatantId, cause: 'auto' },
+      { type: 'turn-started', combatantId, round: state.round }
+    ]
+  };
 }
 
 function resetEncounter(state: EncounterState): CommandResult {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -277,6 +277,8 @@ export type DomainEvent =
   | { type: 'combatant-renamed'; combatantId: CombatantId; oldName: string; newName: string }
   | { type: 'initiative-set'; order: CombatantId[] }
   | { type: 'initiative-changed'; combatantId: CombatantId; newIndex: number }
+  | { type: 'combatant-delayed'; combatantId: CombatantId }
+  | { type: 'combatant-resumed-from-delay'; combatantId: CombatantId; insertIndex: number }
   | { type: 'turn-started'; combatantId: CombatantId; round: number }
   | { type: 'turn-ended'; combatantId: CombatantId }
   | { type: 'combatant-died'; combatantId: CombatantId; cause: 'marked-dead' | 'dying-threshold' }


### PR DESCRIPTION
## Summary
- Implements domain reducer handling for `DELAY` and `RESUME_FROM_DELAY`.
- Adds public domain events for delayed and resumed combatants, with reducer-owned turn-end/start sequencing and automatic reaction reset.
- Aligns the command vocabulary spec with the canonical domain-events behavior and marks the M2 roadmap item complete.

## Test Plan
- `npm run test:run -- src/domain/reducer.test.ts`
- `npm run check`
- `npm run test:run`
- `npm run build`

Closes #7