### PR TITLE
[codex] Add built-in effect library

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 - [x] Initialize SvelteKit, TypeScript, Vitest, and static Cloudflare Pages build.
 - [x] Add first pure domain reducer slice for combatants, initiative setup, lifecycle, and HP commands.
 - [x] Add dependency audit script that fails on known low-or-higher vulnerabilities.
-- [ ] Add CI for `npm run check`, `npm run test:run`, `npm run audit`, and `npm run build`.
+- [x] Add CI for `npm run check`, `npm run test:run`, `npm run audit`, and `npm run build`.
 - [x] Expand command/event test fixtures for future domain tests.
 
 ## M1 Encounter Setup

--- a/src/domain/effects/library.test.ts
+++ b/src/domain/effects/library.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'vitest';
+import { effectLibrary } from './library';
+import type { BonusType, Modifier, StatTarget, TurnBoundarySuggestion } from '../types';
+
+const supportedBonusTypes = new Set<BonusType>(['status', 'circumstance', 'item', 'untyped']);
+
+const supportedStatTargets = new Set<StatTarget>([
+  'ac',
+  'fortitude',
+  'reflex',
+  'will',
+  'allSaves',
+  'perception',
+  'attackRolls',
+  'allDCs',
+  'allSkills',
+  'strSkills',
+  'dexSkills',
+  'intSkills',
+  'wisSkills',
+  'chaSkills',
+  'mentalSkills'
+]);
+
+const supportedSuggestionTypes = new Set<TurnBoundarySuggestion['type']>([
+  'suggestDecrement',
+  'suggestRemove',
+  'confirmSustained',
+  'promptResolution',
+  'reminder'
+]);
+
+function expectModifierShape(modifier: Modifier): void {
+  expect(supportedStatTargets.has(modifier.stat)).toBe(true);
+  expect(supportedBonusTypes.has(modifier.bonusType)).toBe(true);
+  expect(
+    typeof modifier.value === 'number' || modifier.value === 'effectValue' || modifier.value === '-effectValue'
+  ).toBe(true);
+}
+
+function expectSuggestionShape(suggestion: TurnBoundarySuggestion): void {
+  expect(supportedSuggestionTypes.has(suggestion.type)).toBe(true);
+
+  if (suggestion.type === 'suggestDecrement') {
+    expect(typeof suggestion.amount).toBe('number');
+    expect(suggestion.amount).toBeGreaterThan(0);
+  }
+
+  if (
+    suggestion.type === 'suggestRemove' ||
+    suggestion.type === 'promptResolution' ||
+    suggestion.type === 'reminder'
+  ) {
+    expect(typeof suggestion.description).toBe('string');
+    expect(suggestion.description.length).toBeGreaterThan(0);
+  }
+}
+
+describe('effectLibrary', () => {
+  test('uses matching record keys and definition ids', () => {
+    for (const [key, definition] of Object.entries(effectLibrary)) {
+      expect(definition.id).toBe(key);
+    }
+  });
+
+  test('contains only serializable definitions with supported modifier and suggestion shapes', () => {
+    expect(JSON.parse(JSON.stringify(effectLibrary))).toEqual(effectLibrary);
+
+    for (const definition of Object.values(effectLibrary)) {
+      expect(definition.name.length).toBeGreaterThan(0);
+      expect(['condition', 'spell', 'affliction', 'persistent-damage', 'custom']).toContain(definition.category);
+      expect(Array.isArray(definition.modifiers)).toBe(true);
+
+      for (const modifier of definition.modifiers) {
+        expectModifierShape(modifier);
+      }
+
+      if (definition.turnStartSuggestion) {
+        expectSuggestionShape(definition.turnStartSuggestion);
+      }
+
+      if (definition.turnEndSuggestion) {
+        expectSuggestionShape(definition.turnEndSuggestion);
+      }
+    }
+  });
+
+  test('references only existing definitions from implied effects', () => {
+    for (const definition of Object.values(effectLibrary)) {
+      for (const impliedEffect of definition.impliedEffects ?? []) {
+        expect(effectLibrary[impliedEffect], `${definition.id} implies ${impliedEffect}`).toBeDefined();
+      }
+    }
+  });
+
+  test('defines high-risk condition mechanics from the canonical library spec', () => {
+    expect(effectLibrary.frightened).toMatchObject({
+      id: 'frightened',
+      hasValue: true,
+      maxValue: 4,
+      turnEndSuggestion: { type: 'suggestDecrement', amount: 1 }
+    });
+    expect(effectLibrary.frightened.modifiers).toContainEqual({
+      stat: 'attackRolls',
+      bonusType: 'status',
+      value: '-effectValue'
+    });
+
+    expect(effectLibrary['off-guard']).toMatchObject({
+      id: 'off-guard',
+      hasValue: false,
+      modifiers: [{ stat: 'ac', bonusType: 'circumstance', value: -2 }]
+    });
+
+    expect(effectLibrary.dying).toMatchObject({
+      id: 'dying',
+      hasValue: true,
+      maxValue: 4,
+      impliedEffects: ['unconscious'],
+      turnStartSuggestion: { type: 'promptResolution' }
+    });
+
+    expect(effectLibrary.encumbered).toMatchObject({
+      id: 'encumbered',
+      hasValue: false,
+      impliedEffects: ['clumsy']
+    });
+  });
+
+  test('models persistent damage as note-driven prompt definitions', () => {
+    expect(effectLibrary['persistent-fire']).toMatchObject({
+      id: 'persistent-fire',
+      name: 'Persistent Fire',
+      category: 'persistent-damage',
+      hasValue: false,
+      modifiers: [],
+      turnStartSuggestion: {
+        type: 'promptResolution',
+        description: 'Take {note} fire damage, then flat check DC 15 to remove.'
+      }
+    });
+  });
+});

