### PR TITLE
Slice 6: Dead/unconscious visual state on cards

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { CombatantState, EncounterState } from '../domain';
-  import type { CombatantCardActionAvailability } from '$lib/encounter-app';
+  import { combatantVisualState, type CombatantCardActionAvailability } from '$lib/encounter-app';
 
   export let combatant: CombatantState;
   export let isCurrent: boolean;
@@ -25,6 +25,8 @@
     0,
     Math.min(100, (combatant.currentHp / combatant.baseStats.hp) * 100)
   );
+
+  $: visualState = combatantVisualState(combatant);
 
   $: endTurnTitle = actions.canEndTurn
     ? 'End this combatant’s turn'
@@ -53,7 +55,12 @@
       : 'Revive is unavailable in this phase';
 </script>
 
-<article class:current-card={isCurrent} class="combatant-card">
+<article
+  class:current-card={isCurrent}
+  class:dimmed={visualState !== 'alive'}
+  data-visual-state={visualState}
+  class="combatant-card"
+>
   <div class="card-heading">
     <div>
       <div class="card-title">
@@ -61,8 +68,10 @@
         {#if combatant.templateAdjustment}
           <span class="template-badge {combatant.templateAdjustment}">{templateLabel(combatant.templateAdjustment)}</span>
         {/if}
-        {#if !combatant.isAlive}
+        {#if visualState === 'dead'}
           <span class="status-badge dead" aria-label="Combatant is dead">Dead</span>
+        {:else if visualState === 'unconscious'}
+          <span class="status-badge unconscious" aria-label="Combatant is unconscious">Unconscious</span>
         {/if}
       </div>
       <p>AC {combatant.baseStats.ac} · Fort +{combatant.baseStats.fortitude} · Ref +{combatant.baseStats.reflex} · Will +{combatant.baseStats.will}</p>
@@ -215,6 +224,20 @@
   .status-badge.dead {
     background: #f4d7d7;
     color: #7a1f1f;
+  }
+
+  .status-badge.unconscious {
+    background: #f4ead7;
+    color: #7a5a1f;
+  }
+
+  .combatant-card.dimmed {
+    background: #f1f2ef;
+    opacity: 0.72;
+  }
+
+  .combatant-card.dimmed .hp-fill {
+    background: #8a9a92;
   }
 
   .hp-row {

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   combatantCardActions,
+  combatantVisualState,
   dispatchEncounterCommand,
   makeCombatant,
   makeCreatureCombatant,
@@ -226,6 +227,57 @@ describe('combatantCardActions', () => {
       canMarkDead: false,
       canRevive: false
     });
+  });
+});
+
+describe('combatantVisualState', () => {
+  test('returns "alive" for a living combatant above 0 HP', () => {
+    const state = stateWithTwoCombatants();
+
+    expect(combatantVisualState(state.combatants['goblin-1'])).toBe('alive');
+  });
+
+  test('returns "unconscious" when a living combatant is at 0 HP', () => {
+    const state = stateWithTwoCombatants();
+    const downed = dispatchEncounterCommand(
+      state,
+      [],
+      toCommand('APPLY_DAMAGE', { combatantId: 'goblin-1', amount: 999 }, 'cmd-down')
+    );
+
+    expect(downed.state.combatants['goblin-1'].currentHp).toBe(0);
+    expect(downed.state.combatants['goblin-1'].isAlive).toBe(true);
+    expect(combatantVisualState(downed.state.combatants['goblin-1'])).toBe('unconscious');
+  });
+
+  test('returns "dead" once the combatant is marked dead, regardless of HP', () => {
+    const state = stateWithTwoCombatants();
+    const killed = dispatchEncounterCommand(
+      state,
+      [],
+      toCommand('MARK_DEAD', { combatantId: 'goblin-1' }, 'cmd-kill')
+    );
+
+    expect(killed.state.combatants['goblin-1'].isAlive).toBe(false);
+    expect(combatantVisualState(killed.state.combatants['goblin-1'])).toBe('dead');
+  });
+
+  test('reviving a dead combatant restores the "alive" visual state', () => {
+    const state = stateWithTwoCombatants();
+    const killed = dispatchEncounterCommand(
+      state,
+      [],
+      toCommand('MARK_DEAD', { combatantId: 'goblin-1' }, 'cmd-kill')
+    );
+    const revived = dispatchEncounterCommand(
+      killed.state,
+      killed.feedback,
+      toCommand('REVIVE', { combatantId: 'goblin-1' }, 'cmd-revive')
+    );
+
+    expect(revived.state.combatants['goblin-1'].isAlive).toBe(true);
+    expect(revived.state.combatants['goblin-1'].currentHp).toBeGreaterThan(0);
+    expect(combatantVisualState(revived.state.combatants['goblin-1'])).toBe('alive');
   });
 });
 

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -117,6 +117,14 @@ export function currentCombatant(state: EncounterState): CombatantState | undefi
   return currentId ? state.combatants[currentId] : undefined;
 }
 
+export type CombatantVisualState = 'alive' | 'unconscious' | 'dead';
+
+export function combatantVisualState(combatant: CombatantState): CombatantVisualState {
+  if (!combatant.isAlive) return 'dead';
+  if (combatant.currentHp === 0) return 'unconscious';
+  return 'alive';
+}
+
 export interface CombatantCardActionAvailability {
   canEndTurn: boolean;
   canMarkReactionUsed: boolean;


### PR DESCRIPTION
## Summary
- Adds a `combatantVisualState(combatant)` selector in `src/lib/encounter-app.ts` returning `'alive' | 'unconscious' | 'dead'`. Pure derivation: `dead` when `!isAlive`, else `unconscious` at 0 HP, else `alive`.
- Wires `CombatantCard.svelte` to dim the card and render an `Unconscious` badge alongside the existing `Dead` badge based on the selector.
- Adds focused tests covering alive / 0 HP / dead / revived transitions through the orchestrator.

No domain changes — `MARK_DEAD`, `REVIVE`, and `APPLY_DAMAGE` were already wired. The reducer's existing REVIVE semantics (flips `isAlive` only, does not restore HP) are preserved, so reviving a combatant killed at 0 HP correctly transitions to "Unconscious" rather than "Alive".

Closes #43.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run test:run` — 76/76 passing (4 new selector tests)
- [x] `npm run audit` — same low-severity baseline as master
- [x] `npm run build` — static build succeeds
- [x] Manual UI: add Goblin (alive, no badge) → Set 0 HP (dimmed + Unconscious badge) → Mark Dead (dimmed + Dead badge) → Revive (transitions back to Unconscious because HP still 0) → Heal (returns to alive, no badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)