### PR TITLE
Add stat derivation

### DIFF
--- a/pf2e-conditions-library-spec.md
+++ b/pf2e-conditions-library-spec.md
@@ -49,7 +49,7 @@ Conditions gated on ability scores (Clumsy → Dex, Enfeebled → Str, Stupefied
 | `chaSkills` | Deception, Diplomacy, Intimidation, Performance |
 | `mentalSkills` | All of intSkills + wisSkills + chaSkills |
 
-Lore skills are excluded — they have no combat relevance. They are stored and displayed but never targeted by ability-gated modifiers.
+Lore skills are excluded from ability-score meta-targets. They are stored and displayed, and `allSkills` still targets them when a condition affects every skill the creature actually has.
 
 These are added to the `StatTarget` type:
 
@@ -88,8 +88,8 @@ Each condition entry specifies:
 - **description**: rules text for GM reference — especially important when modifiers can't capture the full effect
 
 Modifier `value` field uses:
-- `"-effectValue"` → resolves to negative of the condition's current value (penalty)
-- `"effectValue"` → resolves to the condition's current value (bonus)
+- `{ kind: "effectValue", sign: -1 }` → resolves to negative of the condition's current value (penalty)
+- `{ kind: "effectValue", sign: 1 }` → resolves to the condition's current value (bonus)
 - A literal number for fixed modifiers (e.g., Off-Guard is always -2)
 
 ---
@@ -108,12 +108,12 @@ Status penalty equal to value on **all** checks and DCs.
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "ac",           bonusType: "status", value: "-effectValue" },
-    { stat: "allSaves",     bonusType: "status", value: "-effectValue" },
-    { stat: "perception",   bonusType: "status", value: "-effectValue" },
-    { stat: "attackRolls",  bonusType: "status", value: "-effectValue" },
-    { stat: "allSkills",    bonusType: "status", value: "-effectValue" },
-    { stat: "allDCs",       bonusType: "status", value: "-effectValue" },
+    { stat: "ac",           bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allSaves",     bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "perception",   bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "attackRolls",  bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allSkills",    bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allDCs",       bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   turnEndSuggestion: { type: "suggestDecrement", amount: 1 },
   description: "Decreases by 1 at end of your turn.",
@@ -132,12 +132,12 @@ Status penalty equal to value on **all** checks and DCs. Persists until removed.
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "ac",           bonusType: "status", value: "-effectValue" },
-    { stat: "allSaves",     bonusType: "status", value: "-effectValue" },
-    { stat: "perception",   bonusType: "status", value: "-effectValue" },
-    { stat: "attackRolls",  bonusType: "status", value: "-effectValue" },
-    { stat: "allSkills",    bonusType: "status", value: "-effectValue" },
-    { stat: "allDCs",       bonusType: "status", value: "-effectValue" },
+    { stat: "ac",           bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allSaves",     bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "perception",   bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "attackRolls",  bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allSkills",    bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "allDCs",       bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   description: "Can spend an action to retch (Fortitude save vs source DC to reduce by 1, or 0 on critical success). Can't willingly ingest anything.",
 }
@@ -157,9 +157,9 @@ Status penalty equal to value on Dexterity-based checks and DCs.
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "ac",        bonusType: "status", value: "-effectValue" },
-    { stat: "reflex",    bonusType: "status", value: "-effectValue" },
-    { stat: "dexSkills", bonusType: "status", value: "-effectValue" },
+    { stat: "ac",        bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "reflex",    bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "dexSkills", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   description: "Also applies to Dex-based attack rolls (not automated — creature attacks don't tag their ability).",
 }
@@ -177,7 +177,7 @@ Status penalty equal to value on Strength-based checks and DCs, including melee 
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "strSkills", bonusType: "status", value: "-effectValue" },
+    { stat: "strSkills", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   description: "Also applies to Str-based melee attack rolls and damage rolls (not automated — creature attacks don't tag their ability).",
 }
@@ -197,8 +197,8 @@ Status penalty equal to value on mental checks, spell attack rolls, and spell DC
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "mentalSkills", bonusType: "status", value: "-effectValue" },
-    { stat: "will",         bonusType: "status", value: "-effectValue" },
+    { stat: "mentalSkills", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "will",         bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   description: "Also applies to spell attack rolls and spell DCs (not in stat model). When casting a spell, DC 5 + value flat check or spell is lost.",
 }
