### PR TITLE
Slice 10: Conditions UI on combatant cards

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import type { CombatantState, EncounterState } from '../domain';
-  import { combatantVisualState, type CombatantCardActionAvailability } from '$lib/encounter-app';
+  import {
+    combatantVisualState,
+    type AppliedEffectView,
+    type CombatantCardActionAvailability,
+    type ConditionOption
+  } from '$lib/encounter-app';
 
   export let combatant: CombatantState;
   export let isCurrent: boolean;
   export let phase: EncounterState['phase'];
   export let actions: CombatantCardActionAvailability;
+  export let appliedEffectsView: AppliedEffectView[];
+  export let conditionOptions: ConditionOption[];
   export let onDamage: (id: string) => void;
   export let onHeal: (id: string) => void;
   export let onSetTemp: (id: string) => void;
@@ -14,6 +21,60 @@
   export let onMarkReactionUsed: (id: string) => void;
   export let onMarkDead: (id: string) => void;
   export let onRevive: (id: string) => void;
+  export let onApplyCondition: (id: string, choice: { effectId: string; value?: number }) => void;
+  export let onRemoveCondition: (id: string, instanceId: string) => void;
+  export let onModifyConditionValue: (id: string, instanceId: string, delta: number) => void;
+  export let onSetConditionValue: (id: string, instanceId: string, newValue: number) => void;
+
+  let pickerOpen = false;
+  let pickerEffectId = '';
+  let pickerValue = 1;
+  let editingInstanceId: string | null = null;
+  let editingValue = 1;
+
+  $: pickerSelected = conditionOptions.find((option) => option.id === pickerEffectId);
+
+  function openPicker() {
+    pickerEffectId = conditionOptions[0]?.id ?? '';
+    pickerValue = 1;
+    pickerOpen = true;
+  }
+
+  function cancelPicker() {
+    pickerOpen = false;
+  }
+
+  function applyFromPicker() {
+    if (!pickerSelected) return;
+    const choice = pickerSelected.hasValue
+      ? { effectId: pickerSelected.id, value: clampValue(pickerValue, pickerSelected.maxValue) }
+      : { effectId: pickerSelected.id };
+    onApplyCondition(combatant.id, choice);
+    pickerOpen = false;
+  }
+
+  function startEdit(view: AppliedEffectView) {
+    editingInstanceId = view.instanceId;
+    editingValue = view.value ?? 1;
+  }
+
+  function commitEdit(view: AppliedEffectView) {
+    const next = clampValue(editingValue, view.maxValue);
+    if (next !== view.value) {
+      onSetConditionValue(combatant.id, view.instanceId, next);
+    }
+    editingInstanceId = null;
+  }
+
+  function cancelEdit() {
+    editingInstanceId = null;
+  }
+
+  function clampValue(value: number, maxValue: number | undefined): number {
+    const integer = Number.isFinite(value) ? Math.trunc(value) : 1;
+    const lowerBounded = Math.max(1, integer);
+    return maxValue ? Math.min(lowerBounded, maxValue) : lowerBounded;
+  }
 
   function templateLabel(adjustment: CombatantState['templateAdjustment']) {
     if (adjustment === 'elite') return 'Elite';
@@ -91,6 +152,92 @@
   </div>
   <div class="hp-track" aria-label={`${combatant.name} HP`}>
     <div class="hp-fill" style={`width: ${hpPercent}%`}></div>
+  </div>
+
+  <div class="conditions" aria-label={`${combatant.name} conditions`}>
+    {#if appliedEffectsView.length === 0 && !pickerOpen}
+      <span class="conditions-empty">No conditions.</span>
+    {/if}
+
+    {#each appliedEffectsView as view (view.instanceId)}
+      <span class="condition-chip" class:implied={view.isImplied}>
+        <span class="condition-name">{view.name}</span>
+        {#if view.hasValue}
+          {#if editingInstanceId === view.instanceId}
+            <input
+              class="condition-value-input"
+              type="number"
+              min="1"
+              max={view.maxValue ?? 99}
+              bind:value={editingValue}
+              aria-label={`${view.name} value`}
+            />
+            <button type="button" class="condition-mini" onclick={() => commitEdit(view)}>Set</button>
+            <button type="button" class="condition-mini secondary" onclick={cancelEdit}>Cancel</button>
+          {:else}
+            <button
+              type="button"
+              class="condition-mini"
+              onclick={() => onModifyConditionValue(combatant.id, view.instanceId, -1)}
+              aria-label={`Decrease ${view.name}`}
+            >−</button>
+            <button
+              type="button"
+              class="condition-value"
+              onclick={() => startEdit(view)}
+              title="Click to edit"
+              aria-label={`${view.name} value ${view.value}`}
+            >{view.value ?? 1}</button>
+            <button
+              type="button"
+              class="condition-mini"
+              onclick={() => onModifyConditionValue(combatant.id, view.instanceId, 1)}
+              aria-label={`Increase ${view.name}`}
+            >+</button>
+          {/if}
+        {/if}
+        <span class="condition-duration">{view.durationLabel}</span>
+        {#if view.isImplied && view.parentName}
+          <span class="condition-parent">via {view.parentName}</span>
+        {/if}
+        <button
+          type="button"
+          class="condition-remove"
+          onclick={() => onRemoveCondition(combatant.id, view.instanceId)}
+          aria-label={`Remove ${view.name}`}
+          title="Remove"
+        >✕</button>
+      </span>
+    {/each}
+
+    {#if !pickerOpen}
+      <button
+        type="button"
+        class="condition-add"
+        onclick={openPicker}
+        disabled={conditionOptions.length === 0}
+      >+ Condition</button>
+    {:else}
+      <div class="condition-picker" role="group" aria-label="Apply condition">
+        <select bind:value={pickerEffectId} aria-label="Condition">
+          {#each conditionOptions as option (option.id)}
+            <option value={option.id}>{option.name}</option>
+          {/each}
+        </select>
+        {#if pickerSelected?.hasValue}
+          <input
+            class="condition-value-input"
+            type="number"
+            min="1"
+            max={pickerSelected.maxValue ?? 99}
+            bind:value={pickerValue}
+            aria-label="Initial value"
+          />
+        {/if}
+        <button type="button" class="condition-apply" onclick={applyFromPicker}>Apply</button>
+        <button type="button" class="condition-apply secondary" onclick={cancelPicker}>Cancel</button>
+      </div>
+    {/if}
   </div>
 
   <div class="card-actions">
@@ -274,6 +421,172 @@
     height: 100%;
     border-radius: inherit;
     background: #3f7f64;
+  }
+
+  .conditions {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+
+  .conditions-empty {
+    color: #8a9690;
+    font-size: 12px;
+    font-style: italic;
+  }
+
+  .condition-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid #cfd6d1;
+    border-radius: 999px;
+    background: #eef1ee;
+    color: #263235;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 3px 5px 3px 10px;
+  }
+
+  .condition-chip.implied {
+    background: #f5f6f3;
+    border-style: dashed;
+    opacity: 0.78;
+  }
+
+  .condition-name {
+    font-weight: 700;
+  }
+
+  .condition-duration {
+    color: #627171;
+    font-weight: 500;
+    font-size: 11px;
+  }
+
+  .condition-parent {
+    color: #8a9690;
+    font-size: 11px;
+    font-style: italic;
+  }
+
+  .condition-mini {
+    border: 1px solid #b8c3be;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #263235;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    min-width: 22px;
+    padding: 2px 6px;
+  }
+
+  .condition-mini.secondary {
+    color: #627171;
+  }
+
+  .condition-value {
+    border: 1px solid #b8c3be;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #263235;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    min-width: 22px;
+    padding: 2px 6px;
+  }
+
+  .condition-value-input {
+    border: 1px solid #b8c3be;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #1d2528;
+    font: inherit;
+    font-size: 12px;
+    padding: 2px 4px;
+    width: 48px;
+  }
+
+  .condition-remove {
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: #7a1f1f;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    padding: 2px 6px;
+  }
+
+  .condition-remove:hover {
+    background: #f4d7d7;
+  }
+
+  .condition-add {
+    border: 1px dashed #9aa7a3;
+    border-radius: 999px;
+    background: transparent;
+    color: #28494c;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 4px 11px;
+  }
+
+  .condition-add:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  .condition-picker {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid #b8c3be;
+    border-radius: 8px;
+    background: #ffffff;
+    padding: 5px 7px;
+  }
+
+  .condition-picker select {
+    border: 1px solid #b8c3be;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #1d2528;
+    font: inherit;
+    font-size: 13px;
+    padding: 3px 6px;
+    max-width: 160px;
+  }
+
+  .condition-apply {
+    border: 1px solid #28494c;
+    border-radius: 4px;
+    background: #28494c;
+    color: #ffffff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 4px 10px;
+  }
+
+  .condition-apply.secondary {
+    border-color: #9aa7a3;
+    color: #263235;
+    background: #ffffff;
   }
 
   .card-actions {

--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import type { CombatantState, EncounterState } from '../domain';
   import {
+    clampValue,
     combatantVisualState,
+    resolveApplyChoice,
     type AppliedEffectView,
+    type ApplyConditionChoice,
     type CombatantCardActionAvailability,
     type ConditionOption
   } from '$lib/encounter-app';
@@ -21,7 +24,7 @@
   export let onMarkReactionUsed: (id: string) => void;
   export let onMarkDead: (id: string) => void;
   export let onRevive: (id: string) => void;
-  export let onApplyCondition: (id: string, choice: { effectId: string; value?: number }) => void;
+  export let onApplyCondition: (id: string, choice: ApplyConditionChoice) => void;
   export let onRemoveCondition: (id: string, instanceId: string) => void;
   export let onModifyConditionValue: (id: string, instanceId: string, delta: number) => void;
   export let onSetConditionValue: (id: string, instanceId: string, newValue: number) => void;
@@ -46,23 +49,22 @@
 
   function applyFromPicker() {
     if (!pickerSelected) return;
-    const choice = pickerSelected.hasValue
-      ? { effectId: pickerSelected.id, value: clampValue(pickerValue, pickerSelected.maxValue) }
-      : { effectId: pickerSelected.id };
-    onApplyCondition(combatant.id, choice);
+    onApplyCondition(combatant.id, resolveApplyChoice(pickerSelected, pickerValue));
     pickerOpen = false;
   }
 
   function startEdit(view: AppliedEffectView) {
     editingInstanceId = view.instanceId;
-    editingValue = view.value ?? 1;
+    editingValue = view.value.kind === 'valued' ? view.value.current : 1;
   }
 
   function commitEdit(view: AppliedEffectView) {
-    const next = clampValue(editingValue, view.maxValue);
-    if (next !== view.value) {
-      onSetConditionValue(combatant.id, view.instanceId, next);
+    if (view.value.kind !== 'valued') {
+      editingInstanceId = null;
+      return;
     }
+    const next = clampValue(editingValue, view.value.maxValue);
+    onSetConditionValue(combatant.id, view.instanceId, next);
     editingInstanceId = null;
   }
 
@@ -70,10 +72,16 @@
     editingInstanceId = null;
   }
 
-  function clampValue(value: number, maxValue: number | undefined): number {
-    const integer = Number.isFinite(value) ? Math.trunc(value) : 1;
-    const lowerBounded = Math.max(1, integer);
-    return maxValue ? Math.min(lowerBounded, maxValue) : lowerBounded;
+  function clampPickerValue() {
+    if (pickerSelected?.value.kind === 'valued') {
+      pickerValue = clampValue(pickerValue, pickerSelected.value.maxValue);
+    }
+  }
+
+  function clampEditingValue(view: AppliedEffectView) {
+    if (view.value.kind === 'valued') {
+      editingValue = clampValue(editingValue, view.value.maxValue);
+    }
   }
 
   function templateLabel(adjustment: CombatantState['templateAdjustment']) {
@@ -160,16 +168,17 @@
     {/if}
 
     {#each appliedEffectsView as view (view.instanceId)}
-      <span class="condition-chip" class:implied={view.isImplied}>
+      <span class="condition-chip" class:implied={view.source.kind === 'implied'}>
         <span class="condition-name">{view.name}</span>
-        {#if view.hasValue}
+        {#if view.value.kind === 'valued'}
           {#if editingInstanceId === view.instanceId}
             <input
               class="condition-value-input"
               type="number"
               min="1"
-              max={view.maxValue ?? 99}
+              max={view.value.maxValue ?? 99}
               bind:value={editingValue}
+              onblur={() => clampEditingValue(view)}
               aria-label={`${view.name} value`}
             />
             <button type="button" class="condition-mini" onclick={() => commitEdit(view)}>Set</button>
@@ -186,8 +195,8 @@
               class="condition-value"
               onclick={() => startEdit(view)}
               title="Click to edit"
-              aria-label={`${view.name} value ${view.value}`}
-            >{view.value ?? 1}</button>
+              aria-label={`${view.name} value ${view.value.current}, click to edit`}
+            >{view.value.current}</button>
             <button
               type="button"
               class="condition-mini"
@@ -197,8 +206,8 @@
           {/if}
         {/if}
         <span class="condition-duration">{view.durationLabel}</span>
-        {#if view.isImplied && view.parentName}
-          <span class="condition-parent">via {view.parentName}</span>
+        {#if view.source.kind === 'implied'}
+          <span class="condition-parent">via {view.source.parentName}</span>
         {/if}
         <button
           type="button"
@@ -224,13 +233,14 @@
             <option value={option.id}>{option.name}</option>
           {/each}
         </select>
-        {#if pickerSelected?.hasValue}
+        {#if pickerSelected?.value.kind === 'valued'}
           <input
             class="condition-value-input"
             type="number"
             min="1"
-            max={pickerSelected.maxValue ?? 99}
+            max={pickerSelected.value.maxValue ?? 99}
             bind:value={pickerValue}
+            onblur={clampPickerValue}
             aria-label="Initial value"
           />
         {/if}

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -3,12 +3,17 @@ import {
   combatantCardActions,
   combatantVisualState,
   dispatchEncounterCommand,
+  formatDuration,
+  listConditionDefinitions,
+  listConditionOptions,
   makeCombatant,
   makeCreatureCombatant,
   newEncounterState,
-  toCommand
+  toCommand,
+  viewAppliedEffects
 } from './encounter-app';
-import type { Creature } from '../domain';
+import { effectLibrary } from '../domain';
+import type { CombatantState, Creature, EncounterState } from '../domain';
 
 describe('encounter app boundary', () => {
   test('creates a normal creature combatant through the app boundary', () => {
@@ -322,7 +327,250 @@ describe('end-to-end turn-control dispatches', () => {
   });
 });
 
-function stateWithTwoCombatants() {
+describe('listConditionDefinitions', () => {
+  test('returns only condition-category definitions, alphabetized by name', () => {
+    const definitions = listConditionDefinitions();
+    const expectedCount = Object.values(effectLibrary).filter((d) => d.category === 'condition').length;
+
+    expect(definitions.length).toBe(expectedCount);
+    expect(definitions.every((d) => d.category === 'condition')).toBe(true);
+
+    const names = definitions.map((d) => d.name);
+    expect([...names].sort((a, b) => a.localeCompare(b))).toEqual(names);
+  });
+
+  test('listConditionOptions projects only the fields the UI needs', () => {
+    const options = listConditionOptions();
+    const frightened = options.find((o) => o.id === 'frightened');
+
+    expect(frightened).toEqual({
+      id: 'frightened',
+      name: 'Frightened',
+      hasValue: true,
+      maxValue: 4,
+      description: 'Decreases by 1 at end of your turn.'
+    });
+  });
+});
+
+describe('formatDuration', () => {
+  const state = newEncounterState();
+
+  test('renders unlimited durations', () => {
+    expect(formatDuration({ type: 'unlimited' }, state)).toBe('unlimited');
+  });
+
+  test('renders rounds with singular and plural forms', () => {
+    expect(formatDuration({ type: 'rounds', count: 1 }, state)).toBe('1 round');
+    expect(formatDuration({ type: 'rounds', count: 4 }, state)).toBe('4 rounds');
+  });
+
+  test('renders turn-bound durations using the combatant name', () => {
+    const populated = stateWithTwoCombatants();
+
+    expect(formatDuration({ type: 'untilTurnEnd', combatantId: 'goblin-1' }, populated))
+      .toBe("until end of Goblin Warrior's turn");
+    expect(formatDuration({ type: 'untilTurnStart', combatantId: 'fighter-1' }, populated))
+      .toBe("until start of Fighter's turn");
+  });
+
+  test('falls back to combatant id when the target is missing', () => {
+    expect(formatDuration({ type: 'untilTurnEnd', combatantId: 'ghost' }, state))
+      .toBe("until end of ghost's turn");
+  });
+
+  test('renders conditional durations using the description text', () => {
+    expect(formatDuration({ type: 'conditional', description: 'until next save' }, state))
+      .toBe('until next save');
+  });
+});
+
+describe('viewAppliedEffects', () => {
+  test('returns an empty list for a combatant with no effects', () => {
+    const state = stateWithTwoCombatants();
+    expect(viewAppliedEffects(state.combatants['goblin-1'], state)).toEqual([]);
+  });
+
+  test('hydrates name, hasValue, value, duration label, and parent attribution', () => {
+    const started = startedState();
+    const fightened = dispatchEncounterCommand(
+      started,
+      [],
+      toCommand('APPLY_EFFECT', {
+        effectId: 'frightened',
+        targetId: 'fighter-1',
+        value: 2,
+        duration: { type: 'unlimited' }
+      }, 'cmd-frighten')
+    );
+    const dyingApplied = dispatchEncounterCommand(
+      fightened.state,
+      fightened.feedback,
+      toCommand('APPLY_EFFECT', {
+        effectId: 'dying',
+        targetId: 'fighter-1',
+        value: 1,
+        duration: { type: 'unlimited' }
+      }, 'cmd-dying')
+    );
+
+    const fighter = dyingApplied.state.combatants['fighter-1'];
+    const views = viewAppliedEffects(fighter, dyingApplied.state);
+
+    const frightenedView = views.find((v) => v.effectId === 'frightened');
+    expect(frightenedView).toMatchObject({
+      effectId: 'frightened',
+      name: 'Frightened',
+      hasValue: true,
+      maxValue: 4,
+      value: 2,
+      durationLabel: 'unlimited',
+      isImplied: false,
+      parentName: undefined
+    });
+
+    const dyingView = views.find((v) => v.effectId === 'dying');
+    expect(dyingView).toMatchObject({
+      name: 'Dying',
+      hasValue: true,
+      value: 1,
+      isImplied: false
+    });
+
+    const unconsciousView = views.find((v) => v.effectId === 'unconscious');
+    expect(unconsciousView).toMatchObject({
+      name: 'Unconscious',
+      hasValue: false,
+      value: undefined,
+      isImplied: true,
+      parentName: 'Dying'
+    });
+
+    const offGuardView = views.find((v) => v.effectId === 'off-guard');
+    expect(offGuardView).toMatchObject({
+      name: 'Off-Guard',
+      isImplied: true,
+      parentName: 'Unconscious'
+    });
+  });
+});
+
+describe('end-to-end condition dispatches', () => {
+  test('apply, modify, and auto-remove a value condition through the orchestrator', () => {
+    const started = startedState();
+
+    const applied = dispatchEncounterCommand(
+      started,
+      [],
+      toCommand('APPLY_EFFECT', {
+        effectId: 'frightened',
+        targetId: 'fighter-1',
+        value: 2,
+        duration: { type: 'unlimited' }
+      }, 'cmd-apply')
+    );
+    const fightenedInstance = applied.state.combatants['fighter-1'].appliedEffects[0];
+    expect(fightenedInstance).toMatchObject({ effectId: 'frightened', value: 2 });
+
+    const decremented = dispatchEncounterCommand(
+      applied.state,
+      applied.feedback,
+      toCommand('MODIFY_EFFECT_VALUE', {
+        targetId: 'fighter-1',
+        instanceId: fightenedInstance.instanceId,
+        delta: -1
+      }, 'cmd-mod-1')
+    );
+    expect(decremented.state.combatants['fighter-1'].appliedEffects[0]).toMatchObject({
+      effectId: 'frightened',
+      value: 1
+    });
+
+    const removed = dispatchEncounterCommand(
+      decremented.state,
+      decremented.feedback,
+      toCommand('MODIFY_EFFECT_VALUE', {
+        targetId: 'fighter-1',
+        instanceId: fightenedInstance.instanceId,
+        delta: -1
+      }, 'cmd-mod-2')
+    );
+
+    expect(removed.state.combatants['fighter-1'].appliedEffects).toEqual([]);
+
+    const messages = removed.feedback.map((entry) => entry.message).join(' | ');
+    expect(messages).toContain('effect-applied');
+    expect(messages).toContain('effect-value-changed');
+    expect(messages).toContain('effect-removed');
+  });
+
+  test('SET_EFFECT_VALUE replaces the current value without removing the effect', () => {
+    const started = startedState();
+
+    const applied = dispatchEncounterCommand(
+      started,
+      [],
+      toCommand('APPLY_EFFECT', {
+        effectId: 'frightened',
+        targetId: 'fighter-1',
+        value: 1,
+        duration: { type: 'unlimited' }
+      }, 'cmd-apply')
+    );
+    const instance = applied.state.combatants['fighter-1'].appliedEffects[0];
+
+    const setTo3 = dispatchEncounterCommand(
+      applied.state,
+      applied.feedback,
+      toCommand('SET_EFFECT_VALUE', {
+        targetId: 'fighter-1',
+        instanceId: instance.instanceId,
+        newValue: 3
+      }, 'cmd-set')
+    );
+
+    expect(setTo3.state.combatants['fighter-1'].appliedEffects[0]).toMatchObject({
+      effectId: 'frightened',
+      value: 3
+    });
+  });
+
+  test('REMOVE_EFFECT cascades to implied children', () => {
+    const started = startedState();
+
+    const applied = dispatchEncounterCommand(
+      started,
+      [],
+      toCommand('APPLY_EFFECT', {
+        effectId: 'dying',
+        targetId: 'fighter-1',
+        value: 1,
+        duration: { type: 'unlimited' }
+      }, 'cmd-apply')
+    );
+
+    const dying = applied.state.combatants['fighter-1'].appliedEffects.find(
+      (e: CombatantState['appliedEffects'][number]) => e.effectId === 'dying'
+    );
+    expect(dying).toBeDefined();
+    expect(applied.state.combatants['fighter-1'].appliedEffects.some(
+      (e: CombatantState['appliedEffects'][number]) => e.effectId === 'unconscious'
+    )).toBe(true);
+
+    const removed = dispatchEncounterCommand(
+      applied.state,
+      applied.feedback,
+      toCommand('REMOVE_EFFECT', {
+        targetId: 'fighter-1',
+        instanceId: dying!.instanceId
+      }, 'cmd-remove')
+    );
+
+    expect(removed.state.combatants['fighter-1'].appliedEffects).toEqual([]);
+  });
+});
+
+function stateWithTwoCombatants(): EncounterState {
   const goblin = makeCombatant({
     id: 'goblin-1',
     name: 'Goblin Warrior',

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  clampValue,
   combatantCardActions,
   combatantVisualState,
   dispatchEncounterCommand,
@@ -9,8 +10,10 @@ import {
   makeCombatant,
   makeCreatureCombatant,
   newEncounterState,
+  resolveApplyChoice,
   toCommand,
-  viewAppliedEffects
+  viewAppliedEffects,
+  type ConditionOption
 } from './encounter-app';
 import { effectLibrary } from '../domain';
 import type { CombatantState, Creature, EncounterState } from '../domain';
@@ -346,9 +349,79 @@ describe('listConditionDefinitions', () => {
     expect(frightened).toEqual({
       id: 'frightened',
       name: 'Frightened',
-      hasValue: true,
-      maxValue: 4,
+      value: { kind: 'valued', defaultValue: 1, maxValue: 4 },
       description: 'Decreases by 1 at end of your turn.'
+    });
+  });
+
+  test('listConditionOptions marks unvalued conditions with kind "unvalued"', () => {
+    const options = listConditionOptions();
+    const offGuard = options.find((o) => o.id === 'off-guard');
+
+    expect(offGuard?.value).toEqual({ kind: 'unvalued' });
+  });
+});
+
+describe('clampValue', () => {
+  test('floors fractional input via Math.trunc rather than rounding', () => {
+    expect(clampValue(2.7, 4)).toBe(2);
+    expect(clampValue(2.99, 4)).toBe(2);
+  });
+
+  test('returns 1 for non-finite input (NaN, +/-Infinity)', () => {
+    expect(clampValue(Number.NaN, 4)).toBe(1);
+    expect(clampValue(Number.POSITIVE_INFINITY, 4)).toBe(1);
+    expect(clampValue(Number.NEGATIVE_INFINITY, 4)).toBe(1);
+  });
+
+  test('floors zero and negatives to 1', () => {
+    expect(clampValue(0, 4)).toBe(1);
+    expect(clampValue(-5, 4)).toBe(1);
+  });
+
+  test('caps at maxValue when provided', () => {
+    expect(clampValue(99, 4)).toBe(4);
+    expect(clampValue(5, 4)).toBe(4);
+  });
+
+  test('does not cap when maxValue is undefined', () => {
+    expect(clampValue(99, undefined)).toBe(99);
+  });
+
+  test('respects maxValue of 0 instead of treating it as unbounded', () => {
+    expect(clampValue(5, 0)).toBe(0);
+  });
+});
+
+describe('resolveApplyChoice', () => {
+  const valuedOption: ConditionOption = {
+    id: 'frightened',
+    name: 'Frightened',
+    value: { kind: 'valued', defaultValue: 1, maxValue: 4 }
+  };
+  const unvaluedOption: ConditionOption = {
+    id: 'off-guard',
+    name: 'Off-Guard',
+    value: { kind: 'unvalued' }
+  };
+
+  test('returns kind "unvalued" for unvalued conditions and ignores rawValue', () => {
+    expect(resolveApplyChoice(unvaluedOption, 7)).toEqual({
+      kind: 'unvalued',
+      effectId: 'off-guard'
+    });
+  });
+
+  test('returns kind "valued" with the clamped raw value for valued conditions', () => {
+    expect(resolveApplyChoice(valuedOption, 99)).toEqual({
+      kind: 'valued',
+      effectId: 'frightened',
+      value: 4
+    });
+    expect(resolveApplyChoice(valuedOption, Number.NaN)).toEqual({
+      kind: 'valued',
+      effectId: 'frightened',
+      value: 1
     });
   });
 });
@@ -421,37 +494,76 @@ describe('viewAppliedEffects', () => {
     expect(frightenedView).toMatchObject({
       effectId: 'frightened',
       name: 'Frightened',
-      hasValue: true,
-      maxValue: 4,
-      value: 2,
+      value: { kind: 'valued', current: 2, maxValue: 4 },
       durationLabel: 'unlimited',
-      isImplied: false,
-      parentName: undefined
+      source: { kind: 'direct' }
     });
 
     const dyingView = views.find((v) => v.effectId === 'dying');
     expect(dyingView).toMatchObject({
       name: 'Dying',
-      hasValue: true,
-      value: 1,
-      isImplied: false
+      value: { kind: 'valued', current: 1 },
+      source: { kind: 'direct' }
     });
 
     const unconsciousView = views.find((v) => v.effectId === 'unconscious');
     expect(unconsciousView).toMatchObject({
       name: 'Unconscious',
-      hasValue: false,
-      value: undefined,
-      isImplied: true,
-      parentName: 'Dying'
+      value: { kind: 'unvalued' },
+      source: { kind: 'implied', parentName: 'Dying' }
     });
 
     const offGuardView = views.find((v) => v.effectId === 'off-guard');
     expect(offGuardView).toMatchObject({
       name: 'Off-Guard',
-      isImplied: true,
-      parentName: 'Unconscious'
+      source: { kind: 'implied', parentName: 'Unconscious' }
     });
+  });
+
+  test('falls back to the raw effectId when the definition is missing from the library', () => {
+    const orphan: CombatantState = {
+      ...stateWithTwoCombatants().combatants['fighter-1'],
+      appliedEffects: [
+        {
+          instanceId: 'inst-1',
+          effectId: 'custom-status',
+          duration: { type: 'unlimited' }
+        }
+      ]
+    };
+
+    const [view] = viewAppliedEffects(orphan, stateWithTwoCombatants());
+
+    expect(view).toMatchObject({
+      effectId: 'custom-status',
+      name: 'custom-status',
+      value: { kind: 'unvalued' },
+      source: { kind: 'direct' }
+    });
+  });
+
+  test('falls back to the parent effectId when the parent definition is missing', () => {
+    const fighter: CombatantState = {
+      ...stateWithTwoCombatants().combatants['fighter-1'],
+      appliedEffects: [
+        {
+          instanceId: 'parent-inst',
+          effectId: 'custom-source',
+          duration: { type: 'unlimited' }
+        },
+        {
+          instanceId: 'child-inst',
+          effectId: 'off-guard',
+          parentInstanceId: 'parent-inst',
+          duration: { type: 'unlimited' }
+        }
+      ]
+    };
+
+    const views = viewAppliedEffects(fighter, stateWithTwoCombatants());
+    const child = views.find((v) => v.effectId === 'off-guard');
+
+    expect(child?.source).toEqual({ kind: 'implied', parentName: 'custom-source' });
   });
 });
 
@@ -498,10 +610,18 @@ describe('end-to-end condition dispatches', () => {
 
     expect(removed.state.combatants['fighter-1'].appliedEffects).toEqual([]);
 
-    const messages = removed.feedback.map((entry) => entry.message).join(' | ');
-    expect(messages).toContain('effect-applied');
-    expect(messages).toContain('effect-value-changed');
-    expect(messages).toContain('effect-removed');
+    const firstDecrementFeedback = decremented.feedback
+      .slice(applied.feedback.length)
+      .map((entry) => entry.message)
+      .join(' | ');
+    expect(firstDecrementFeedback).toContain('effect-value-changed');
+    expect(firstDecrementFeedback).not.toContain('effect-removed');
+
+    const autoRemoveFeedback = removed.feedback
+      .slice(decremented.feedback.length)
+      .map((entry) => entry.message)
+      .join(' | ');
+    expect(autoRemoveFeedback).toContain('effect-removed');
   });
 
   test('SET_EFFECT_VALUE replaces the current value without removing the effect', () => {

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -143,25 +143,37 @@ export interface CombatantCardActionAvailability {
   canRevive: boolean;
 }
 
+export type ConditionOptionValue =
+  | { kind: 'valued'; defaultValue: number; maxValue?: number }
+  | { kind: 'unvalued' };
+
 export interface ConditionOption {
   id: string;
   name: string;
-  hasValue: boolean;
-  maxValue?: number;
+  value: ConditionOptionValue;
   description?: string;
 }
+
+export type AppliedEffectValue =
+  | { kind: 'valued'; current: number; maxValue?: number }
+  | { kind: 'unvalued' };
+
+export type AppliedEffectSource =
+  | { kind: 'direct' }
+  | { kind: 'implied'; parentName: string };
 
 export interface AppliedEffectView {
   instanceId: string;
   effectId: string;
   name: string;
-  hasValue: boolean;
-  maxValue?: number;
-  value?: number;
+  value: AppliedEffectValue;
   durationLabel: string;
-  isImplied: boolean;
-  parentName?: string;
+  source: AppliedEffectSource;
 }
+
+export type ApplyConditionChoice =
+  | { kind: 'valued'; effectId: string; value: number }
+  | { kind: 'unvalued'; effectId: string };
 
 export function listConditionDefinitions(): EffectDefinition[] {
   return Object.values(effectLibrary)
@@ -173,10 +185,29 @@ export function listConditionOptions(): ConditionOption[] {
   return listConditionDefinitions().map((definition) => ({
     id: definition.id,
     name: definition.name,
-    hasValue: definition.hasValue,
-    maxValue: definition.maxValue,
+    value: definition.hasValue
+      ? { kind: 'valued', defaultValue: 1, maxValue: definition.maxValue }
+      : { kind: 'unvalued' },
     description: definition.description
   }));
+}
+
+// PF2e condition values are 1..maxValue. Non-finite or sub-1 input falls back to 1.
+export function clampValue(value: number, maxValue: number | undefined): number {
+  const integer = Number.isFinite(value) ? Math.trunc(value) : 1;
+  const lowerBounded = Math.max(1, integer);
+  return maxValue !== undefined ? Math.min(lowerBounded, maxValue) : lowerBounded;
+}
+
+export function resolveApplyChoice(option: ConditionOption, rawValue: number): ApplyConditionChoice {
+  if (option.value.kind === 'unvalued') {
+    return { kind: 'unvalued', effectId: option.id };
+  }
+  return {
+    kind: 'valued',
+    effectId: option.id,
+    value: clampValue(rawValue, option.value.maxValue)
+  };
 }
 
 export function formatDuration(duration: Duration, state: EncounterState): string {
@@ -212,16 +243,21 @@ function toAppliedEffectView(
     : undefined;
   const parentDefinition = parent ? effectLibrary[parent.effectId] : undefined;
 
+  const value: AppliedEffectValue = definition?.hasValue
+    ? { kind: 'valued', current: effect.value ?? 1, maxValue: definition.maxValue }
+    : { kind: 'unvalued' };
+
+  const source: AppliedEffectSource = effect.parentInstanceId
+    ? { kind: 'implied', parentName: parentDefinition?.name ?? parent?.effectId ?? effect.parentInstanceId }
+    : { kind: 'direct' };
+
   return {
     instanceId: effect.instanceId,
     effectId: effect.effectId,
     name: definition?.name ?? effect.effectId,
-    hasValue: definition?.hasValue ?? false,
-    maxValue: definition?.maxValue,
-    value: effect.value,
+    value,
     durationLabel: formatDuration(effect.duration, state),
-    isImplied: Boolean(effect.parentInstanceId),
-    parentName: parentDefinition?.name ?? parent?.effectId
+    source
   };
 }
 

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -1,5 +1,16 @@
 import { applyCommand, createCombatantFromCreature, effectLibrary } from '../domain';
-import type { CombatantState, Command, CommandType, Creature, CreatureTemplateAdjustment, DomainEvent, EncounterState } from '../domain';
+import type {
+  AppliedEffect,
+  CombatantState,
+  Command,
+  CommandType,
+  Creature,
+  CreatureTemplateAdjustment,
+  DomainEvent,
+  Duration,
+  EffectDefinition,
+  EncounterState
+} from '../domain';
 
 export interface ManualCombatantInput {
   id: string;
@@ -130,6 +141,88 @@ export interface CombatantCardActionAvailability {
   canMarkReactionUsed: boolean;
   canMarkDead: boolean;
   canRevive: boolean;
+}
+
+export interface ConditionOption {
+  id: string;
+  name: string;
+  hasValue: boolean;
+  maxValue?: number;
+  description?: string;
+}
+
+export interface AppliedEffectView {
+  instanceId: string;
+  effectId: string;
+  name: string;
+  hasValue: boolean;
+  maxValue?: number;
+  value?: number;
+  durationLabel: string;
+  isImplied: boolean;
+  parentName?: string;
+}
+
+export function listConditionDefinitions(): EffectDefinition[] {
+  return Object.values(effectLibrary)
+    .filter((definition) => definition.category === 'condition')
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function listConditionOptions(): ConditionOption[] {
+  return listConditionDefinitions().map((definition) => ({
+    id: definition.id,
+    name: definition.name,
+    hasValue: definition.hasValue,
+    maxValue: definition.maxValue,
+    description: definition.description
+  }));
+}
+
+export function formatDuration(duration: Duration, state: EncounterState): string {
+  switch (duration.type) {
+    case 'unlimited':
+      return 'unlimited';
+    case 'rounds':
+      return duration.count === 1 ? '1 round' : `${duration.count} rounds`;
+    case 'untilTurnEnd':
+      return `until end of ${combatantName(state, duration.combatantId)}'s turn`;
+    case 'untilTurnStart':
+      return `until start of ${combatantName(state, duration.combatantId)}'s turn`;
+    case 'conditional':
+      return duration.description;
+  }
+}
+
+export function viewAppliedEffects(
+  combatant: CombatantState,
+  state: EncounterState
+): AppliedEffectView[] {
+  return combatant.appliedEffects.map((effect) => toAppliedEffectView(effect, combatant, state));
+}
+
+function toAppliedEffectView(
+  effect: AppliedEffect,
+  combatant: CombatantState,
+  state: EncounterState
+): AppliedEffectView {
+  const definition = effectLibrary[effect.effectId];
+  const parent = effect.parentInstanceId
+    ? combatant.appliedEffects.find((candidate) => candidate.instanceId === effect.parentInstanceId)
+    : undefined;
+  const parentDefinition = parent ? effectLibrary[parent.effectId] : undefined;
+
+  return {
+    instanceId: effect.instanceId,
+    effectId: effect.effectId,
+    name: definition?.name ?? effect.effectId,
+    hasValue: definition?.hasValue ?? false,
+    maxValue: definition?.maxValue,
+    value: effect.value,
+    durationLabel: formatDuration(effect.duration, state),
+    isImplied: Boolean(effect.parentInstanceId),
+    parentName: parentDefinition?.name ?? parent?.effectId
+  };
 }
 
 export function combatantCardActions(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,14 +9,18 @@
     combatantCardActions,
     currentCombatant,
     dispatchEncounterCommand,
+    listConditionOptions,
     makeCombatant,
     makeCreatureCombatant,
     newEncounterState,
     toCommand,
+    viewAppliedEffects,
     type FeedbackEntry,
     type ManualCombatantInput,
     type TemplateAdjustmentChoice
   } from '$lib/encounter-app';
+
+  const conditionOptions = listConditionOptions();
 
   let encounter = newEncounterState();
   let feedback: FeedbackEntry[] = [];
@@ -132,6 +136,37 @@
     runCommand(toCommand('REVIVE', { combatantId }, nextCommandId()));
   }
 
+  function applyCondition(combatantId: string, choice: { effectId: string; value?: number }) {
+    runCommand(
+      toCommand(
+        'APPLY_EFFECT',
+        {
+          effectId: choice.effectId,
+          targetId: combatantId,
+          value: choice.value,
+          duration: { type: 'unlimited' }
+        },
+        nextCommandId()
+      )
+    );
+  }
+
+  function removeCondition(combatantId: string, instanceId: string) {
+    runCommand(toCommand('REMOVE_EFFECT', { targetId: combatantId, instanceId }, nextCommandId()));
+  }
+
+  function modifyConditionValue(combatantId: string, instanceId: string, delta: number) {
+    runCommand(
+      toCommand('MODIFY_EFFECT_VALUE', { targetId: combatantId, instanceId, delta }, nextCommandId())
+    );
+  }
+
+  function setConditionValue(combatantId: string, instanceId: string, newValue: number) {
+    runCommand(
+      toCommand('SET_EFFECT_VALUE', { targetId: combatantId, instanceId, newValue }, nextCommandId())
+    );
+  }
+
   function resetLocal() {
     encounter = newEncounterState();
     feedback = [];
@@ -187,6 +222,8 @@
             isCurrent={combatant.id === activeCombatant?.id}
             phase={encounter.phase}
             actions={combatantCardActions(encounter, combatant.id)}
+            appliedEffectsView={viewAppliedEffects(combatant, encounter)}
+            {conditionOptions}
             onDamage={applyDamage}
             onHeal={applyHealing}
             onSetTemp={setTempHp}
@@ -195,6 +232,10 @@
             onMarkReactionUsed={markReactionUsed}
             onMarkDead={markDead}
             onRevive={revive}
+            onApplyCondition={applyCondition}
+            onRemoveCondition={removeCondition}
+            onModifyConditionValue={modifyConditionValue}
+            onSetConditionValue={setConditionValue}
           />
         {/each}
       </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
     newEncounterState,
     toCommand,
     viewAppliedEffects,
+    type ApplyConditionChoice,
     type FeedbackEntry,
     type ManualCombatantInput,
     type TemplateAdjustmentChoice
@@ -136,14 +137,14 @@
     runCommand(toCommand('REVIVE', { combatantId }, nextCommandId()));
   }
 
-  function applyCondition(combatantId: string, choice: { effectId: string; value?: number }) {
+  function applyCondition(combatantId: string, choice: ApplyConditionChoice) {
     runCommand(
       toCommand(
         'APPLY_EFFECT',
         {
           effectId: choice.effectId,
           targetId: combatantId,
-          value: choice.value,
+          value: choice.kind === 'valued' ? choice.value : undefined,
           duration: { type: 'unlimited' }
         },
         nextCommandId()


### PR DESCRIPTION
## Summary
- Adds an inline conditions row to each combatant card: live chips with name/value/duration, ± and explicit-set value controls, click-to-edit, and remove. A "+ Condition" picker opens an inline form for applying conditions from the built-in library.
- Implied effects (e.g. Dying → Unconscious → Off-Guard) render as faded "via {parent}" chips and rely on the reducer's existing cascade behaviour for removal.
- Domain layer untouched. Pure UI + orchestrator selectors (`listConditionDefinitions`, `listConditionOptions`, `viewAppliedEffects`, `formatDuration`) wiring `APPLY_EFFECT`, `REMOVE_EFFECT`, `SET_EFFECT_VALUE`, and `MODIFY_EFFECT_VALUE` through `dispatchEncounterCommand`.

Closes #45.

## Scope (matches issue #45 ACs)
- ✅ Cards list applied conditions with value and duration where applicable.
- ✅ GM can pick a condition from the built-in library and apply it (defaults to `{ type: 'unlimited' }`).
- ✅ GM can edit value, modify value (delta), and clear the condition.
- ✅ UI dispatches existing commands through the orchestrator; no new domain behaviour.
- ✅ Focused tests cover the wiring for each command.

Out of scope (deferred): persistent damage UX (needs note field), `SET_EFFECT_DURATION` editor, source attribution, stacking derivation (#11), prompt resolution panel (#46), custom effects.

## Test plan
- [x] `npm run check` — svelte-check + domain tsc clean.
- [x] `npm run test:run` — 106/106 (24 new tests added in `src/lib/encounter-app.test.ts`).
- [x] `npm run audit` — no moderate-or-higher findings.
- [x] `npm run build` — static Cloudflare Pages build succeeds.
- [x] Manual walkthrough: Frightened apply with value 2 → decrement to 1 → decrement auto-removes; Off-Guard apply (no value); Dying 1 apply cascades to Unconscious + Off-Guard chips; Remove Dying cascades all three; Click-to-edit Frightened from 1 → 3 via Set button.