### PR TITLE
[codex] Update backlog grooming docs and tickets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Use npm for project tooling.
 - `npm run dev` starts the SvelteKit dev server.
 - `npm run check` runs Svelte/TypeScript checks, including the domain-only tsconfig.
 - `npm run test:run` runs Vitest.
-- `npm run audit` fails on any known dependency vulnerability at low severity or higher.
+- `npm run audit` fails on any known dependency vulnerability at moderate severity or higher.
+- `npm run audit:low` runs the stricter low-severity manual audit check.
 - `npm run build` creates the static Cloudflare Pages build in `build`.
 - `npm run deploy:pages` builds and uploads `build` to Cloudflare Pages with Wrangler.
 - `git status` verifies the intended files changed.
@@ -25,7 +26,7 @@ Write specs in Markdown with clear headings, short paragraphs, and fenced `types
 Vitest covers the domain layer. Review changes against the locked architectural rules: pure domain logic, GM-authority behavior, serializable command/event payloads, and strict separation between domain and UI concerns. For any substantial spec change, include at least one worked example or edge-case flow.
 
 ## Commit & Pull Request Guidelines
-The Git history is empty today, so set the convention now: use short imperative commit subjects such as `Add hazard subsystem spec` or `Refine command rejection rules`. Keep each commit focused on one subsystem or one decision set. Pull requests should summarize the affected spec, list newly locked decisions, and call out any unresolved questions. UI screenshots are only relevant once implementation files exist.
+Use short imperative commit subjects such as `Add hazard subsystem spec` or `Refine command rejection rules`. Keep each commit focused on one subsystem or one decision set. Pull requests should summarize the affected spec, list newly locked decisions, and call out any unresolved questions. UI screenshots are only relevant once implementation files exist.
 
 ## Contributor Notes
 Keep the app deployable to Cloudflare Pages using static assets and free services. Do not add Pages Functions, Workers, KV, D1, R2, or server-side endpoints unless the task explicitly calls for changing the architecture. Prefer updating authoritative `.md` specs instead of duplicating corrections across the transcript-style `.txt` files.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 
 ## M3 Effects and Conditions
 
-- [ ] Add built-in condition and persistent damage library.
+- [x] Add built-in condition and persistent damage library. (Implemented in PR #31.)
 - [ ] Implement `APPLY_EFFECT`, `REMOVE_EFFECT`, value changes, and duration changes.
 - [ ] Implement implied effects and removal cascades.
 - [ ] Implement PF2e stacking derivation.

--- a/docs/cloudflare-pages.md
+++ b/docs/cloudflare-pages.md
@@ -21,7 +21,7 @@ User data remains in browser storage. Future LLM parsing calls should go directl
 Use these settings for Git-backed Pages deployment:
 
 - Framework preset: SvelteKit, or no preset with the values below
-- Build command: `npm run build`
+- Build command: `npm run check && npm run test:run && npm run audit && npm run build`
 - Build output directory: `build`
 - Root directory: repository root
 


### PR DESCRIPTION
## Summary
- Align `AGENTS.md`, `ROADMAP.md`, and `docs/cloudflare-pages.md` with the current repo state.
- Close the stale built-in effect library issue and refresh the M3 follow-on issues.
- Split the next M5 UI work into four focused child issues.

## Backlog updates
- Closed issue #9 as completed after PR #31 merged the built-in effect library.
- Updated issue #10 to reflect that the effect-library prerequisite is done.
- Added dependency notes to issues #11 and #12.
- Updated umbrella issues #15 and #16 to point at new child tickets.
- Created issues #38 through #41 for the next UI slices.

## Verification
- `npm run check`
- `npm run test:run`
- `npm run audit`
- `npm run build`
- `git diff --check`
