### PR TITLE
Ignore local agent and tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ node_modules/
 build/
 .vite/
 coverage/
+
+# Local agent / tooling artifacts.
+.claude/settings.local.json
+.claude/worktrees/
+.playwright-mcp/
+*.png


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for `.claude/settings.local.json`, `.claude/worktrees/`, `.playwright-mcp/`, and `*.png` so per-session agent/tooling artifacts stop appearing as untracked files.
- Strictly additive — no existing tracked files are affected.

## Test plan
- [x] `git status` after the change reports a clean working tree (only the `.gitignore` modification was visible before commit).