### PR TITLE
Slice 1: Extract combatant UI into components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,13 @@ All four must pass before opening a PR.
 Strict unidirectional layering. Edits must respect this direction:
 
 ```
-src/routes/ (Svelte UI)  ──>  src/lib/ (orchestrator)  ──>  src/domain/ (pure TS)
+src/routes/ (Svelte routes)  ──>  src/components/ (Svelte UI)  ──>  src/lib/ (orchestrator)  ──>  src/domain/ (pure TS)
 ```
 
 - **`src/domain/`** — Pure reducer + types. Zero framework deps. State and events are JSON-serializable. Vitest covers this layer. Purity is enforced by `tsconfig.domain.json` via `tsc -p tsconfig.domain.json --noEmit` (run as part of `npm run check`).
-- **`src/lib/`** — Orchestrator glue: `dispatchEncounterCommand`, `newEncounterState`, the creature library. The only layer that bridges UI and domain.
-- **`src/routes/`** — SvelteKit file-based routes. The combat tracker UI currently lives in a single `+page.svelte`; `+layout.ts` enables prerender + SSR for static export.
+- **`src/lib/`** — Orchestrator glue: `dispatchEncounterCommand`, `newEncounterState`, the creature library. TS-only; no Svelte. The only layer that bridges UI and domain.
+- **`src/components/`** — Reusable Svelte components. Presentational: receive state via props, emit intentions via callback props. **Must not own encounter state** and must not call `dispatchEncounterCommand` directly. May import types and helpers from `$lib` and `../domain`.
+- **`src/routes/`** — SvelteKit file-based routes. Holds encounter state, owns command dispatch, composes components. `+layout.ts` enables prerender + SSR for static export.
 
 Command flow:
 

