### PR TITLE
Harden CI workflow and tick M0 roadmap item

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/audit-strict.yml
+++ b/.github/workflows/audit-strict.yml
@@ -1,0 +1,27 @@
+name: Strict dependency audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit-low:
+    name: npm audit (low)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies (low severity)
+        run: npm run audit:low

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     name: Check, test, audit, and build
@@ -13,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 22
           cache: npm

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 - [x] Initialize SvelteKit, TypeScript, Vitest, and static Cloudflare Pages build.
 - [x] Add first pure domain reducer slice for combatants, initiative setup, lifecycle, and HP commands.
 - [x] Add dependency audit script that fails on known low-or-higher vulnerabilities.
-- [ ] Add CI for `npm run check`, `npm run test:run`, `npm run audit`, and `npm run build`.
+- [x] Add CI for `npm run check`, `npm run test:run`, `npm run audit`, and `npm run build`.
 - [x] Expand command/event test fixtures for future domain tests.
 
 ## M1 Encounter Setup


### PR DESCRIPTION
## Summary

- Add `concurrency` block to `.github/workflows/ci.yml` so a new push to a PR branch cancels the in-flight run for the same PR (scoped to `pull_request` only — pushes to `master` don't cancel each other).
- Pin `actions/checkout` and `actions/setup-node` to commit SHAs (`# v4` comment retained for Dependabot tracking) for supply-chain safety.
- Add `.github/workflows/audit-strict.yml` — weekly Mondays 09:00 UTC + `workflow_dispatch`, runs `npm run audit:low` to surface low-severity advisories without gating PRs.
- Add `.github/dependabot.yml` — weekly bumps for both `github-actions` and `npm` ecosystems so the pinned SHAs and deps stay fresh.
- Tick M0 CI item in `ROADMAP.md` — the workflow has been live and green since commit `bad6c08`.

## Heads-up — `audit-strict` will fail on its first run

`npm run audit:low` currently exits 1 because of three low-severity advisories upstream:

```
cookie  <0.7.0  (GHSA-pxg6-pf52-xh8x)
  via @sveltejs/kit  >=1.0.0-next.0
  via @sveltejs/adapter-static  >=1.0.0-next.0
```

`npm audit fix --force` would downgrade `@sveltejs/kit` to 0.0.30 (breaking) — not viable. The fix is to wait for SvelteKit to bump its `cookie` dep (or accept the weekly red email until then). If the noise becomes annoying, three options without reverting this PR:

- Disable the cron and keep `workflow_dispatch` only (drop the `schedule:` block).
- Add `continue-on-error: true` to the audit step so it surfaces output without failing.
- Bump `@sveltejs/kit` once an upstream fix lands.

The PR-blocking `audit` job (moderate-severity gate) is unaffected and stays green.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings (213 files)
- [x] `npm run test:run` — 49 tests pass
- [x] `npm run audit` — passes (moderate gate; low advisories don't block)
- [x] `npm run build` — static build succeeds
- [x] CI on this PR turns green
- [ ] Push an empty commit and confirm the previous CI run is `cancelled` (concurrency working)
- [ ] `gh workflow run audit-strict.yml` succeeds locally on demand once the cookie advisory is resolved (will fail until then — see heads-up above)
- [ ] After merge: confirm Dependabot starts opening PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)