@@ -218,7 +218,7 @@ Status penalty equal to value on Constitution-based checks. Reduces max HP.
   hasValue: true,
   maxValue: 4,
   modifiers: [
-    { stat: "fortitude", bonusType: "status", value: "-effectValue" },
+    { stat: "fortitude", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
   description: "Reduces max HP by level × value (reduce current HP to new max if needed). Also applies to Con-based checks beyond Fortitude. Decreases by 1 after full night's rest.",
 }
@@ -813,12 +813,12 @@ The orchestrator's combat log formatter should produce human-readable entries th
 
 | Condition | Stat | Type | Value |
 |---|---|---|---|
-| Frightened | ac, allSaves, perception, attackRolls, allSkills, allDCs | status | -effectValue |
-| Sickened | ac, allSaves, perception, attackRolls, allSkills, allDCs | status | -effectValue |
-| Clumsy | ac, reflex, dexSkills | status | -effectValue |
-| Drained | fortitude | status | -effectValue |
-| Enfeebled | strSkills | status | -effectValue |
-| Stupefied | mentalSkills, will | status | -effectValue |
+| Frightened | ac, allSaves, perception, attackRolls, allSkills, allDCs | status | `{ kind: "effectValue", sign: -1 }` |
+| Sickened | ac, allSaves, perception, attackRolls, allSkills, allDCs | status | `{ kind: "effectValue", sign: -1 }` |
+| Clumsy | ac, reflex, dexSkills | status | `{ kind: "effectValue", sign: -1 }` |
+| Drained | fortitude | status | `{ kind: "effectValue", sign: -1 }` |
+| Enfeebled | strSkills | status | `{ kind: "effectValue", sign: -1 }` |
+| Stupefied | mentalSkills, will | status | `{ kind: "effectValue", sign: -1 }` |
 | Off-Guard | ac | circumstance | -2 |
 | Blinded | perception | status | -4 |
 | Prone | attackRolls | circumstance | -2 |

--- a/pf2e-conditions-library-spec.md
+++ b/pf2e-conditions-library-spec.md
@@ -44,7 +44,7 @@ Conditions gated on ability scores (Clumsy → Dex, Enfeebled → Str, Stupefied
 |---|---|
 | `strSkills` | Athletics |
 | `dexSkills` | Acrobatics, Stealth, Thievery |
-| `intSkills` | Arcana, Crafting, Society |
+| `intSkills` | Arcana, Crafting, Occultism, Society |
 | `wisSkills` | Medicine, Nature, Religion, Survival |
 | `chaSkills` | Deception, Diplomacy, Intimidation, Performance |
 | `mentalSkills` | All of intSkills + wisSkills + chaSkills |
@@ -183,7 +183,7 @@ Status penalty equal to value on Strength-based checks and DCs, including melee 
 }
 ```
 
-No automated modifiers — can't distinguish Str-based vs Dex-based attacks from statblock data.
+No automated attack or damage modifiers — can't distinguish Str-based vs Dex-based attacks from statblock data.
 
 #### Stupefied (1–4)
 
@@ -204,7 +204,7 @@ Status penalty equal to value on mental checks, spell attack rolls, and spell DC
 }
 ```
 
-No automated modifiers — can't identify mental skills or spell stats from creature data.
+No automated spell attack or spell DC modifiers — those spell stats are outside the current combatant stat model.
 
 #### Drained (1–4)
 

--- a/pf2e-tracker-v2-architecture-spec.md
+++ b/pf2e-tracker-v2-architecture-spec.md
@@ -311,10 +311,12 @@ This function is stateless, has no side effects, and is called on every render. 
 ### 9.2 Modifier Shape
 
 ```typescript
+type ModifierValue = number | { kind: "effectValue"; sign: 1 | -1 }
+
 interface Modifier {
   stat: StatTarget
   bonusType: BonusType
-  value: number | "effectValue" | "-effectValue"
+  value: ModifierValue
 }
 
 type BonusType = "status" | "circumstance" | "item" | "untyped"
@@ -329,9 +331,9 @@ type StatTarget =
   | string    // specific skill: "athletics", "stealth", etc.
 ```
 
-`"effectValue"` resolves to the current value of the parent `AppliedEffect`. Frightened 2 with modifier `{ stat: "attackRolls", bonusType: "status", value: "-effectValue" }` resolves to a -2 status penalty to attack rolls.
+`{ kind: "effectValue", sign: 1 }` resolves to the current value of the parent `AppliedEffect`; `sign: -1` resolves to the negative of that value. Frightened 2 with modifier `{ stat: "attackRolls", bonusType: "status", value: { kind: "effectValue", sign: -1 } }` resolves to a -2 status penalty to attack rolls.
 
-**"All" variant expansion:** `allSaves` expands to `[fortitude, reflex, will]`. `allSkills` expands against the creature's actual skill list (creature-dependent). Both explicit targets and "all" variants are supported — explicit takes precedence if both exist.
+**"All" variant expansion:** `allSaves` expands to `[fortitude, reflex, will]`. `allSkills` expands against the creature's actual skill list (creature-dependent). Both explicit targets and "all" variants are supported; expanded and explicit modifiers are collected together, then PF2e stacking decides which same-type value remains active.
 
 ### 9.3 PF2e Stacking Rules
 
@@ -355,9 +357,9 @@ interface ComputedStats {
   reflex: { final: number; base: number; modifiers: AppliedModifier[] }
   will: { final: number; base: number; modifiers: AppliedModifier[] }
   perception: { final: number; base: number; modifiers: AppliedModifier[] }
-  attackRolls: { final: number; base: number; modifiers: AppliedModifier[] }
+  attackRolls: { total: number; modifiers: AppliedModifier[] }
+  allDCs: { total: number; modifiers: AppliedModifier[] }
   skills: Record<string, { final: number; base: number; modifiers: AppliedModifier[] }>
-  // ... other derivable stats
 }
 
 interface AppliedModifier {

--- a/src/domain/effects/derivation.test.ts
+++ b/src/domain/effects/derivation.test.ts
@@ -39,13 +39,6 @@ function applied(effectId: string, value?: number, instanceId = `${effectId}-${v
 }
 
 const customLibrary: EffectLibrary = {
-  statusBoost: {
-    id: 'statusBoost',
-    name: 'Status Boost',
-    category: 'custom',
-    hasValue: false,
-    modifiers: [{ stat: 'ac', bonusType: 'status', value: 1 }]
-  },
   lowerStatusBoost: {
     id: 'lowerStatusBoost',
     name: 'Lower Status Boost',
@@ -124,9 +117,23 @@ const customLibrary: EffectLibrary = {
     category: 'custom',
     hasValue: true,
     modifiers: [
-      { stat: 'attackRolls', bonusType: 'status', value: 'effectValue' },
-      { stat: 'allDCs', bonusType: 'status', value: '-effectValue' }
+      { stat: 'attackRolls', bonusType: 'status', value: { kind: 'effectValue', sign: 1 } },
+      { stat: 'allDCs', bonusType: 'status', value: { kind: 'effectValue', sign: -1 } }
     ]
+  },
+  stealthStatusPenalty: {
+    id: 'stealthStatusPenalty',
+    name: 'Stealth Status Penalty',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'stealth', bonusType: 'status', value: -1 }]
+  },
+  savePenalty: {
+    id: 'savePenalty',
+    name: 'Save Penalty',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'allSaves', bonusType: 'circumstance', value: -2 }]
   }
 };
 
@@ -258,5 +265,61 @@ describe('deriveStats', () => {
       total: -3,
       modifiers: [expect.objectContaining({ effectId: 'valuePenalty', value: -3, suppressed: false })]
     });
+  });
+
+  test('defaults missing value effects to 1 in resolved values and source names', () => {
+    const computed = deriveStats(baseStats, [applied('valuePenalty')], customLibrary);
+
+    expect(computed.attackRolls).toEqual({
+      total: 1,
+      modifiers: [
+        expect.objectContaining({
+          effectId: 'valuePenalty',
+          sourceName: 'Value Penalty 1',
+          value: 1,
+          suppressed: false
+        })
+      ]
+    });
+    expect(computed.allDCs).toEqual({
+      total: -1,
+      modifiers: [
+        expect.objectContaining({
+          effectId: 'valuePenalty',
+          sourceName: 'Value Penalty 1',
+          value: -1,
+          suppressed: false
+        })
+      ]
+    });
+  });
+
+  test('suppresses exactly one lower same-type stealth modifier from explicit and ability meta-targets', () => {
+    const computed = deriveStats(baseStats, [applied('stealthStatusPenalty'), applied('abilityMetaPenalty')], customLibrary);
+
+    expect(computed.skills.stealth.final).toBe(9);
+    expect(computed.skills.stealth.modifiers).toEqual([
+      expect.objectContaining({ effectId: 'stealthStatusPenalty', value: -1, suppressed: true }),
+      expect.objectContaining({ effectId: 'abilityMetaPenalty', value: -2, suppressed: false })
+    ]);
+    expect(computed.skills.stealth.modifiers.filter((modifier) => modifier.suppressed)).toHaveLength(1);
+  });
+
+  test('applies standalone Fascinated to all actual creature skills', () => {
+    const computed = deriveStats(baseStats, [applied('fascinated')], effectLibrary);
+
+    expect(computed.perception.final).toBe(4);
+    expect(computed.skills.stealth.final).toBe(9);
+    expect(computed.skills.warfareLore.final).toBe(10);
+    expect(Object.keys(computed.skills)).toHaveLength(Object.keys(baseStats.skills).length);
+  });
+
+  test('applies standalone custom allSaves modifier to all saves', () => {
+    const computed = deriveStats(baseStats, [applied('savePenalty')], customLibrary);
+
+    expect(computed.fortitude.final).toBe(7);
+    expect(computed.reflex.final).toBe(6);
+    expect(computed.will.final).toBe(5);
+    expect(computed.ac.final).toBe(18);
   });
 });

--- a/src/domain/effects/derivation.test.ts
+++ b/src/domain/effects/derivation.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'vitest';
+import { deriveStats } from './derivation';
+import { effectLibrary } from './library';
+import type { AppliedEffect, CreatureBaseStats, EffectLibrary } from '../types';
+
+const baseStats: CreatureBaseStats = {
+  hp: 20,
+  ac: 18,
+  fortitude: 9,
+  reflex: 8,
+  will: 7,
+  perception: 6,
+  speed: 25,
+  skills: {
+    acrobatics: 8,
+    arcana: 5,
+    athletics: 10,
+    crafting: 4,
+    deception: 3,
+    diplomacy: 2,
+    intimidation: 6,
+    medicine: 7,
+    nature: 5,
+    occultism: 9,
+    performance: 1,
+    religion: 6,
+    society: 4,
+    stealth: 11,
+    survival: 8,
+    thievery: 7,
+    warfareLore: 12
+  }
+};
+
+const defaultDuration = { type: 'unlimited' } as const;
+
+function applied(effectId: string, value?: number, instanceId = `${effectId}-${value ?? 'base'}`): AppliedEffect {
+  return { instanceId, effectId, value, duration: defaultDuration };
+}
+
+const customLibrary: EffectLibrary = {
+  statusBoost: {
+    id: 'statusBoost',
+    name: 'Status Boost',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'status', value: 1 }]
+  },
+  lowerStatusBoost: {
+    id: 'lowerStatusBoost',
+    name: 'Lower Status Boost',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'status', value: 1 }]
+  },
+  higherStatusBoost: {
+    id: 'higherStatusBoost',
+    name: 'Higher Status Boost',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'status', value: 3 }]
+  },
+  untypedPenaltyA: {
+    id: 'untypedPenaltyA',
+    name: 'Untyped Penalty A',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'untyped', value: -1 }]
+  },
+  untypedPenaltyB: {
+    id: 'untypedPenaltyB',
+    name: 'Untyped Penalty B',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'untyped', value: -2 }]
+  },
+  lowerUntypedBoost: {
+    id: 'lowerUntypedBoost',
+    name: 'Lower Untyped Boost',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'untyped', value: 1 }]
+  },
+  higherUntypedBoost: {
+    id: 'higherUntypedBoost',
+    name: 'Higher Untyped Boost',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'ac', bonusType: 'untyped', value: 2 }]
+  },
+  allMetaPenalty: {
+    id: 'allMetaPenalty',
+    name: 'All Meta Penalty',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [
+      { stat: 'allSaves', bonusType: 'circumstance', value: -1 },
+      { stat: 'allSkills', bonusType: 'circumstance', value: -1 }
+    ]
+  },
+  abilityMetaPenalty: {
+    id: 'abilityMetaPenalty',
+    name: 'Ability Meta Penalty',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [
+      { stat: 'strSkills', bonusType: 'status', value: -1 },
+      { stat: 'dexSkills', bonusType: 'status', value: -2 },
+      { stat: 'intSkills', bonusType: 'item', value: -3 },
+      { stat: 'wisSkills', bonusType: 'untyped', value: -4 },
+      { stat: 'chaSkills', bonusType: 'circumstance', value: -5 }
+    ]
+  },
+  mentalPenalty: {
+    id: 'mentalPenalty',
+    name: 'Mental Penalty',
+    category: 'custom',
+    hasValue: false,
+    modifiers: [{ stat: 'mentalSkills', bonusType: 'status', value: -1 }]
+  },
+  valuePenalty: {
+    id: 'valuePenalty',
+    name: 'Value Penalty',
+    category: 'custom',
+    hasValue: true,
+    modifiers: [
+      { stat: 'attackRolls', bonusType: 'status', value: 'effectValue' },
+      { stat: 'allDCs', bonusType: 'status', value: '-effectValue' }
+    ]
+  }
+};
+
+describe('deriveStats', () => {
+  test('returns base values unchanged when no effects apply and ignores unknown effects', () => {
+    const computed = deriveStats(baseStats, [applied('missing-effect')], effectLibrary);
+
+    expect(computed.ac).toEqual({ base: 18, final: 18, modifiers: [] });
+    expect(computed.fortitude).toEqual({ base: 9, final: 9, modifiers: [] });
+    expect(computed.reflex).toEqual({ base: 8, final: 8, modifiers: [] });
+    expect(computed.will).toEqual({ base: 7, final: 7, modifiers: [] });
+    expect(computed.perception).toEqual({ base: 6, final: 6, modifiers: [] });
+    expect(computed.skills.stealth).toEqual({ base: 11, final: 11, modifiers: [] });
+    expect(computed.attackRolls).toEqual({ total: 0, modifiers: [] });
+    expect(computed.allDCs).toEqual({ total: 0, modifiers: [] });
+  });
+
+  test('keeps only the worse same-type status penalty from Frightened and Sickened', () => {
+    const computed = deriveStats(baseStats, [applied('frightened', 1), applied('sickened', 2)], effectLibrary);
+
+    expect(computed.ac.final).toBe(16);
+    expect(computed.ac.modifiers).toEqual([
+      expect.objectContaining({ effectId: 'frightened', value: -1, suppressed: true }),
+      expect.objectContaining({ effectId: 'sickened', value: -2, suppressed: false })
+    ]);
+  });
+
+  test('stacks Frightened status penalty and Off-Guard circumstance penalty on AC', () => {
+    const computed = deriveStats(baseStats, [applied('frightened', 1), applied('off-guard')], effectLibrary);
+
+    expect(computed.ac.final).toBe(15);
+    expect(computed.ac.modifiers).toEqual([
+      expect.objectContaining({ effectId: 'frightened', bonusType: 'status', value: -1, suppressed: false }),
+      expect.objectContaining({ effectId: 'off-guard', bonusType: 'circumstance', value: -2, suppressed: false })
+    ]);
+  });
+
+  test('suppresses the lower duplicate Frightened value', () => {
+    const computed = deriveStats(baseStats, [applied('frightened', 1, 'frightened-low'), applied('frightened', 3, 'frightened-high')], effectLibrary);
+
+    expect(computed.will.final).toBe(4);
+    expect(computed.will.modifiers).toEqual([
+      expect.objectContaining({ instanceId: 'frightened-low', value: -1, suppressed: true }),
+      expect.objectContaining({ instanceId: 'frightened-high', value: -3, suppressed: false })
+    ]);
+  });
+
+  test('stacks all untyped penalties and suppresses lower untyped bonuses', () => {
+    const computed = deriveStats(
+      baseStats,
+      [
+        applied('untypedPenaltyA'),
+        applied('untypedPenaltyB'),
+        applied('lowerUntypedBoost'),
+        applied('higherUntypedBoost')
+      ],
+      customLibrary
+    );
+
+    expect(computed.ac.final).toBe(17);
+    expect(computed.ac.modifiers).toEqual([
+      expect.objectContaining({ effectId: 'untypedPenaltyA', value: -1, suppressed: false }),
+      expect.objectContaining({ effectId: 'untypedPenaltyB', value: -2, suppressed: false }),
+      expect.objectContaining({ effectId: 'lowerUntypedBoost', value: 1, suppressed: true }),
+      expect.objectContaining({ effectId: 'higherUntypedBoost', value: 2, suppressed: false })
+    ]);
+  });
+
+  test('suppresses lower same-type bonuses while keeping same-type penalties', () => {
+    const computed = deriveStats(
+      baseStats,
+      [applied('lowerStatusBoost'), applied('higherStatusBoost'), applied('frightened', 1)],
+      { ...customLibrary, frightened: effectLibrary.frightened }
+    );
+
+    expect(computed.ac.final).toBe(20);
+    expect(computed.ac.modifiers).toEqual([
+      expect.objectContaining({ effectId: 'lowerStatusBoost', value: 1, suppressed: true }),
+      expect.objectContaining({ effectId: 'higherStatusBoost', value: 3, suppressed: false }),
+      expect.objectContaining({ effectId: 'frightened', value: -1, suppressed: false })
+    ]);
+  });
+
+  test('expands save, skill, ability, and mental skill meta-targets against existing skills only', () => {
+    const allComputed = deriveStats(baseStats, [applied('allMetaPenalty')], customLibrary);
+    const abilityComputed = deriveStats(baseStats, [applied('abilityMetaPenalty')], customLibrary);
+    const mentalComputed = deriveStats(baseStats, [applied('mentalPenalty')], customLibrary);
+
+    expect(allComputed.fortitude.final).toBe(8);
+    expect(allComputed.reflex.final).toBe(7);
+    expect(allComputed.will.final).toBe(6);
+    expect(allComputed.skills.stealth.final).toBe(10);
+    expect(allComputed.skills.warfareLore.final).toBe(11);
+
+    expect(abilityComputed.skills.athletics.final).toBe(9);
+    expect(abilityComputed.skills.acrobatics.final).toBe(6);
+    expect(abilityComputed.skills.stealth.final).toBe(9);
+    expect(abilityComputed.skills.thievery.final).toBe(5);
+    expect(abilityComputed.skills.arcana.final).toBe(2);
+    expect(abilityComputed.skills.crafting.final).toBe(1);
+    expect(abilityComputed.skills.occultism.final).toBe(6);
+    expect(abilityComputed.skills.society.final).toBe(1);
+    expect(abilityComputed.skills.medicine.final).toBe(3);
+    expect(abilityComputed.skills.nature.final).toBe(1);
+    expect(abilityComputed.skills.religion.final).toBe(2);
+    expect(abilityComputed.skills.survival.final).toBe(4);
+    expect(abilityComputed.skills.deception.final).toBe(-2);
+    expect(abilityComputed.skills.diplomacy.final).toBe(-3);
+    expect(abilityComputed.skills.intimidation.final).toBe(1);
+    expect(abilityComputed.skills.performance.final).toBe(-4);
+    expect(abilityComputed.skills.warfareLore.final).toBe(12);
+
+    expect(mentalComputed.skills.arcana.final).toBe(4);
+    expect(mentalComputed.skills.occultism.final).toBe(8);
+    expect(mentalComputed.skills.survival.final).toBe(7);
+    expect(mentalComputed.skills.intimidation.final).toBe(5);
+    expect(mentalComputed.skills.athletics.final).toBe(10);
+    expect(mentalComputed.skills.warfareLore.final).toBe(12);
+  });
+
+  test('resolves effectValue and negative effectValue from AppliedEffect value for bucket stats', () => {
+    const computed = deriveStats(baseStats, [applied('valuePenalty', 3)], customLibrary);
+
+    expect(computed.attackRolls).toEqual({
+      total: 3,
+      modifiers: [expect.objectContaining({ effectId: 'valuePenalty', value: 3, suppressed: false })]
+    });
+    expect(computed.allDCs).toEqual({
+      total: -3,
+      modifiers: [expect.objectContaining({ effectId: 'valuePenalty', value: -3, suppressed: false })]
+    });
+  });
+});

--- a/src/domain/effects/derivation.ts
+++ b/src/domain/effects/derivation.ts
@@ -129,14 +129,14 @@ function applyStacking(modifiers: AppliedModifier[]): AppliedModifier[] {
     const bonuses = typedModifiers.filter((modifier) => modifier.value > 0);
     const penalties = typedModifiers.filter((modifier) => modifier.value < 0);
 
-    keepStrongest(bonuses, active);
+    keepSelected(bonuses, active, (modifier, selected) => modifier.value > selected.value);
 
     if (bonusType === 'untyped') {
       for (const penalty of penalties) {
         active.add(penalty);
       }
     } else {
-      keepWorstPenalty(penalties, active);
+      keepSelected(penalties, active, (modifier, selected) => modifier.value < selected.value);
     }
 
     for (const zero of typedModifiers.filter((modifier) => modifier.value === 0)) {
@@ -151,25 +151,18 @@ function uniqueBonusTypes(modifiers: AppliedModifier[]): BonusType[] {
   return Array.from(new Set(modifiers.map((modifier) => modifier.bonusType)));
 }
 
-function keepStrongest(modifiers: AppliedModifier[], active: Set<AppliedModifier>): void {
-  const strongest = modifiers.reduce<AppliedModifier | undefined>(
-    (current, modifier) => (!current || modifier.value > current.value ? modifier : current),
+function keepSelected(
+  modifiers: AppliedModifier[],
+  active: Set<AppliedModifier>,
+  isBetterSelection: (modifier: AppliedModifier, selected: AppliedModifier) => boolean
+): void {
+  const selected = modifiers.reduce<AppliedModifier | undefined>(
+    (current, modifier) => (!current || isBetterSelection(modifier, current) ? modifier : current),
     undefined
   );
 
-  if (strongest) {
-    active.add(strongest);
-  }
-}
-
-function keepWorstPenalty(modifiers: AppliedModifier[], active: Set<AppliedModifier>): void {
-  const worst = modifiers.reduce<AppliedModifier | undefined>(
-    (current, modifier) => (!current || modifier.value < current.value ? modifier : current),
-    undefined
-  );
-
-  if (worst) {
-    active.add(worst);
+  if (selected) {
+    active.add(selected);
   }
 }
 
@@ -182,9 +175,11 @@ function resolveModifierValue(modifier: Modifier, appliedEffect: AppliedEffect):
     return modifier.value;
   }
 
-  const effectValue = appliedEffect.value ?? 1;
+  return modifier.value.sign * resolveAppliedEffectValue(appliedEffect);
+}
 
-  return modifier.value === 'effectValue' ? effectValue : -effectValue;
+function resolveAppliedEffectValue(appliedEffect: AppliedEffect): number {
+  return appliedEffect.value ?? 1;
 }
 
 function toAppliedModifier(
@@ -196,7 +191,7 @@ function toAppliedModifier(
   return {
     effectId: appliedEffect.effectId,
     instanceId: appliedEffect.instanceId,
-    sourceName: definition.hasValue ? `${definition.name} ${appliedEffect.value ?? 1}` : definition.name,
+    sourceName: definition.hasValue ? `${definition.name} ${resolveAppliedEffectValue(appliedEffect)}` : definition.name,
     bonusType,
     value,
     suppressed: false

--- a/src/domain/effects/derivation.ts
+++ b/src/domain/effects/derivation.ts
@@ -1,0 +1,265 @@
+import type {
+  AppliedEffect,
+  AppliedModifier,
+  BonusType,
+  ComputedModifierBucket,
+  ComputedStat,
+  ComputedStats,
+  CreatureBaseStats,
+  EffectDefinition,
+  EffectLibrary,
+  Modifier,
+  StatTarget
+} from '../types';
+
+type BaseStatKey = 'ac' | 'fortitude' | 'reflex' | 'will' | 'perception';
+type BucketKey = 'attackRolls' | 'allDCs';
+type ModifierTarget =
+  | { kind: 'base'; key: BaseStatKey }
+  | { kind: 'bucket'; key: BucketKey }
+  | { kind: 'skill'; key: string };
+
+const baseStatKeys: BaseStatKey[] = ['ac', 'fortitude', 'reflex', 'will', 'perception'];
+
+const skillMetaTargets: Record<'strSkills' | 'dexSkills' | 'intSkills' | 'wisSkills' | 'chaSkills', string[]> = {
+  strSkills: ['athletics'],
+  dexSkills: ['acrobatics', 'stealth', 'thievery'],
+  intSkills: ['arcana', 'crafting', 'occultism', 'society'],
+  wisSkills: ['medicine', 'nature', 'religion', 'survival'],
+  chaSkills: ['deception', 'diplomacy', 'intimidation', 'performance']
+};
+
+export function deriveStats(
+  baseStats: CreatureBaseStats,
+  appliedEffects: AppliedEffect[],
+  effectLibrary: EffectLibrary
+): ComputedStats {
+  const modifiersByTarget = collectModifiers(baseStats, appliedEffects, effectLibrary);
+
+  return {
+    ac: computeBaseStat(baseStats.ac, modifiersByTarget.ac),
+    fortitude: computeBaseStat(baseStats.fortitude, modifiersByTarget.fortitude),
+    reflex: computeBaseStat(baseStats.reflex, modifiersByTarget.reflex),
+    will: computeBaseStat(baseStats.will, modifiersByTarget.will),
+    perception: computeBaseStat(baseStats.perception, modifiersByTarget.perception),
+    skills: computeSkills(baseStats.skills, modifiersByTarget.skills),
+    attackRolls: computeBucket(modifiersByTarget.attackRolls),
+    allDCs: computeBucket(modifiersByTarget.allDCs)
+  };
+}
+
+function collectModifiers(
+  baseStats: CreatureBaseStats,
+  appliedEffects: AppliedEffect[],
+  effectLibrary: EffectLibrary
+): {
+  [K in BaseStatKey | BucketKey]: AppliedModifier[];
+} & { skills: Record<string, AppliedModifier[]> } {
+  const collected = {
+    ac: [],
+    fortitude: [],
+    reflex: [],
+    will: [],
+    perception: [],
+    attackRolls: [],
+    allDCs: [],
+    skills: Object.fromEntries(Object.keys(baseStats.skills).map((skill) => [skill, []]))
+  } as {
+    [K in BaseStatKey | BucketKey]: AppliedModifier[];
+  } & { skills: Record<string, AppliedModifier[]> };
+
+  for (const appliedEffect of appliedEffects) {
+    const definition = effectLibrary[appliedEffect.effectId];
+
+    if (!definition) {
+      continue;
+    }
+
+    for (const modifier of definition.modifiers) {
+      const value = resolveModifierValue(modifier, appliedEffect);
+
+      for (const target of expandTarget(modifier.stat, baseStats.skills)) {
+        const appliedModifier = toAppliedModifier(definition, appliedEffect, modifier.bonusType, value);
+
+        if (target.kind === 'skill') {
+          collected.skills[target.key].push(appliedModifier);
+        } else {
+          collected[target.key].push(appliedModifier);
+        }
+      }
+    }
+  }
+
+  return collected;
+}
+
+function computeBaseStat(base: number, modifiers: AppliedModifier[]): ComputedStat {
+  const stackedModifiers = applyStacking(modifiers);
+
+  return {
+    base,
+    final: base + sumActive(stackedModifiers),
+    modifiers: stackedModifiers
+  };
+}
+
+function computeBucket(modifiers: AppliedModifier[]): ComputedModifierBucket {
+  const stackedModifiers = applyStacking(modifiers);
+
+  return {
+    total: sumActive(stackedModifiers),
+    modifiers: stackedModifiers
+  };
+}
+
+function computeSkills(
+  skills: Record<string, number>,
+  modifiersBySkill: Record<string, AppliedModifier[]>
+): Record<string, ComputedStat> {
+  return Object.fromEntries(
+    Object.entries(skills).map(([skill, base]) => [skill, computeBaseStat(base, modifiersBySkill[skill] ?? [])])
+  );
+}
+
+function applyStacking(modifiers: AppliedModifier[]): AppliedModifier[] {
+  const active = new Set<AppliedModifier>();
+
+  for (const bonusType of uniqueBonusTypes(modifiers)) {
+    const typedModifiers = modifiers.filter((modifier) => modifier.bonusType === bonusType);
+    const bonuses = typedModifiers.filter((modifier) => modifier.value > 0);
+    const penalties = typedModifiers.filter((modifier) => modifier.value < 0);
+
+    keepStrongest(bonuses, active);
+
+    if (bonusType === 'untyped') {
+      for (const penalty of penalties) {
+        active.add(penalty);
+      }
+    } else {
+      keepWorstPenalty(penalties, active);
+    }
+
+    for (const zero of typedModifiers.filter((modifier) => modifier.value === 0)) {
+      active.add(zero);
+    }
+  }
+
+  return modifiers.map((modifier) => ({ ...modifier, suppressed: !active.has(modifier) }));
+}
+
+function uniqueBonusTypes(modifiers: AppliedModifier[]): BonusType[] {
+  return Array.from(new Set(modifiers.map((modifier) => modifier.bonusType)));
+}
+
+function keepStrongest(modifiers: AppliedModifier[], active: Set<AppliedModifier>): void {
+  const strongest = modifiers.reduce<AppliedModifier | undefined>(
+    (current, modifier) => (!current || modifier.value > current.value ? modifier : current),
+    undefined
+  );
+
+  if (strongest) {
+    active.add(strongest);
+  }
+}
+
+function keepWorstPenalty(modifiers: AppliedModifier[], active: Set<AppliedModifier>): void {
+  const worst = modifiers.reduce<AppliedModifier | undefined>(
+    (current, modifier) => (!current || modifier.value < current.value ? modifier : current),
+    undefined
+  );
+
+  if (worst) {
+    active.add(worst);
+  }
+}
+
+function sumActive(modifiers: AppliedModifier[]): number {
+  return modifiers.reduce((total, modifier) => total + (modifier.suppressed ? 0 : modifier.value), 0);
+}
+
+function resolveModifierValue(modifier: Modifier, appliedEffect: AppliedEffect): number {
+  if (typeof modifier.value === 'number') {
+    return modifier.value;
+  }
+
+  const effectValue = appliedEffect.value ?? 1;
+
+  return modifier.value === 'effectValue' ? effectValue : -effectValue;
+}
+
+function toAppliedModifier(
+  definition: EffectDefinition,
+  appliedEffect: AppliedEffect,
+  bonusType: BonusType,
+  value: number
+): AppliedModifier {
+  return {
+    effectId: appliedEffect.effectId,
+    instanceId: appliedEffect.instanceId,
+    sourceName: definition.hasValue ? `${definition.name} ${appliedEffect.value ?? 1}` : definition.name,
+    bonusType,
+    value,
+    suppressed: false
+  };
+}
+
+function expandTarget(stat: StatTarget, skills: Record<string, number>): ModifierTarget[] {
+  if (isBaseStatKey(stat)) {
+    return [{ kind: 'base', key: stat }];
+  }
+
+  if (isBucketKey(stat)) {
+    return [{ kind: 'bucket', key: stat }];
+  }
+
+  if (stat === 'allSaves') {
+    return [
+      { kind: 'base', key: 'fortitude' },
+      { kind: 'base', key: 'reflex' },
+      { kind: 'base', key: 'will' }
+    ];
+  }
+
+  if (stat === 'allSkills') {
+    return Object.keys(skills).map((skill) => ({ kind: 'skill', key: skill }));
+  }
+
+  if (stat === 'mentalSkills') {
+    return expandSkillNames(
+      [...skillMetaTargets.intSkills, ...skillMetaTargets.wisSkills, ...skillMetaTargets.chaSkills],
+      skills
+    );
+  }
+
+  if (isSkillMetaTarget(stat)) {
+    return expandSkillNames(skillMetaTargets[stat], skills);
+  }
+
+  return Object.prototype.hasOwnProperty.call(skills, stat) ? [{ kind: 'skill', key: stat }] : [];
+}
+
+function expandSkillNames(skillNames: string[], skills: Record<string, number>): ModifierTarget[] {
+  return skillNames
+    .filter((skill) => Object.prototype.hasOwnProperty.call(skills, skill))
+    .map((skill) => ({ kind: 'skill', key: skill }));
+}
+
+function isBaseStatKey(stat: StatTarget): stat is BaseStatKey {
+  return baseStatKeys.includes(stat as BaseStatKey);
+}
+
+function isBucketKey(stat: StatTarget): stat is BucketKey {
+  return stat === 'attackRolls' || stat === 'allDCs';
+}
+
+function isSkillMetaTarget(
+  stat: StatTarget
+): stat is 'strSkills' | 'dexSkills' | 'intSkills' | 'wisSkills' | 'chaSkills' {
+  return (
+    stat === 'strSkills' ||
+    stat === 'dexSkills' ||
+    stat === 'intSkills' ||
+    stat === 'wisSkills' ||
+    stat === 'chaSkills'
+  );
+}

--- a/src/domain/effects/library.test.ts
+++ b/src/domain/effects/library.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { effectLibrary } from './library';
-import type { BonusType, Modifier, StatTarget, TurnBoundarySuggestion } from '../types';
+import type { BonusType, Modifier, ModifierValue, StatTarget, TurnBoundarySuggestion } from '../types';
 
 const supportedBonusTypes = new Set<BonusType>(['status', 'circumstance', 'item', 'untyped']);
 
@@ -33,9 +33,14 @@ const supportedSuggestionTypes = new Set<TurnBoundarySuggestion['type']>([
 function expectModifierShape(modifier: Modifier): void {
   expect(supportedStatTargets.has(modifier.stat)).toBe(true);
   expect(supportedBonusTypes.has(modifier.bonusType)).toBe(true);
-  expect(
-    typeof modifier.value === 'number' || modifier.value === 'effectValue' || modifier.value === '-effectValue'
-  ).toBe(true);
+  expect(isSupportedModifierValue(modifier.value)).toBe(true);
+}
+
+function isSupportedModifierValue(value: ModifierValue): boolean {
+  return (
+    typeof value === 'number' ||
+    (value.kind === 'effectValue' && (value.sign === 1 || value.sign === -1))
+  );
 }
 
 function expectSuggestionShape(suggestion: TurnBoundarySuggestion): void {
@@ -103,7 +108,7 @@ describe('effectLibrary', () => {
     expect(effectLibrary.frightened.modifiers).toContainEqual({
       stat: 'attackRolls',
       bonusType: 'status',
-      value: '-effectValue'
+      value: { kind: 'effectValue', sign: -1 }
     });
 
     expect(effectLibrary['off-guard']).toMatchObject({

--- a/src/domain/effects/library.ts
+++ b/src/domain/effects/library.ts
@@ -1,13 +1,15 @@
 import type { EffectDefinition, EffectLibrary, Modifier } from '../types';
 
+const negativeEffectValue = { kind: 'effectValue', sign: -1 } as const;
+
 function allChecksAndDcsModifiers(): Modifier[] {
   return [
-    { stat: 'ac', bonusType: 'status', value: '-effectValue' },
-    { stat: 'allSaves', bonusType: 'status', value: '-effectValue' },
-    { stat: 'perception', bonusType: 'status', value: '-effectValue' },
-    { stat: 'attackRolls', bonusType: 'status', value: '-effectValue' },
-    { stat: 'allSkills', bonusType: 'status', value: '-effectValue' },
-    { stat: 'allDCs', bonusType: 'status', value: '-effectValue' }
+    { stat: 'ac', bonusType: 'status', value: negativeEffectValue },
+    { stat: 'allSaves', bonusType: 'status', value: negativeEffectValue },
+    { stat: 'perception', bonusType: 'status', value: negativeEffectValue },
+    { stat: 'attackRolls', bonusType: 'status', value: negativeEffectValue },
+    { stat: 'allSkills', bonusType: 'status', value: negativeEffectValue },
+    { stat: 'allDCs', bonusType: 'status', value: negativeEffectValue }
   ];
 }
 
@@ -56,9 +58,9 @@ export const effectLibrary: EffectLibrary = {
     hasValue: true,
     maxValue: 4,
     modifiers: [
-      { stat: 'ac', bonusType: 'status', value: '-effectValue' },
-      { stat: 'reflex', bonusType: 'status', value: '-effectValue' },
-      { stat: 'dexSkills', bonusType: 'status', value: '-effectValue' }
+      { stat: 'ac', bonusType: 'status', value: negativeEffectValue },
+      { stat: 'reflex', bonusType: 'status', value: negativeEffectValue },
+      { stat: 'dexSkills', bonusType: 'status', value: negativeEffectValue }
     ],
     description: "Also applies to Dex-based attack rolls, which are not automated because creature attacks don't tag ability."
   }),
@@ -67,7 +69,7 @@ export const effectLibrary: EffectLibrary = {
     name: 'Enfeebled',
     hasValue: true,
     maxValue: 4,
-    modifiers: [{ stat: 'strSkills', bonusType: 'status', value: '-effectValue' }],
+    modifiers: [{ stat: 'strSkills', bonusType: 'status', value: negativeEffectValue }],
     description:
       "Also applies to Str-based melee attack rolls and damage rolls, which are not automated because creature attacks don't tag ability."
   }),
@@ -77,8 +79,8 @@ export const effectLibrary: EffectLibrary = {
     hasValue: true,
     maxValue: 4,
     modifiers: [
-      { stat: 'mentalSkills', bonusType: 'status', value: '-effectValue' },
-      { stat: 'will', bonusType: 'status', value: '-effectValue' }
+      { stat: 'mentalSkills', bonusType: 'status', value: negativeEffectValue },
+      { stat: 'will', bonusType: 'status', value: negativeEffectValue }
     ],
     description:
       'Also applies to spell attack rolls and spell DCs. When casting a spell, DC 5 + value flat check or spell is lost.'
@@ -88,7 +90,7 @@ export const effectLibrary: EffectLibrary = {
     name: 'Drained',
     hasValue: true,
     maxValue: 4,
-    modifiers: [{ stat: 'fortitude', bonusType: 'status', value: '-effectValue' }],
+    modifiers: [{ stat: 'fortitude', bonusType: 'status', value: negativeEffectValue }],
     persistAfterEncounter: true,
     description:
       "Reduces max HP by level times value. Also applies to Con-based checks beyond Fortitude. Decreases by 1 after a full night's rest."

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -2,9 +2,11 @@ export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
 export { applyEliteWeak } from './creatures/templates';
 export { effectLibrary } from './effects/library';
+export { deriveStats } from './effects/derivation';
 export type { CreatureTemplateAdjustment } from './creatures/templates';
 export type {
   Ability,
+  AppliedModifier,
   AppliedEffect,
   Attack,
   AttackType,
@@ -17,6 +19,9 @@ export type {
   Command,
   CommandResult,
   CommandType,
+  ComputedModifierBucket,
+  ComputedStat,
+  ComputedStats,
   Creature,
   CreatureBaseStats,
   CreatureRarity,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -394,8 +394,10 @@ export type StatTarget =
 export interface Modifier {
   stat: StatTarget;
   bonusType: BonusType;
-  value: number | 'effectValue' | '-effectValue';
+  value: ModifierValue;
 }
+
+export type ModifierValue = number | { kind: 'effectValue'; sign: 1 | -1 };
 
 export interface AppliedModifier {
   effectId: string;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -397,6 +397,37 @@ export interface Modifier {
   value: number | 'effectValue' | '-effectValue';
 }
 
+export interface AppliedModifier {
+  effectId: string;
+  instanceId: string;
+  sourceName: string;
+  bonusType: BonusType;
+  value: number;
+  suppressed: boolean;
+}
+
+export interface ComputedStat {
+  base: number;
+  final: number;
+  modifiers: AppliedModifier[];
+}
+
+export interface ComputedModifierBucket {
+  total: number;
+  modifiers: AppliedModifier[];
+}
+
+export interface ComputedStats {
+  ac: ComputedStat;
+  fortitude: ComputedStat;
+  reflex: ComputedStat;
+  will: ComputedStat;
+  perception: ComputedStat;
+  skills: Record<string, ComputedStat>;
+  attackRolls: ComputedModifierBucket;
+  allDCs: ComputedModifierBucket;
+}
+
 export type TurnBoundarySuggestion =
   | { type: 'suggestDecrement'; amount: number; description?: string }
   | { type: 'suggestRemove'; description: string }


### PR DESCRIPTION
## Summary
- Add pure `deriveStats(baseStats, appliedEffects, effectLibrary)` for PF2e modifier expansion and stacking.
- Export computed stat breakdown types and the derivation API from the domain package.
- Correct the conditions spec so `intSkills` includes Occultism and clarify non-automated attack/spell-stat gaps.

## Test Plan
- [x] `npm run test:run`
- [x] `npm run check`
- [x] `npm run build`
- [x] `npm run audit`

Closes #11