### PR TITLE
Re-prioritize backlog and update ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,12 @@
 
 This roadmap tracks implementation milestones. Canonical behavior still lives in the `pf2e-*-spec.md` files; roadmap items should link back to those specs when they become GitHub issues.
 
+Active work is grouped into three parallel tracks. Within each track items are dependency-ordered; across tracks they are independent and can ship in any order.
+
+- **Track A — close M3 (effects engine):** #10 → #11 → #12.
+- **Track B — combat UI slices:** #38, #39, #40, #41, #43, #44, #45 (depends on #10), #46 (depends on #12).
+- **Track C — persistence & import:** #13 → #14 → #47 (depends on #13) → #48 (depends on #14).
+
 ## M0 Foundation
 
 - [x] Initialize SvelteKit, TypeScript, Vitest, and static Cloudflare Pages build.
@@ -26,23 +32,53 @@ This roadmap tracks implementation milestones. Canonical behavior still lives in
 
 ## M3 Effects and Conditions
 
+Track A. Order: effect handlers first, then derived stacking, then prompts.
+
 - [x] Add built-in condition and persistent damage library. (Implemented in PR #31.)
-- [ ] Implement `APPLY_EFFECT`, `REMOVE_EFFECT`, value changes, and duration changes.
-- [ ] Implement implied effects and removal cascades.
-- [ ] Implement PF2e stacking derivation.
-- [ ] Implement turn-boundary prompt generation.
+- [ ] Implement `APPLY_EFFECT`, `REMOVE_EFFECT`, value changes, and duration changes. (Issue #10. Unblocks #11, #12, and the conditions UI in #45.)
+- [ ] Implement implied effects and removal cascades. (Issue #10.)
+- [ ] Implement PF2e stacking derivation. (Issue #11. Depends on #10.)
+- [ ] Implement turn-boundary prompt generation. (Issue #12. Depends on #10 and #11.)
 
 ## M4 Persistence and Import
 
-- [ ] Add IndexedDB persistence for active encounter state.
-- [ ] Add YAML envelope import/export.
-- [ ] Add creature import validation.
-- [ ] Add settings storage for user-owned parser API keys.
+Track C. Order: encounter persistence first so other persistence work can reuse the storage helper.
+
+- [ ] Add IndexedDB persistence for active encounter state. (Issue #13.)
+- [ ] Add YAML envelope import/export. (Issue #14.)
+- [ ] Add creature import validation. (Issue #14 covers schema; per-document validation is part of that slice.)
+- [ ] Add settings storage for user-owned parser API keys. (Issue #47. Depends on #13.)
+- [ ] Replace hardcoded creature library with import-driven storage. (Issue #48. Depends on #14.)
 
 ## M5 Combat UI
 
-- [ ] Build tablet-first combat screen.
-- [ ] Add combatant cards with HP, initiative, conditions, and notes.
-- [ ] Add prompt resolution panel.
-- [ ] Add append-only combat log.
-- [ ] Add manual static Cloudflare Pages deployment verification.
+Track B. Slice numbering follows the umbrella issues #15 (combat screen) and #16 (prompt panel + log).
+
+- [x] Slice 1 — extract combatant UI into components. (Issue #28.)
+- [ ] Slice 3 — turn controls on combatant cards. (Issue #38.)
+- [ ] Slice 4 — combatant notes UI. (Issue #40.)
+- [ ] Slice 5 — per-card HP delta controls. (Issue #39.)
+- [ ] Slice 6 — dead/unconscious visual state. (Issue #43.)
+- [ ] Slice 7 — tablet-first responsive layout pass. (Issue #44.)
+- [ ] Slice 8 — append-only combat log component. (Issue #41.)
+- [ ] Slice 9 — prompt resolution panel. (Issue #46. Depends on #12.)
+- [ ] Slice 10 — conditions UI on combatant cards. (Issue #45. Depends on #10.)
+- [ ] Manual static Cloudflare Pages deployment verification.
+
+## M6 Spellcasting (deferred)
+
+Tracking only. Captured in issue #49. Domain commands are stubbed in `src/domain/types.ts` but not wired in `applyCommand`.
+
+- [ ] Wire `USE_SPELL_SLOT`, `RESTORE_SPELL_SLOT`, `SET_SPELL_SLOT_USAGE`, and `RESET_SPELL_BLOCK`.
+- [ ] Wire `USE_FOCUS_POINT`, `RESTORE_FOCUS_POINT`, `SET_FOCUS_USAGE`.
+- [ ] Wire `USE_INNATE_SPELL`, `RESTORE_INNATE_SPELL`, `SET_INNATE_USAGE`.
+- [ ] Add spellcasting block UI on combatant cards.
+
+## Deferred milestones
+
+Specs are authoritative; tracking issues hold scope so the work is not lost. None of these are in the active backlog filter.
+
+- **Hazards** — issue #50, spec `pf2e-hazards-spec.md`. Hazards as initiative participants with reactions, triggers, and disables.
+- **Afflictions** — issue #51, spec `pf2e-afflictions-spec.md`. Poison/disease/curse staging, saves, and turn-boundary prompts.
+- **Party members** — issue #52, spec `pf2e-party-members-spec.md`. PCs as first-class persisted entities, not ad-hoc combatants.
+- **Creature types** — spec `pf2e-creature-types-spec.md`. Folds into #48 once the import-driven creature library lands.


### PR DESCRIPTION
## Summary
- Reorganize the active backlog into three parallel tracks (Track A close M3, Track B combat UI slices, Track C persistence & import) with explicit dependency edges between issues.
- Tick the M3 effect library bullet that landed in PR #31, expand M5 to match the slice numbering already used in issues #15 and #16, split M4 into per-issue bullets, and capture spellcasting / hazards / afflictions / party-members as deferred sections so the specs do not drift.
- Cross-link existing issues (#10, #15, #16, #38, #39, #40, #41) and open ten new issues (#43-#52) that previously had no tracking — UI slices for dead/unconscious visuals, tablet layout, conditions UI, prompt panel, plus persistence sub-tasks and deferred-milestone tracking issues.

## Suggested next-up sequence (one per PR)
`#10 -> #38 -> #13 -> #11 -> #39 -> #41 -> #40 -> #45 -> #12 -> #46 -> #14 -> #47 -> #48 -> #15 polish slices`

## Test plan
- [ ] `npm run check`
- [ ] `npm run test:run`
- [ ] `npm run audit`
- [ ] `npm run build`
- [ ] `gh issue list --state open` — confirm every roadmap bullet is either closed, has an issue, or is explicitly deferred.

Docs-only change; no runtime code paths or dependencies are touched.