--- a/src/domain/effects/library.ts
+++ b/src/domain/effects/library.ts
@@ -1,0 +1,344 @@
+import type { EffectDefinition, EffectLibrary, Modifier } from '../types';
+
+function allChecksAndDcsModifiers(): Modifier[] {
+  return [
+    { stat: 'ac', bonusType: 'status', value: '-effectValue' },
+    { stat: 'allSaves', bonusType: 'status', value: '-effectValue' },
+    { stat: 'perception', bonusType: 'status', value: '-effectValue' },
+    { stat: 'attackRolls', bonusType: 'status', value: '-effectValue' },
+    { stat: 'allSkills', bonusType: 'status', value: '-effectValue' },
+    { stat: 'allDCs', bonusType: 'status', value: '-effectValue' }
+  ];
+}
+
+function condition(definition: Omit<EffectDefinition, 'category'>): EffectDefinition {
+  return { category: 'condition', ...definition };
+}
+
+function persistentDamage(type: string, name: string): EffectDefinition {
+  return {
+    id: `persistent-${type}`,
+    name: `Persistent ${name}`,
+    category: 'persistent-damage',
+    hasValue: false,
+    modifiers: [],
+    turnStartSuggestion: {
+      type: 'promptResolution',
+      description: `Take {note} ${type} damage, then flat check DC 15 to remove.`
+    },
+    description:
+      'At start of turn: take damage, then DC 15 flat check to end. Assisted recovery lowers DC to 10. Multiple sources: take only the highest.'
+  };
+}
+
+export const effectLibrary: EffectLibrary = {
+  frightened: condition({
+    id: 'frightened',
+    name: 'Frightened',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: allChecksAndDcsModifiers(),
+    turnEndSuggestion: { type: 'suggestDecrement', amount: 1 },
+    description: 'Decreases by 1 at end of your turn.'
+  }),
+  sickened: condition({
+    id: 'sickened',
+    name: 'Sickened',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: allChecksAndDcsModifiers(),
+    description:
+      "Can spend an action to retch (Fortitude save vs source DC to reduce by 1, or 0 on critical success). Can't willingly ingest anything."
+  }),
+  clumsy: condition({
+    id: 'clumsy',
+    name: 'Clumsy',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: [
+      { stat: 'ac', bonusType: 'status', value: '-effectValue' },
+      { stat: 'reflex', bonusType: 'status', value: '-effectValue' },
+      { stat: 'dexSkills', bonusType: 'status', value: '-effectValue' }
+    ],
+    description: "Also applies to Dex-based attack rolls, which are not automated because creature attacks don't tag ability."
+  }),
+  enfeebled: condition({
+    id: 'enfeebled',
+    name: 'Enfeebled',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: [{ stat: 'strSkills', bonusType: 'status', value: '-effectValue' }],
+    description:
+      "Also applies to Str-based melee attack rolls and damage rolls, which are not automated because creature attacks don't tag ability."
+  }),
+  stupefied: condition({
+    id: 'stupefied',
+    name: 'Stupefied',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: [
+      { stat: 'mentalSkills', bonusType: 'status', value: '-effectValue' },
+      { stat: 'will', bonusType: 'status', value: '-effectValue' }
+    ],
+    description:
+      'Also applies to spell attack rolls and spell DCs. When casting a spell, DC 5 + value flat check or spell is lost.'
+  }),
+  drained: condition({
+    id: 'drained',
+    name: 'Drained',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: [{ stat: 'fortitude', bonusType: 'status', value: '-effectValue' }],
+    persistAfterEncounter: true,
+    description:
+      "Reduces max HP by level times value. Also applies to Con-based checks beyond Fortitude. Decreases by 1 after a full night's rest."
+  }),
+  doomed: condition({
+    id: 'doomed',
+    name: 'Doomed',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    persistAfterEncounter: true,
+    description: 'Death threshold becomes 4 - Doomed value. Decreases by 1 after a full night of rest.'
+  }),
+  wounded: condition({
+    id: 'wounded',
+    name: 'Wounded',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    persistAfterEncounter: true,
+    description:
+      'When you gain Dying, add Wounded value to the Dying value. Removed when restored to full HP. Increases by 1 each time you recover from Dying.'
+  }),
+  dying: condition({
+    id: 'dying',
+    name: 'Dying',
+    hasValue: true,
+    maxValue: 4,
+    impliedEffects: ['unconscious'],
+    modifiers: [],
+    turnStartSuggestion: {
+      type: 'promptResolution',
+      description:
+        'Recovery check: DC 10 + Dying value (+ Wounded if applicable). Crit Success reduces Dying by 2. Success reduces Dying by 1. Failure increases Dying by 1. Crit Failure increases Dying by 2.'
+    },
+    description: 'You are unconscious. Death occurs at Dying 4, or 4 - Doomed. Recovery check at start of each turn.'
+  }),
+  slowed: condition({
+    id: 'slowed',
+    name: 'Slowed',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    turnStartSuggestion: { type: 'reminder', description: 'Loses {value} action(s) this turn.' },
+    description:
+      'You have fewer actions. At start of turn, lose a number of actions equal to value. Slowed does not affect reactions or free actions.'
+  }),
+  stunned: condition({
+    id: 'stunned',
+    name: 'Stunned',
+    hasValue: true,
+    maxValue: 10,
+    modifiers: [],
+    turnStartSuggestion: {
+      type: 'reminder',
+      description:
+        'Lose up to {value} action(s). Reduce Stunned value by the number lost. If also Slowed, Stunned actions are lost first.'
+    },
+    description:
+      'You lose actions equal to Stunned value, total not per turn. Reduce Stunned by actions lost each turn. Overrides Slowed while active.'
+  }),
+  'off-guard': condition({
+    id: 'off-guard',
+    name: 'Off-Guard',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'circumstance', value: -2 }],
+    description: 'You are flat-footed. -2 circumstance penalty to AC.'
+  }),
+  blinded: condition({
+    id: 'blinded',
+    name: 'Blinded',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [{ stat: 'perception', bonusType: 'status', value: -4 }],
+    description:
+      "Can't see. All terrain is difficult terrain. Auto-crit-fail Perception checks requiring sight. -4 status penalty to Perception if vision is your only precise sense."
+  }),
+  dazzled: condition({
+    id: 'dazzled',
+    name: 'Dazzled',
+    hasValue: false,
+    modifiers: [],
+    description:
+      "Everything is concealed to you (DC 5 flat check to target). If you have a non-visual precise sense, concealment only applies vs. creatures you'd need sight to perceive."
+  }),
+  encumbered: condition({
+    id: 'encumbered',
+    name: 'Encumbered',
+    hasValue: false,
+    impliedEffects: ['clumsy'],
+    modifiers: [],
+    description: 'All Speeds reduced by 10 feet, minimum 5 feet. Implies Clumsy 1.'
+  }),
+  prone: condition({
+    id: 'prone',
+    name: 'Prone',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [{ stat: 'attackRolls', bonusType: 'circumstance', value: -2 }],
+    description:
+      'Off-Guard. -2 circumstance to attack rolls. +1 circumstance bonus to AC vs ranged attacks is not automated. Must Crawl to move or spend an action to Stand.'
+  }),
+  fascinated: condition({
+    id: 'fascinated',
+    name: 'Fascinated',
+    hasValue: false,
+    modifiers: [
+      { stat: 'perception', bonusType: 'status', value: -2 },
+      { stat: 'allSkills', bonusType: 'status', value: -2 }
+    ],
+    description:
+      "Can't use concentrate actions that don't relate to the source of fascination. Ends if a hostile action is taken against you or your allies."
+  }),
+  grabbed: condition({
+    id: 'grabbed',
+    name: 'Grabbed',
+    hasValue: false,
+    impliedEffects: ['off-guard', 'immobilized'],
+    modifiers: [],
+    description:
+      "Off-Guard and Immobilized. Can attempt to Escape (Athletics or Acrobatics vs. grabber's Athletics DC). Ends if grabber moves away or releases."
+  }),
+  restrained: condition({
+    id: 'restrained',
+    name: 'Restrained',
+    hasValue: false,
+    impliedEffects: ['off-guard', 'immobilized'],
+    modifiers: [],
+    description:
+      "Off-Guard and Immobilized. Can't use actions with the manipulate or move trait except Escape and Force Open. Can attempt to Escape."
+  }),
+  paralyzed: condition({
+    id: 'paralyzed',
+    name: 'Paralyzed',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [],
+    description: "Off-Guard. Can't act. Can't move. Body is rigid. Fall prone if standing."
+  }),
+  petrified: condition({
+    id: 'petrified',
+    name: 'Petrified',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [],
+    description:
+      "Off-Guard. Can't act. Can't perceive. Turned to stone. Immune to most effects while petrified. Often permanent until reversed by magic."
+  }),
+  unconscious: condition({
+    id: 'unconscious',
+    name: 'Unconscious',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [
+      { stat: 'ac', bonusType: 'status', value: -4 },
+      { stat: 'perception', bonusType: 'status', value: -4 },
+      { stat: 'reflex', bonusType: 'status', value: -4 }
+    ],
+    description:
+      "Off-Guard. Can't act. Fall prone and drop held items. You don't perceive. A creature can Interact to wake you, or you wake from damage unless magical sleep."
+  }),
+  immobilized: condition({
+    id: 'immobilized',
+    name: 'Immobilized',
+    hasValue: false,
+    modifiers: [],
+    description: "Can't use actions with the move trait. Can be dragged or teleported."
+  }),
+  concealed: condition({
+    id: 'concealed',
+    name: 'Concealed',
+    hasValue: false,
+    modifiers: [],
+    description: "DC 5 flat check for attacks targeting this creature; on failure, attack misses. Doesn't change what senses can detect you."
+  }),
+  hidden: condition({
+    id: 'hidden',
+    name: 'Hidden',
+    hasValue: false,
+    modifiers: [],
+    description: "Creatures know your space but can't see you. DC 11 flat check to target; on failure, attack misses. Must Seek to find with Perception."
+  }),
+  undetected: condition({
+    id: 'undetected',
+    name: 'Undetected',
+    hasValue: false,
+    modifiers: [],
+    description:
+      "Creatures don't know your location. Must guess the space to target; DC 11 flat check if correct space. Must Seek to become Hidden first."
+  }),
+  unnoticed: condition({
+    id: 'unnoticed',
+    name: 'Unnoticed',
+    hasValue: false,
+    modifiers: [],
+    description: "Creatures don't know you're present at all. Can't be targeted or affected. More restrictive than Undetected."
+  }),
+  invisible: condition({
+    id: 'invisible',
+    name: 'Invisible',
+    hasValue: false,
+    modifiers: [],
+    description:
+      "Can't be seen. You are Hidden or Undetected to creatures relying on sight, depending on whether they can identify your space. Non-visual senses may still detect you."
+  }),
+  fleeing: condition({
+    id: 'fleeing',
+    name: 'Fleeing',
+    hasValue: false,
+    modifiers: [],
+    description:
+      'Must spend each action to move away from the source of fear using the most efficient route. Cannot Delay or Ready. If cornered, uses other actions as GM sees fit.'
+  }),
+  controlled: condition({
+    id: 'controlled',
+    name: 'Controlled',
+    hasValue: false,
+    modifiers: [],
+    description: "Another creature determines your actions. The controller spends your actions. You're typically Off-Guard; apply separately if needed."
+  }),
+  confused: condition({
+    id: 'confused',
+    name: 'Confused',
+    hasValue: false,
+    impliedEffects: ['off-guard'],
+    modifiers: [],
+    description:
+      "Off-Guard. Can't Delay, Ready, or use reactions. Treats all creatures as enemies. Each turn, Strike a random adjacent creature if possible; otherwise move toward the nearest creature."
+  }),
+  quickened: condition({
+    id: 'quickened',
+    name: 'Quickened',
+    hasValue: false,
+    modifiers: [],
+    turnStartSuggestion: {
+      type: 'reminder',
+      description: 'Gains 1 extra action this turn (constrained to specified use, if any).'
+    },
+    description:
+      'Gain 1 extra action at start of each turn. The extra action is often limited to specific uses by the granting effect, noted in AppliedEffect.note.'
+  }),
+  'persistent-fire': persistentDamage('fire', 'Fire'),
+  'persistent-cold': persistentDamage('cold', 'Cold'),
+  'persistent-acid': persistentDamage('acid', 'Acid'),
+  'persistent-electricity': persistentDamage('electricity', 'Electricity'),
+  'persistent-sonic': persistentDamage('sonic', 'Sonic'),
+  'persistent-bleed': persistentDamage('bleed', 'Bleed'),
+  'persistent-poison': persistentDamage('poison', 'Poison'),
+  'persistent-mental': persistentDamage('mental', 'Mental'),
+  'persistent-bludgeoning': persistentDamage('bludgeoning', 'Bludgeoning'),
+  'persistent-piercing': persistentDamage('piercing', 'Piercing'),
+  'persistent-slashing': persistentDamage('slashing', 'Slashing')
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,6 +1,7 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
 export { applyEliteWeak } from './creatures/templates';