--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import type { CombatantState, EncounterState } from '../domain';
+
+  export let combatant: CombatantState;
+  export let isCurrent: boolean;
+  export let phase: EncounterState['phase'];
+  export let onDamage: (id: string) => void;
+  export let onHeal: (id: string) => void;
+  export let onSetTemp: (id: string) => void;
+  export let onSetZero: (id: string) => void;
+
+  function templateLabel(adjustment: CombatantState['templateAdjustment']) {
+    if (adjustment === 'elite') return 'Elite';
+    if (adjustment === 'weak') return 'Weak';
+    return '';
+  }
+
+  $: hpPercent = Math.max(
+    0,
+    Math.min(100, (combatant.currentHp / combatant.baseStats.hp) * 100)
+  );
+</script>
+
+<article class:current-card={isCurrent} class="combatant-card">
+  <div class="card-heading">
+    <div>
+      <div class="card-title">
+        <h2>{combatant.name}</h2>
+        {#if combatant.templateAdjustment}
+          <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
+        {/if}
+      </div>
+      <p>AC {combatant.baseStats.ac} · Fort +{combatant.baseStats.fortitude} · Ref +{combatant.baseStats.reflex} · Will +{combatant.baseStats.will}</p>
+    </div>
+    <span>{isCurrent ? 'Turn' : phase}</span>
+  </div>
+
+  <div class="hp-row">
+    <div>
+      <strong>{combatant.currentHp}</strong>
+      <span>/ {combatant.baseStats.hp} HP</span>
+    </div>
+    <div>
+      <strong>{combatant.tempHp}</strong>
+      <span>temp</span>
+    </div>
+  </div>
+  <div class="hp-track" aria-label={`${combatant.name} HP`}>
+    <div class="hp-fill" style={`width: ${hpPercent}%`}></div>
+  </div>
+
+  <div class="card-actions">
+    <button type="button" onclick={() => onDamage(combatant.id)}>Damage</button>
+    <button type="button" onclick={() => onHeal(combatant.id)}>Heal</button>
+    <button type="button" onclick={() => onSetTemp(combatant.id)}>Set Temp</button>
+    <button type="button" class="secondary" onclick={() => onSetZero(combatant.id)}>Set 0</button>
+  </div>
+</article>
+
+<style>
+  .combatant-card {
+    border: 1px solid #cfd6d1;
+    border-radius: 8px;
+    background: #fbfcfa;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 16px;
+  }
+
+  .current-card {
+    border-color: #a53f2b;
+  }
+
+  .card-heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .card-title {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+  }
+
+  .card-heading p {
+    margin: 5px 0 0;
+    color: #526061;
+    font-size: 13px;
+  }
+
+  .card-heading > span {
+    border-radius: 999px;
+    background: #eef1ee;
+    padding: 5px 8px;
+    color: #627171;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+
+  .template-badge {
+    border-radius: 999px;
+    background: #eef1ee;
+    color: #334143;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    padding: 5px 7px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .template-badge.elite {
+    background: #f4e6d7;
+    color: #7c3d1f;
+  }
+
+  .template-badge.weak {
+    background: #e6eef6;
+    color: #275171;
+  }
+
+  .hp-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 18px;
+  }
+
+  .hp-row > div {
+    border-radius: 7px;
+    background: #eef1ee;
+    padding: 10px;
+  }
+
+  .hp-row strong {
+    font-size: 24px;
+  }
+
+  .hp-row span {
+    color: #526061;
+    font-size: 13px;
+  }
+
+  .hp-track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #d9dfdb;
+    margin: 12px 0;
+  }
+
+  .hp-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: #3f7f64;
+  }
+
+  .card-actions {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .card-actions button {
+    min-height: 38px;
+    border: 1px solid #28494c;
+    border-radius: 6px;
+    background: #28494c;
+    color: #ffffff;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    padding: 8px 12px;
+  }
+
+  .card-actions button.secondary {
+    border-color: #9aa7a3;
+    color: #263235;
+    background: #ffffff;
+  }
+
+  @media (max-width: 760px) {
+    .card-heading {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .card-actions button {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/components/FeedbackPanel.svelte
+++ b/src/components/FeedbackPanel.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { FeedbackEntry } from '$lib/encounter-app';
+
+  export let entries: FeedbackEntry[];
+</script>
+
+<aside class="panel feedback-panel" aria-labelledby="feedback-title">
+  <div class="panel-heading">
+    <h2 id="feedback-title">Event Feedback</h2>
+    <span>{entries.length}</span>
+  </div>
+  {#if entries.length === 0}
+    <p class="empty">Domain events will appear here.</p>
+  {:else}
+    <ol class="feedback-list">
+      {#each entries as entry (entry.id)}
+        <li class:warn={entry.severity === 'warn'}>{entry.message}</li>
+      {/each}
+    </ol>
+  {/if}
+</aside>
+
+<style>
+  .panel {
+    border: 1px solid #cfd6d1;
+    border-radius: 8px;
+    background: #fbfcfa;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 14px;
+  }
+
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+  }
+
+  .panel-heading > span,
+  .empty {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .empty {
+    margin: 0;
+  }
+
+  .feedback-list {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .feedback-list li {
+    border-left: 4px solid #3f7f64;
+    border-radius: 6px;
+    background: #ffffff;
+    padding: 10px;
+    font-size: 13px;
+  }
+
+  .feedback-list li.warn {
+    border-left-color: #b6652e;
+    background: #fff7ee;
+  }
+</style>

--- a/src/components/InitiativeTrack.svelte
+++ b/src/components/InitiativeTrack.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import type { CombatantState } from '../domain';
+
+  export let ordered: CombatantState[];
+  export let unordered: CombatantState[];
+  export let activeId: string | undefined;
+  export let onMove: (id: string, direction: -1 | 1) => void;
+
+  function templateLabel(adjustment: CombatantState['templateAdjustment']) {
+    if (adjustment === 'elite') return 'Elite';
+    if (adjustment === 'weak') return 'Weak';
+    return '';
+  }
+</script>
+
+<section class="panel initiative-panel" aria-labelledby="initiative-title">
+  <div class="panel-heading">
+    <h2 id="initiative-title">Initiative</h2>
+    <span>{ordered.length} ordered</span>
+  </div>
+
+  {#if ordered.length === 0}
+    <p class="empty">Add combatants to begin.</p>
+  {:else}
+    <ol class="initiative-list">
+      {#each ordered as combatant, index (combatant.id)}
+        <li class:current={combatant.id === activeId}>
+          <div>
+            <strong>{combatant.name}</strong>
+            {#if combatant.templateAdjustment}
+              <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
+            {/if}
+            <span>HP {combatant.currentHp}/{combatant.baseStats.hp}</span>
+          </div>
+          <div class="icon-actions">
+            <button type="button" title="Move up" disabled={index === 0} onclick={() => onMove(combatant.id, -1)}>↑</button>
+            <button
+              type="button"
+              title="Move down"
+              disabled={index === ordered.length - 1}
+              onclick={() => onMove(combatant.id, 1)}
+            >
+              ↓
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ol>
+  {/if}
+
+  {#if unordered.length > 0}
+    <div class="queue">
+      <h3>Unordered</h3>
+      {#each unordered as combatant (combatant.id)}
+        <p>{combatant.name}</p>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .panel {
+    border: 1px solid #cfd6d1;
+    border-radius: 8px;
+    background: #fbfcfa;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 14px;
+  }
+
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+  }
+
+  h3 {
+    margin: 16px 0 0;
+    font-size: 14px;
+  }
+
+  .panel-heading > span,
+  .queue,
+  .empty {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .empty,
+  .queue p {
+    margin: 0;
+  }
+
+  .initiative-list {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .initiative-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    border: 1px solid #d8ddd9;
+    border-radius: 7px;
+    background: #ffffff;
+    padding: 10px;
+  }
+
+  .initiative-list li.current {
+    border-color: #a53f2b;
+    box-shadow: inset 4px 0 0 #a53f2b;
+  }
+
+  .initiative-list strong,
+  .initiative-list > li > div > span {
+    display: block;
+  }
+
+  .initiative-list span {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .template-badge {
+    display: inline-block;
+    margin: 5px 0 1px;
+    border-radius: 999px;
+    background: #eef1ee;
+    color: #334143;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    padding: 5px 7px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .template-badge.elite {
+    background: #f4e6d7;
+    color: #7c3d1f;
+  }
+
+  .template-badge.weak {
+    background: #e6eef6;
+    color: #275171;
+  }
+
+  .icon-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .icon-actions button {
+    min-height: 38px;
+    width: 36px;
+    padding: 0;
+    border: 1px solid #28494c;
+    border-radius: 6px;
+    background: #28494c;
+    color: #ffffff;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+  }
+
+  .icon-actions button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  @media (max-width: 760px) {
+    .panel-heading {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/components/SetupPanel.svelte
+++ b/src/components/SetupPanel.svelte
@@ -1,0 +1,427 @@
+<script lang="ts">
+  import type { Creature } from '../domain';
+  import { creatureLibrary } from '$lib/creature-library';
+  import {
+    makeCreatureCombatant,
+    type ManualCombatantInput,
+    type TemplateAdjustmentChoice
+  } from '$lib/encounter-app';
+
+  export let canStart: boolean;
+  export let onAddCreatures: (input: {
+    creature: Creature;
+    adjustment: TemplateAdjustmentChoice;
+    quantity: number;
+    namePrefix: string;
+  }) => void;
+  export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
+  export let onStart: () => void;
+  export let onReset: () => void;
+
+  let selectedCreatureId = creatureLibrary[0]?.id ?? '';
+  let selectedAdjustment: TemplateAdjustmentChoice = 'normal';
+  let creatureQuantity = 1;
+  let creatureNamePrefix = '';
+
+  let manualName = 'Goblin Warrior';
+  let manualHp = 18;
+  let manualAc = 16;
+  let manualFortitude = 6;
+  let manualReflex = 8;
+  let manualWill = 5;
+  let manualPerception = 7;
+  let manualSpeed = 25;
+
+  $: selectedCreature = creatureLibrary.find((c) => c.id === selectedCreatureId) ?? creatureLibrary[0];
+  $: previewCombatant = selectedCreature
+    ? makeCreatureCombatant({
+        creature: selectedCreature,
+        combatantId: 'preview',
+        adjustment: selectedAdjustment
+      })
+    : undefined;
+
+  function templateLabel(adjustment: TemplateAdjustmentChoice) {
+    if (adjustment === 'elite') return 'Elite';
+    if (adjustment === 'weak') return 'Weak';
+    return 'Normal';
+  }
+
+  function formatTraits(creature: Creature) {
+    return [creature.rarity, creature.size, ...creature.traits].join(' · ');
+  }
+
+  function numberOrDefault(value: number, fallback: number) {
+    return Number.isFinite(value) ? Math.trunc(value) : fallback;
+  }
+
+  function submitCreatures() {
+    if (!selectedCreature) return;
+    onAddCreatures({
+      creature: selectedCreature,
+      adjustment: selectedAdjustment,
+      quantity: Math.max(1, numberOrDefault(creatureQuantity, 1)),
+      namePrefix: creatureNamePrefix
+    });
+  }
+
+  function submitManual() {
+    onAddManual({
+      name: manualName.trim() || 'Combatant',
+      maxHp: numberOrDefault(manualHp, 1),
+      ac: numberOrDefault(manualAc, 10),
+      fortitude: numberOrDefault(manualFortitude, 0),
+      reflex: numberOrDefault(manualReflex, 0),
+      will: numberOrDefault(manualWill, 0),
+      perception: numberOrDefault(manualPerception, 0),
+      speed: numberOrDefault(manualSpeed, 25)
+    });
+  }
+
+  function reset() {
+    selectedAdjustment = 'normal';
+    creatureQuantity = 1;
+    creatureNamePrefix = '';
+    onReset();
+  }
+</script>
+
+<aside class="panel setup-panel" aria-labelledby="setup-title">
+  <div class="panel-heading">
+    <h2 id="setup-title">Encounter Setup</h2>
+    <span>{creatureLibrary.length} creatures</span>
+  </div>
+
+  <form class="creature-form" onsubmit={(event) => { event.preventDefault(); submitCreatures(); }}>
+    <label>
+      Creature
+      <select bind:value={selectedCreatureId}>
+        {#each creatureLibrary as creature (creature.id)}
+          <option value={creature.id}>{creature.name}</option>
+        {/each}
+      </select>
+    </label>
+
+    {#if selectedCreature && previewCombatant}
+      <section class="creature-preview" aria-label="Selected creature preview">
+        <div class="preview-heading">
+          <div>
+            <strong>{selectedCreature.name}</strong>
+            <span>Level {selectedCreature.level} · {formatTraits(selectedCreature)}</span>
+          </div>
+          <span class:adjusted={selectedAdjustment !== 'normal'}>{templateLabel(selectedAdjustment)}</span>
+        </div>
+        <dl class="preview-stats">
+          <div><dt>HP</dt><dd>{previewCombatant.baseStats.hp}</dd></div>
+          <div><dt>AC</dt><dd>{previewCombatant.baseStats.ac}</dd></div>
+          <div><dt>Fort</dt><dd>+{previewCombatant.baseStats.fortitude}</dd></div>
+          <div><dt>Ref</dt><dd>+{previewCombatant.baseStats.reflex}</dd></div>
+          <div><dt>Will</dt><dd>+{previewCombatant.baseStats.will}</dd></div>
+          <div><dt>Per</dt><dd>+{previewCombatant.baseStats.perception}</dd></div>
+        </dl>
+        <p class="preview-line">
+          {selectedCreature.attacks.length} attack{selectedCreature.attacks.length === 1 ? '' : 's'}
+          {selectedCreature.spellcasting ? ` · ${selectedCreature.spellcasting.length} spell block${selectedCreature.spellcasting.length === 1 ? '' : 's'}` : ''}
+        </p>
+      </section>
+    {/if}
+
+    <fieldset class="template-picker">
+      <legend>Template</legend>
+      <div class="segmented">
+        <button type="button" class:active={selectedAdjustment === 'normal'} aria-pressed={selectedAdjustment === 'normal'} onclick={() => (selectedAdjustment = 'normal')}>Normal</button>
+        <button type="button" class:active={selectedAdjustment === 'weak'} aria-pressed={selectedAdjustment === 'weak'} onclick={() => (selectedAdjustment = 'weak')}>Weak</button>
+        <button type="button" class:active={selectedAdjustment === 'elite'} aria-pressed={selectedAdjustment === 'elite'} onclick={() => (selectedAdjustment = 'elite')}>Elite</button>
+      </div>
+    </fieldset>
+
+    {#if selectedAdjustment !== 'normal'}
+      <p class="template-warning">
+        {templateLabel(selectedAdjustment)} adjusts structured stats, attacks, spell DCs, and HP. DCs or damage written only inside ability text are not adjusted automatically.
+      </p>
+    {/if}
+
+    <div class="add-grid">
+      <label>
+        Quantity
+        <input type="number" min="1" max="12" bind:value={creatureQuantity} />
+      </label>
+      <label>
+        Name prefix
+        <input bind:value={creatureNamePrefix} autocomplete="off" placeholder={selectedCreature?.name ?? 'Combatant'} />
+      </label>
+    </div>
+    <button type="submit">Add Creature</button>
+  </form>
+
+  <details class="custom-combatant">
+    <summary>Custom Combatant</summary>
+    <form class="manual-form" onsubmit={(event) => { event.preventDefault(); submitManual(); }}>
+      <label>Name<input bind:value={manualName} autocomplete="off" /></label>
+      <div class="stat-grid">
+        <label>HP<input type="number" min="1" bind:value={manualHp} /></label>
+        <label>AC<input type="number" bind:value={manualAc} /></label>
+        <label>Fort<input type="number" bind:value={manualFortitude} /></label>
+        <label>Ref<input type="number" bind:value={manualReflex} /></label>
+        <label>Will<input type="number" bind:value={manualWill} /></label>
+        <label>Per<input type="number" bind:value={manualPerception} /></label>
+      </div>
+      <label>Speed<input type="number" min="0" bind:value={manualSpeed} /></label>
+      <button type="submit">Add Custom</button>
+    </form>
+  </details>
+
+  <div class="control-row">
+    <button type="button" disabled={!canStart} onclick={onStart}>Start Encounter</button>
+    <button type="button" class="secondary" onclick={reset}>Reset Local</button>
+  </div>
+</aside>
+
+<style>
+  .panel {
+    border: 1px solid #cfd6d1;
+    border-radius: 8px;
+    background: #fbfcfa;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 14px;
+  }
+
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+  }
+
+  .panel-heading > span {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .creature-form,
+  .manual-form {
+    display: grid;
+    gap: 10px;
+  }
+
+  label {
+    display: grid;
+    gap: 5px;
+    color: #526061;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  input,
+  select {
+    min-width: 0;
+    border: 1px solid #b8c3be;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #1d2528;
+    padding: 9px 10px;
+    font: inherit;
+  }
+
+  button {
+    min-height: 38px;
+    border: 1px solid #28494c;
+    border-radius: 6px;
+    background: #28494c;
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 700;
+    padding: 8px 12px;
+    font: inherit;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  button.secondary {
+    border-color: #9aa7a3;
+    color: #263235;
+    background: #ffffff;
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .add-grid {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .creature-preview {
+    display: grid;
+    gap: 10px;
+    border: 1px solid #d8ddd9;
+    border-radius: 7px;
+    background: #ffffff;
+    padding: 12px;
+  }
+
+  .preview-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .preview-heading strong,
+  .preview-heading span {
+    display: block;
+  }
+
+  .preview-heading span,
+  .preview-line,
+  .custom-combatant summary {
+    color: #627171;
+    font-size: 13px;
+  }
+
+  .preview-heading > span {
+    border-radius: 999px;
+    background: #eef1ee;
+    color: #334143;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    padding: 5px 7px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .preview-heading > span.adjusted {
+    background: #f4e6d7;
+    color: #7c3d1f;
+  }
+
+  .preview-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    margin: 0;
+  }
+
+  .preview-stats div {
+    border-radius: 6px;
+    background: #eef1ee;
+    padding: 8px;
+  }
+
+  .preview-stats dt,
+  .preview-stats dd,
+  .preview-line {
+    margin: 0;
+  }
+
+  .preview-stats dt {
+    color: #627171;
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .preview-stats dd {
+    color: #1d2528;
+    font-size: 18px;
+    font-weight: 800;
+  }
+
+  .template-picker {
+    display: grid;
+    gap: 6px;
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  .template-picker legend {
+    color: #526061;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 0;
+  }
+
+  .segmented {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border: 1px solid #b8c3be;
+    border-radius: 7px;
+    overflow: hidden;
+  }
+
+  .segmented button {
+    min-height: 36px;
+    border: 0;
+    border-radius: 0;
+    background: #ffffff;
+    color: #334143;
+  }
+
+  .segmented button + button {
+    border-left: 1px solid #d8ddd9;
+  }
+
+  .segmented button.active {
+    background: #28494c;
+    color: #ffffff;
+  }
+
+  .template-warning {
+    border-left: 4px solid #b6652e;
+    border-radius: 6px;
+    background: #fff7ee;
+    color: #5f3c23;
+    font-size: 13px;
+    line-height: 1.4;
+    margin: 0;
+    padding: 10px;
+  }
+
+  .custom-combatant {
+    border-top: 1px solid #d8ddd9;
+    margin-top: 14px;
+    padding-top: 12px;
+  }
+
+  .custom-combatant summary {
+    cursor: pointer;
+    font-weight: 800;
+    margin-bottom: 10px;
+  }
+
+  .control-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-top: 12px;
+  }
+
+  @media (max-width: 760px) {
+    .panel-heading,
+    .control-row {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .control-row button {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { EncounterState } from '../domain';
+
+  export let name: string;
+  export let phase: EncounterState['phase'];
+  export let round: number;
+  export let activeName: string | undefined;
+</script>
+
+<header class="topbar">
+  <div>
+    <p class="eyebrow">PF2e Encounter Tracker v2</p>
+    <h1>{name}</h1>
+  </div>
+  <div class="status-strip" aria-label="Encounter status">
+    <span class="status">{phase}</span>
+    <span>Round {round}</span>
+    <span>{activeName ? `${activeName}'s turn` : 'No active turn'}</span>
+  </div>
+</header>
+
+<style>
+  .topbar {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 20px;
+    margin: 0 auto 18px;
+    max-width: 1440px;
+  }
+
+  .eyebrow,
+  h1 {
+    margin: 0;
+  }
+
+  .eyebrow {
+    color: #697170;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: 32px;
+    line-height: 1.1;
+  }
+
+  .status-strip {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+    color: #415052;
+    font-size: 14px;
+  }
+
+  .status-strip span,
+  .status {
+    border: 1px solid #c5ccc8;
+    border-radius: 6px;
+    background: #ffffff;
+    padding: 8px 10px;
+  }
+
+  .status {
+    color: #f3f6f5;
+    background: #28494c;
+    border-color: #28494c;
+  }
+
+  @media (max-width: 760px) {
+    .topbar {
+      display: grid;
+      grid-template-columns: 1fr;
+    }
+
+    .status-strip {
+      justify-content: start;
+    }
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { Command, CombatantState, Creature } from '../domain';
-  import { creatureLibrary } from '$lib/creature-library';
+  import TopBar from '../components/TopBar.svelte';
+  import FeedbackPanel from '../components/FeedbackPanel.svelte';
+  import InitiativeTrack from '../components/InitiativeTrack.svelte';
+  import CombatantCard from '../components/CombatantCard.svelte';
+  import SetupPanel from '../components/SetupPanel.svelte';
   import {
     currentCombatant,
     dispatchEncounterCommand,
@@ -9,6 +13,7 @@
     newEncounterState,
     toCommand,
     type FeedbackEntry,
+    type ManualCombatantInput,
     type TemplateAdjustmentChoice
   } from '$lib/encounter-app';
 
@@ -16,20 +21,6 @@
   let feedback: FeedbackEntry[] = [];
   let commandCounter = 1;
   let combatantCounter = 1;
-
-  let selectedCreatureId = creatureLibrary[0]?.id ?? '';
-  let selectedAdjustment: TemplateAdjustmentChoice = 'normal';
-  let creatureQuantity = 1;
-  let creatureNamePrefix = '';
-
-  let manualName = 'Goblin Warrior';
-  let manualHp = 18;
-  let manualAc = 16;
-  let manualFortitude = 6;
-  let manualReflex = 8;
-  let manualWill = 5;
-  let manualPerception = 7;
-  let manualSpeed = 25;
   let hpAmount = 5;
   let tempHpAmount = 0;
 
@@ -39,14 +30,6 @@
   $: unorderedCombatants = Object.values(encounter.combatants).filter((combatant) => !encounter.initiative.order.includes(combatant.id));
   $: activeCombatant = currentCombatant(encounter);
   $: canStart = encounter.phase === 'PREPARING' && encounter.initiative.order.length >= 2;
-  $: selectedCreature = creatureLibrary.find((creature) => creature.id === selectedCreatureId) ?? creatureLibrary[0];
-  $: previewCombatant = selectedCreature
-    ? makeCreatureCombatant({
-        creature: selectedCreature,
-        combatantId: 'preview',
-        adjustment: selectedAdjustment
-      })
-    : undefined;
 
   function runCommand(command: Command) {
     const result = dispatchEncounterCommand(encounter, feedback, command);
@@ -58,43 +41,45 @@
     return `cmd-${commandCounter++}`;
   }
 
-  function addManualCombatant() {
-    const id = `${slugify(manualName)}-${combatantCounter++}`;
-    const combatant = makeCombatant({
-      id,
-      name: manualName.trim() || `Combatant ${combatantCounter}`,
-      maxHp: numberOrDefault(manualHp, 1),
-      ac: numberOrDefault(manualAc, 10),
-      fortitude: numberOrDefault(manualFortitude, 0),
-      reflex: numberOrDefault(manualReflex, 0),
-      will: numberOrDefault(manualWill, 0),
-      perception: numberOrDefault(manualPerception, 0),
-      speed: numberOrDefault(manualSpeed, 25)
-    });
-    addCombatant(combatant);
-  }
-
-  function addSelectedCreatures() {
-    if (!selectedCreature) {
-      return;
-    }
-
-    const count = Math.max(1, numberOrDefault(creatureQuantity, 1));
-    for (let index = 1; index <= count; index += 1) {
-      const combatant = makeCreatureCombatant({
-        creature: selectedCreature,
-        combatantId: `${selectedCreature.id}-${combatantCounter++}`,
-        name: creatureCombatantName(selectedCreature, index, count),
-        adjustment: selectedAdjustment
-      });
-      addCombatant(combatant);
-    }
+  function numberOrDefault(value: number, fallback: number) {
+    return Number.isFinite(value) ? Math.trunc(value) : fallback;
   }
 
   function addCombatant(combatant: CombatantState) {
     runCommand(toCommand('ADD_COMBATANT', { combatant }, nextCommandId()));
     const nextOrder = [...encounter.initiative.order, combatant.id];
     runCommand(toCommand('SET_INITIATIVE_ORDER', { order: nextOrder }, nextCommandId()));
+  }
+
+  function handleAddCreatures(input: {
+    creature: Creature;
+    adjustment: TemplateAdjustmentChoice;
+    quantity: number;
+    namePrefix: string;
+  }) {
+    const prefix = input.namePrefix.trim();
+    for (let index = 1; index <= input.quantity; index += 1) {
+      const name = prefix
+        ? input.quantity > 1 ? `${prefix} ${index}` : prefix
+        : input.quantity > 1 ? `${input.creature.name} ${index}` : input.creature.name;
+      const combatant = makeCreatureCombatant({
+        creature: input.creature,
+        combatantId: `${input.creature.id}-${combatantCounter++}`,
+        name,
+        adjustment: input.adjustment
+      });
+      addCombatant(combatant);
+    }
+  }
+
+  function handleAddManual(input: Omit<ManualCombatantInput, 'id'>) {
+    const slug = input.name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'combatant';
+    const combatant = makeCombatant({ ...input, id: `${slug}-${combatantCounter++}` });
+    addCombatant(combatant);
   }
 
   function moveCombatant(combatantId: string, direction: -1 | 1) {
@@ -135,50 +120,6 @@
     feedback = [];
     commandCounter = 1;
     combatantCounter = 1;
-    selectedAdjustment = 'normal';
-    creatureQuantity = 1;
-    creatureNamePrefix = '';
-  }
-
-  function hpPercent(combatant: CombatantState) {
-    return Math.max(0, Math.min(100, (combatant.currentHp / combatant.baseStats.hp) * 100));
-  }
-
-  function creatureCombatantName(creature: Creature, index: number, count: number) {
-    const prefix = creatureNamePrefix.trim();
-    if (prefix) {
-      return count > 1 ? `${prefix} ${index}` : prefix;
-    }
-
-    return count > 1 ? `${creature.name} ${index}` : creature.name;
-  }
-
-  function templateLabel(adjustment: TemplateAdjustmentChoice | undefined) {
-    if (adjustment === 'elite') {
-      return 'Elite';
-    }
-    if (adjustment === 'weak') {
-      return 'Weak';
-    }
-    return 'Normal';
-  }
-
-  function formatTraits(creature: Creature) {
-    return [creature.rarity, creature.size, ...creature.traits].join(' · ');
-  }
-
-  function numberOrDefault(value: number, fallback: number) {
-    return Number.isFinite(value) ? Math.trunc(value) : fallback;
-  }
-
-  function slugify(value: string) {
-    const slug = value
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '');
-
-    return slug || 'combatant';
   }
 </script>
 
@@ -187,226 +128,31 @@
 </svelte:head>
 
 <main class="shell">
-  <header class="topbar">
-    <div>
-      <p class="eyebrow">PF2e Encounter Tracker v2</p>
-      <h1>{encounter.name}</h1>
-    </div>
-    <div class="status-strip" aria-label="Encounter status">
-      <span class="status">{encounter.phase}</span>
-      <span>Round {encounter.round}</span>
-      <span>{activeCombatant ? `${activeCombatant.name}'s turn` : 'No active turn'}</span>
-    </div>
-  </header>
+  <TopBar
+    name={encounter.name}
+    phase={encounter.phase}
+    round={encounter.round}
+    activeName={activeCombatant?.name}
+  />
 
   <section class="workspace">
-    <aside class="panel setup-panel" aria-labelledby="setup-title">
-      <div class="panel-heading">
-        <h2 id="setup-title">Encounter Setup</h2>
-        <span>{creatureLibrary.length} creatures</span>
-      </div>
+    <SetupPanel
+      {canStart}
+      onAddCreatures={handleAddCreatures}
+      onAddManual={handleAddManual}
+      onStart={startEncounter}
+      onReset={resetLocal}
+    />
 
-      <form class="creature-form" onsubmit={(event) => {
-        event.preventDefault();
-        addSelectedCreatures();
-      }}>
-        <label>
-          Creature
-          <select bind:value={selectedCreatureId}>
-            {#each creatureLibrary as creature (creature.id)}
-              <option value={creature.id}>{creature.name}</option>
-            {/each}
-          </select>
-        </label>
-
-        {#if selectedCreature && previewCombatant}
-          <section class="creature-preview" aria-label="Selected creature preview">
-            <div class="preview-heading">
-              <div>
-                <strong>{selectedCreature.name}</strong>
-                <span>Level {selectedCreature.level} · {formatTraits(selectedCreature)}</span>
-              </div>
-              <span class:adjusted={selectedAdjustment !== 'normal'}>{templateLabel(selectedAdjustment)}</span>
-            </div>
-            <dl class="preview-stats">
-              <div>
-                <dt>HP</dt>
-                <dd>{previewCombatant.baseStats.hp}</dd>
-              </div>
-              <div>
-                <dt>AC</dt>
-                <dd>{previewCombatant.baseStats.ac}</dd>
-              </div>
-              <div>
-                <dt>Fort</dt>
-                <dd>+{previewCombatant.baseStats.fortitude}</dd>
-              </div>
-              <div>
-                <dt>Ref</dt>
-                <dd>+{previewCombatant.baseStats.reflex}</dd>
-              </div>
-              <div>
-                <dt>Will</dt>
-                <dd>+{previewCombatant.baseStats.will}</dd>
-              </div>
-              <div>
-                <dt>Per</dt>
-                <dd>+{previewCombatant.baseStats.perception}</dd>
-              </div>
-            </dl>
-            <p class="preview-line">
-              {selectedCreature.attacks.length} attack{selectedCreature.attacks.length === 1 ? '' : 's'}
-              {selectedCreature.spellcasting ? ` · ${selectedCreature.spellcasting.length} spell block${selectedCreature.spellcasting.length === 1 ? '' : 's'}` : ''}
-            </p>
-          </section>
-        {/if}
-
-        <fieldset class="template-picker">
-          <legend>Template</legend>
-          <div class="segmented">
-            <button
-              type="button"
-              class:active={selectedAdjustment === 'normal'}
-              aria-pressed={selectedAdjustment === 'normal'}
-              onclick={() => (selectedAdjustment = 'normal')}
-            >
-              Normal
-            </button>
-            <button
-              type="button"
-              class:active={selectedAdjustment === 'weak'}
-              aria-pressed={selectedAdjustment === 'weak'}
-              onclick={() => (selectedAdjustment = 'weak')}
-            >
-              Weak
-            </button>
-            <button
-              type="button"
-              class:active={selectedAdjustment === 'elite'}
-              aria-pressed={selectedAdjustment === 'elite'}
-              onclick={() => (selectedAdjustment = 'elite')}
-            >
-              Elite
-            </button>
-          </div>
-        </fieldset>
-
-        {#if selectedAdjustment !== 'normal'}
-          <p class="template-warning">
-            {templateLabel(selectedAdjustment)} adjusts structured stats, attacks, spell DCs, and HP. DCs or damage written only inside ability text are not adjusted automatically.
-          </p>
-        {/if}
-
-        <div class="add-grid">
-          <label>
-            Quantity
-            <input type="number" min="1" max="12" bind:value={creatureQuantity} />
-          </label>
-          <label>
-            Name prefix
-            <input bind:value={creatureNamePrefix} autocomplete="off" placeholder={selectedCreature?.name ?? 'Combatant'} />
-          </label>
-        </div>
-        <button type="submit">Add Creature</button>
-      </form>
-
-      <details class="custom-combatant">
-        <summary>Custom Combatant</summary>
-        <form class="manual-form" onsubmit={(event) => {
-        event.preventDefault();
-        addManualCombatant();
-      }}>
-          <label>
-            Name
-            <input bind:value={manualName} autocomplete="off" />
-          </label>
-          <div class="stat-grid">
-            <label>
-              HP
-              <input type="number" min="1" bind:value={manualHp} />
-            </label>
-            <label>
-              AC
-              <input type="number" bind:value={manualAc} />
-            </label>
-            <label>
-              Fort
-              <input type="number" bind:value={manualFortitude} />
-            </label>
-            <label>
-              Ref
-              <input type="number" bind:value={manualReflex} />
-            </label>
-            <label>
-              Will
-              <input type="number" bind:value={manualWill} />
-            </label>
-            <label>
-              Per
-              <input type="number" bind:value={manualPerception} />
-            </label>
-          </div>
-          <label>
-            Speed
-            <input type="number" min="0" bind:value={manualSpeed} />
-          </label>
-          <button type="submit">Add Custom</button>
-        </form>
-      </details>
-
-      <div class="control-row">
-        <button type="button" disabled={!canStart} onclick={startEncounter}>Start Encounter</button>
-        <button type="button" class="secondary" onclick={resetLocal}>Reset Local</button>
-      </div>
-    </aside>
-
-    <section class="panel initiative-panel" aria-labelledby="initiative-title">
-      <div class="panel-heading">
-        <h2 id="initiative-title">Initiative</h2>
-        <span>{encounter.initiative.order.length} ordered</span>
-      </div>
-
-      {#if orderedCombatants.length === 0}
-        <p class="empty">Add combatants to begin.</p>
-      {:else}
-        <ol class="initiative-list">
-          {#each orderedCombatants as combatant, index (combatant.id)}
-            <li class:current={combatant.id === activeCombatant?.id}>
-              <div>
-                <strong>{combatant.name}</strong>
-                {#if combatant.templateAdjustment}
-                  <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
-                {/if}
-                <span>HP {combatant.currentHp}/{combatant.baseStats.hp}</span>
-              </div>
-              <div class="icon-actions">
-                <button type="button" title="Move up" disabled={index === 0} onclick={() => moveCombatant(combatant.id, -1)}>↑</button>
-                <button
-                  type="button"
-                  title="Move down"
-                  disabled={index === orderedCombatants.length - 1}
-                  onclick={() => moveCombatant(combatant.id, 1)}
-                >
-                  ↓
-                </button>
-              </div>
-            </li>
-          {/each}
-        </ol>
-      {/if}
-
-      {#if unorderedCombatants.length > 0}
-        <div class="queue">
-          <h3>Unordered</h3>
-          {#each unorderedCombatants as combatant (combatant.id)}
-            <p>{combatant.name}</p>
-          {/each}
-        </div>
-      {/if}
-    </section>
+    <InitiativeTrack
+      ordered={orderedCombatants}
+      unordered={unorderedCombatants}
+      activeId={activeCombatant?.id}
+      onMove={moveCombatant}
+    />
 
     <section class="combat-column" aria-label="Combatants">
-      <div class="quick-controls panel">
+      <div class="quick-controls">
         <label>
           HP Amount
           <input type="number" min="1" bind:value={hpAmount} />
@@ -419,60 +165,20 @@
 
       <div class="cards">
         {#each orderedCombatants as combatant (combatant.id)}
-          <article class:current-card={combatant.id === activeCombatant?.id} class="combatant-card">
-            <div class="card-heading">
-              <div>
-                <div class="card-title">
-                  <h2>{combatant.name}</h2>
-                  {#if combatant.templateAdjustment}
-                    <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
-                  {/if}
-                </div>
-                <p>AC {combatant.baseStats.ac} · Fort +{combatant.baseStats.fortitude} · Ref +{combatant.baseStats.reflex} · Will +{combatant.baseStats.will}</p>
-              </div>
-              <span>{combatant.id === activeCombatant?.id ? 'Turn' : encounter.phase}</span>
-            </div>
-
-            <div class="hp-row">
-              <div>
-                <strong>{combatant.currentHp}</strong>
-                <span>/ {combatant.baseStats.hp} HP</span>
-              </div>
-              <div>
-                <strong>{combatant.tempHp}</strong>
-                <span>temp</span>
-              </div>
-            </div>
-            <div class="hp-track" aria-label={`${combatant.name} HP`}>
-              <div class="hp-fill" style={`width: ${hpPercent(combatant)}%`}></div>
-            </div>
-
-            <div class="card-actions">
-              <button type="button" onclick={() => applyDamage(combatant.id)}>Damage</button>
-              <button type="button" onclick={() => applyHealing(combatant.id)}>Heal</button>
-              <button type="button" onclick={() => setTempHp(combatant.id)}>Set Temp</button>
-              <button type="button" class="secondary" onclick={() => setHp(combatant.id, 0)}>Set 0</button>
-            </div>
-          </article>
+          <CombatantCard
+            {combatant}
+            isCurrent={combatant.id === activeCombatant?.id}
+            phase={encounter.phase}
+            onDamage={applyDamage}
+            onHeal={applyHealing}
+            onSetTemp={setTempHp}
+            onSetZero={(id) => setHp(id, 0)}
+          />
         {/each}
       </div>
     </section>
 
-    <aside class="panel feedback-panel" aria-labelledby="feedback-title">
-      <div class="panel-heading">
-        <h2 id="feedback-title">Event Feedback</h2>
-        <span>{feedback.length}</span>
-      </div>
-      {#if feedback.length === 0}
-        <p class="empty">Domain events will appear here.</p>
-      {:else}
-        <ol class="feedback-list">
-          {#each feedback as entry (entry.id)}
-            <li class:warn={entry.severity === 'warn'}>{entry.message}</li>
-          {/each}
-        </ol>
-      {/if}
-    </aside>
+    <FeedbackPanel entries={feedback} />
   </section>
 </main>
 
@@ -485,69 +191,9 @@
       Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 
-  :global(button),
-  :global(input),
-  :global(select) {
-    font: inherit;
-  }
-
   .shell {
     min-height: 100vh;
     padding: 24px;
-  }
-
-  .topbar {
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: 20px;
-    margin: 0 auto 18px;
-    max-width: 1440px;
-  }
-
-  .eyebrow,
-  .topbar h1,
-  .panel h2,
-  .panel h3,
-  .combatant-card h2,
-  .combatant-card p,
-  .empty {
-    margin: 0;
-  }
-
-  .eyebrow {
-    color: #697170;
-    font-size: 13px;
-    font-weight: 700;
-    text-transform: uppercase;
-  }
-
-  h1 {
-    font-size: 32px;
-    line-height: 1.1;
-  }
-
-  .status-strip {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 8px;
-    color: #415052;
-    font-size: 14px;
-  }
-
-  .status-strip span,
-  .status {
-    border: 1px solid #c5ccc8;
-    border-radius: 6px;
-    background: #ffffff;
-    padding: 8px 10px;
-  }
-
-  .status {
-    color: #f3f6f5;
-    background: #28494c;
-    border-color: #28494c;
   }
 
   .workspace {
@@ -559,411 +205,45 @@
     align-items: start;
   }
 
-  .panel,
-  .combatant-card {
-    border: 1px solid #cfd6d1;
-    border-radius: 8px;
-    background: #fbfcfa;
-    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
-  }
-
-  .panel {
-    padding: 14px;
-  }
-
-  .panel-heading,
-  .card-heading,
-  .control-row,
-  .card-actions,
-  .quick-controls {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-  }
-
-  .panel-heading {
-    margin-bottom: 14px;
-  }
-
-  .panel h2,
-  .combatant-card h2 {
-    font-size: 17px;
-    line-height: 1.2;
-  }
-
-  .panel h3 {
-    margin-top: 16px;
-    font-size: 14px;
-  }
-
-  .creature-form,
-  .manual-form,
-  .cards,
-  .feedback-list,
-  .initiative-list {
-    display: grid;
-    gap: 10px;
-  }
-
-  label {
-    display: grid;
-    gap: 5px;
-    color: #526061;
-    font-size: 12px;
-    font-weight: 700;
-  }
-
-  input {
-    min-width: 0;
-    border: 1px solid #b8c3be;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #1d2528;
-    padding: 9px 10px;
-  }
-
-  select {
-    min-width: 0;
-    border: 1px solid #b8c3be;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #1d2528;
-    padding: 9px 10px;
-  }
-
-  button {
-    min-height: 38px;
-    border: 1px solid #28494c;
-    border-radius: 6px;
-    background: #28494c;
-    color: #ffffff;
-    cursor: pointer;
-    font-weight: 700;
-    padding: 8px 12px;
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.45;
-  }
-
-  button.secondary {
-    border-color: #9aa7a3;
-    color: #263235;
-    background: #ffffff;
-  }
-
-  .stat-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-
-  .add-grid {
-    display: grid;
-    grid-template-columns: 96px minmax(0, 1fr);
-    gap: 8px;
-  }
-
-  .creature-preview {
-    display: grid;
-    gap: 10px;
-    border: 1px solid #d8ddd9;
-    border-radius: 7px;
-    background: #ffffff;
-    padding: 12px;
-  }
-
-  .preview-heading,
-  .card-title {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-  }
-
-  .preview-heading strong,
-  .preview-heading span {
-    display: block;
-  }
-
-  .preview-heading span,
-  .preview-line,
-  .custom-combatant summary {
-    color: #627171;
-    font-size: 13px;
-  }
-
-  .preview-heading > span,
-  .template-badge {
-    border-radius: 999px;
-    background: #eef1ee;
-    color: #334143;
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1;
-    padding: 5px 7px;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-
-  .preview-heading > span.adjusted,
-  .template-badge.elite {
-    background: #f4e6d7;
-    color: #7c3d1f;
-  }
-
-  .template-badge.weak {
-    background: #e6eef6;
-    color: #275171;
-  }
-
-  .preview-stats {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 6px;
-    margin: 0;
-  }
-
-  .preview-stats div {
-    border-radius: 6px;
-    background: #eef1ee;
-    padding: 8px;
-  }
-
-  .preview-stats dt,
-  .preview-stats dd,
-  .preview-line {
-    margin: 0;
-  }
-
-  .preview-stats dt {
-    color: #627171;
-    font-size: 11px;
-    font-weight: 800;
-    text-transform: uppercase;
-  }
-
-  .preview-stats dd {
-    color: #1d2528;
-    font-size: 18px;
-    font-weight: 800;
-  }
-
-  .template-picker {
-    display: grid;
-    gap: 6px;
-    border: 0;
-    margin: 0;
-    padding: 0;
-  }
-
-  .template-picker legend {
-    color: #526061;
-    font-size: 12px;
-    font-weight: 700;
-    padding: 0;
-  }
-
-  .segmented {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    border: 1px solid #b8c3be;
-    border-radius: 7px;
-    overflow: hidden;
-  }
-
-  .segmented button {
-    min-height: 36px;
-    border: 0;
-    border-radius: 0;
-    background: #ffffff;
-    color: #334143;
-  }
-
-  .segmented button + button {
-    border-left: 1px solid #d8ddd9;
-  }
-
-  .segmented button.active {
-    background: #28494c;
-    color: #ffffff;
-  }
-
-  .template-warning {
-    border-left: 4px solid #b6652e;
-    border-radius: 6px;
-    background: #fff7ee;
-    color: #5f3c23;
-    font-size: 13px;
-    line-height: 1.4;
-    margin: 0;
-    padding: 10px;
-  }
-
-  .custom-combatant {
-    border-top: 1px solid #d8ddd9;
-    margin-top: 14px;
-    padding-top: 12px;
-  }
-
-  .custom-combatant summary {
-    cursor: pointer;
-    font-weight: 800;
-    margin-bottom: 10px;
-  }
-
-  .control-row {
-    margin-top: 12px;
-  }
-
-  .initiative-list,
-  .feedback-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .initiative-list li {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    border: 1px solid #d8ddd9;
-    border-radius: 7px;
-    background: #ffffff;
-    padding: 10px;
-  }
-
-  .initiative-list li.current {
-    border-color: #a53f2b;
-    box-shadow: inset 4px 0 0 #a53f2b;
-  }
-
-  .initiative-list strong,
-  .initiative-list span {
-    display: block;
-  }
-
-  .initiative-list .template-badge {
-    display: inline-block;
-    margin: 5px 0 1px;
-  }
-
-  .initiative-list span,
-  .card-heading span,
-  .queue,
-  .empty {
-    color: #627171;
-    font-size: 13px;
-  }
-
-  .icon-actions {
-    display: flex;
-    gap: 6px;
-  }
-
-  .icon-actions button {
-    width: 36px;
-    padding: 0;
-  }
-
   .combat-column {
     display: grid;
     gap: 14px;
   }
 
   .quick-controls {
+    display: flex;
+    align-items: center;
     justify-content: start;
+    gap: 10px;
+    border: 1px solid #cfd6d1;
+    border-radius: 8px;
+    background: #fbfcfa;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 14px;
   }
 
   .quick-controls label {
+    display: grid;
+    gap: 5px;
+    color: #526061;
+    font-size: 12px;
+    font-weight: 700;
     max-width: 140px;
   }
 
-  .combatant-card {
-    padding: 16px;
-  }
-
-  .current-card {
-    border-color: #a53f2b;
-  }
-
-  .card-heading {
-    align-items: start;
-  }
-
-  .card-title {
-    justify-content: start;
-    flex-wrap: wrap;
-  }
-
-  .card-heading p {
-    margin-top: 5px;
-    color: #526061;
-    font-size: 13px;
-  }
-
-  .card-heading span {
-    border-radius: 999px;
-    background: #eef1ee;
-    padding: 5px 8px;
-    white-space: nowrap;
-  }
-
-  .hp-row {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-    margin-top: 18px;
-  }
-
-  .hp-row > div {
-    border-radius: 7px;
-    background: #eef1ee;
-    padding: 10px;
-  }
-
-  .hp-row strong {
-    font-size: 24px;
-  }
-
-  .hp-row span {
-    color: #526061;
-    font-size: 13px;
-  }
-
-  .hp-track {
-    height: 10px;
-    overflow: hidden;
-    border-radius: 999px;
-    background: #d9dfdb;
-    margin: 12px 0;
-  }
-
-  .hp-fill {
-    height: 100%;
-    border-radius: inherit;
-    background: #3f7f64;
-  }
-
-  .card-actions {
-    justify-content: start;
-    flex-wrap: wrap;
-  }
-
-  .feedback-list li {
-    border-left: 4px solid #3f7f64;
+  .quick-controls input {
+    min-width: 0;
+    border: 1px solid #b8c3be;
     border-radius: 6px;
     background: #ffffff;
-    padding: 10px;
-    font-size: 13px;
+    color: #1d2528;
+    padding: 9px 10px;
+    font: inherit;
   }
 
-  .feedback-list li.warn {
-    border-left-color: #b6652e;
-    background: #fff7ee;
+  .cards {
+    display: grid;
+    gap: 10px;
   }
 
   @media (max-width: 1180px) {
@@ -971,8 +251,8 @@
       grid-template-columns: minmax(260px, 320px) 1fr;
     }
 
-    .combat-column,
-    .feedback-panel {
+    .workspace > :nth-child(3),
+    .workspace > :nth-child(4) {
       grid-column: span 2;
     }
   }
@@ -982,32 +262,18 @@
       padding: 14px;
     }
 
-    .topbar,
     .workspace {
-      display: grid;
       grid-template-columns: 1fr;
     }
 
-    .status-strip {
-      justify-content: start;
-    }
-
-    .combat-column,
-    .feedback-panel {
+    .workspace > :nth-child(3),
+    .workspace > :nth-child(4) {
       grid-column: auto;
     }
 
-    .card-heading,
-    .panel-heading,
-    .control-row,
     .quick-controls {
       align-items: stretch;
       flex-direction: column;
-    }
-
-    .card-actions button,
-    .control-row button {
-      width: 100%;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
Mechanical extraction of `src/routes/+page.svelte` (1013 lines → 279) into five presentational components in a new `src/components/` layer. No behavior change.

- `TopBar.svelte` — encounter name, phase, round, active turn
- `SetupPanel.svelte` — creature picker, template control, preview, custom combatant form, start/reset
- `InitiativeTrack.svelte` — ordered list + unordered queue with reorder buttons
- `CombatantCard.svelte` — HP row, HP track, damage/heal/temp/set-zero
- `FeedbackPanel.svelte` — severity-styled event feedback

Components own their own form scratch state and emit intentions via callback props (`onAddCreatures`, `onAddManual`, `onMove`, `onDamage`, etc.). The route keeps encounter state, command dispatch, and shared HP/temp inputs.

CLAUDE.md updated to add `src/components/` as a layer between `src/routes/` and `src/lib/`. Components may import from `$lib`/`../domain` but never the reverse.

Closes #28. Part of #15 (slice 1 of 7 — see updated #15 body for the full slice list).

## Test plan
- [x] `npm run check` (svelte-check + tsc on domain) — 0 errors, 0 warnings
- [x] `npm run test:run` — 40/40 passing
- [x] `npm run audit` — passes at moderate threshold
- [x] `npm run build` — static Cloudflare Pages build succeeds
- [x] Manual smoke test in `npm run dev`: add a library creature, add a custom combatant, reorder, start encounter, deal damage, heal, set temp HP, set 0, observe feedback — all behavior should be identical to pre-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)