+export { effectLibrary } from './effects/library';
 export type { CreatureTemplateAdjustment } from './creatures/templates';
 export type {
   Ability,
@@ -8,6 +9,7 @@ export type {
   Attack,
   AttackType,
   ActionCost,
+  BonusType,
   CombatantId,
   CombatantSpellcasting,
   CombatantState,
@@ -21,16 +23,21 @@ export type {
   DamageComponent,
   DomainEvent,
   Duration,
+  EffectCategory,
+  EffectDefinition,
   EffectLibrary,
   EncounterPhase,
   EncounterState,
   InitiativeState,
   LogEntry,
+  Modifier,
   Prompt,
   SourceType,
   SpellcastingBlock,
   SpellcastingType,
   SpellFrequency,
   SpellListEntry,
-  SpellTradition
+  SpellTradition,
+  StatTarget,
+  TurnBoundarySuggestion
 } from './types';

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -299,7 +299,57 @@ export type DomainEvent =
   | { type: 'hp-reached-zero'; combatantId: CombatantId }
   | { type: 'command-rejected'; commandType: CommandType; reason: string };
 
-export type EffectLibrary = Record<string, unknown>;
+export type EffectCategory = 'condition' | 'spell' | 'affliction' | 'persistent-damage' | 'custom';
+
+export type BonusType = 'status' | 'circumstance' | 'item' | 'untyped';
+
+export type StatTarget =
+  | 'ac'
+  | 'fortitude'
+  | 'reflex'
+  | 'will'
+  | 'allSaves'
+  | 'perception'
+  | 'attackRolls'
+  | 'allDCs'
+  | 'allSkills'
+  | 'strSkills'
+  | 'dexSkills'
+  | 'intSkills'
+  | 'wisSkills'
+  | 'chaSkills'
+  | 'mentalSkills'
+  | (string & {});
+
+export interface Modifier {
+  stat: StatTarget;
+  bonusType: BonusType;
+  value: number | 'effectValue' | '-effectValue';
+}
+
+export type TurnBoundarySuggestion =
+  | { type: 'suggestDecrement'; amount: number; description?: string }
+  | { type: 'suggestRemove'; description: string }
+  | { type: 'confirmSustained'; description?: string }
+  | { type: 'promptResolution'; description: string }
+  | { type: 'reminder'; description: string };
+
+export interface EffectDefinition {
+  id: string;
+  name: string;
+  category: EffectCategory;
+  description?: string;
+  modifiers: Modifier[];
+  hasValue: boolean;
+  maxValue?: number;
+  impliedEffects?: string[];
+  turnStartSuggestion?: TurnBoundarySuggestion;
+  turnEndSuggestion?: TurnBoundarySuggestion;
+  persistAfterEncounter?: boolean;
+  traits?: string[];
+}
+
+export type EffectLibrary = Record<string, EffectDefinition>;
 
 export interface CommandResult {
   newState: EncounterState;


### PR DESCRIPTION
## Summary
- Add typed effect-library domain shapes and replace `EffectLibrary` with `Record<string, EffectDefinition>`.
- Add the built-in PF2E condition and persistent damage library under `src/domain/effects/library.ts`.
- Add library integrity tests for serialization, implied-effect references, modifier/suggestion shapes, and high-risk definitions.
- Mark the existing CI workflow complete in `ROADMAP.md`.

## Scope Notes
- Domain-only slice for issue #9.
- No `APPLY_EFFECT`, stacking derivation, prompt generation, persistence, or UI behavior changes.
- Persistent damage stores dice expressions through `AppliedEffect.note`; library definitions use `{note}` in the turn-start prompt text.

## Verification
- `npm run check`
- `npm run test:run`
- `npm run build`
- `npm run audit` (passes at the repo's moderate threshold; known low-severity `cookie <0.7.0` advisory remains)
- `git diff --check`

Refs #9