### PR TITLE
Slice 5: Inline HP / Temp HP edit on combatant cards

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -9,6 +9,8 @@
     type CombatantCardActionAvailability,
     type ConditionOption
   } from '$lib/encounter-app';
+  import type { CommittableEdit, HpEditField } from '$lib/hp-input';
+  import InlineNumberEdit from './InlineNumberEdit.svelte';
 
   export let combatant: CombatantState;
   export let isCurrent: boolean;
@@ -16,10 +18,7 @@
   export let actions: CombatantCardActionAvailability;
   export let appliedEffectsView: AppliedEffectView[];
   export let conditionOptions: ConditionOption[];
-  export let onDamage: (id: string) => void;
-  export let onHeal: (id: string) => void;
-  export let onSetTemp: (id: string) => void;
-  export let onSetZero: (id: string) => void;
+  export let onHpEdit: (id: string, field: HpEditField, parsed: CommittableEdit) => void;
   export let onEndTurn: (id: string) => void;
   export let onMarkReactionUsed: (id: string) => void;
   export let onMarkDead: (id: string) => void;
@@ -149,13 +148,32 @@
   </div>
 
   <div class="hp-row">
-    <div>
-      <strong>{combatant.currentHp}</strong>
+    <div class="hp-cell">
+      <InlineNumberEdit
+        value={combatant.currentHp}
+        ariaLabel="Edit HP. Type 42 to set, +3 to heal, minus 5 to damage."
+        displayAriaLabel={`HP ${combatant.currentHp} of ${combatant.baseStats.hp}, click to edit`}
+        placeholder="−5, +3, 42"
+        displayClass="hp-value"
+        onCommit={(parsed) => onHpEdit(combatant.id, 'hp', parsed)}
+      />
       <span>/ {combatant.baseStats.hp} HP</span>
     </div>
-    <div>
-      <strong>{combatant.tempHp}</strong>
-      <span>temp</span>
+    <div class="hp-cell">
+      <InlineNumberEdit
+        value={combatant.tempHp}
+        ariaLabel="Edit temp HP. Type 5 to set, +3 to add, minus 2 to remove."
+        displayAriaLabel={combatant.tempHp === 0
+          ? 'Add temporary HP'
+          : `Temp HP ${combatant.tempHp}, click to edit`}
+        placeholder="+3, 5, −2"
+        displayClass="hp-value"
+        emptyDisplay="+ Add temp"
+        onCommit={(parsed) => onHpEdit(combatant.id, 'tempHp', parsed)}
+      />
+      {#if combatant.tempHp > 0}
+        <span>temp</span>
+      {/if}
     </div>
   </div>
   <div class="hp-track" aria-label={`${combatant.name} HP`}>
@@ -248,13 +266,6 @@
         <button type="button" class="condition-apply secondary" onclick={cancelPicker}>Cancel</button>
       </div>
     {/if}
-  </div>
-
-  <div class="card-actions">
-    <button type="button" onclick={() => onDamage(combatant.id)}>Damage</button>
-    <button type="button" onclick={() => onHeal(combatant.id)}>Heal</button>
-    <button type="button" onclick={() => onSetTemp(combatant.id)}>Set Temp</button>
-    <button type="button" class="secondary" onclick={() => onSetZero(combatant.id)}>Set 0</button>
   </div>
 
   <div class="card-turn-actions" aria-label="Turn and lifecycle controls">
@@ -408,10 +419,15 @@
     border-radius: 7px;
     background: #eef1ee;
     padding: 10px;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
   }
 
-  .hp-row strong {
+  .hp-row :global(.hp-value) {
     font-size: 24px;
+    font-weight: 700;
+    color: inherit;
   }
 
   .hp-row span {
@@ -599,32 +615,6 @@
     background: #ffffff;
   }
 
-  .card-actions {
-    display: flex;
-    align-items: center;
-    justify-content: start;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-
-  .card-actions button {
-    min-height: 38px;
-    border: 1px solid #28494c;
-    border-radius: 6px;
-    background: #28494c;
-    color: #ffffff;
-    cursor: pointer;
-    font: inherit;
-    font-weight: 700;
-    padding: 8px 12px;
-  }
-
-  .card-actions button.secondary {
-    border-color: #9aa7a3;
-    color: #263235;
-    background: #ffffff;
-  }
-
   .card-turn-actions {
     display: flex;
     align-items: center;
@@ -665,7 +655,6 @@
       flex-direction: column;
     }
 
-    .card-actions button,
     .card-turn-actions button.turn {
       width: 100%;
     }

--- a/src/components/InlineNumberEdit.svelte
+++ b/src/components/InlineNumberEdit.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { parseHpExpression, type CommittableEdit } from '$lib/hp-input';
+
+  export let value: number;
+  export let ariaLabel: string;
+  export let displayAriaLabel: string = ariaLabel;
+  export let placeholder: string = '';
+  export let emptyDisplay: string | undefined = undefined;
+  export let displayClass: string = '';
+  export let onCommit: (parsed: CommittableEdit) => void;
+
+  let editing = false;
+  let buffer = '';
+  let invalid = false;
+  let inputEl: HTMLInputElement | null = null;
+  const hintId = `hp-edit-hint-${Math.random().toString(36).slice(2, 10)}`;
+
+  async function startEdit() {
+    buffer = String(value);
+    invalid = false;
+    editing = true;
+    await tick();
+    inputEl?.select();
+  }
+
+  function cancelEdit() {
+    editing = false;
+    buffer = '';
+    invalid = false;
+  }
+
+  function commitEdit() {
+    const parsed = parseHpExpression(buffer);
+    if (parsed.kind === 'cancel') {
+      cancelEdit();
+      return;
+    }
+    if (parsed.kind === 'invalid') {
+      invalid = true;
+      return;
+    }
+    editing = false;
+    buffer = '';
+    invalid = false;
+    onCommit(parsed);
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitEdit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEdit();
+    }
+  }
+</script>
+
+{#if editing}
+  <span class="inline-edit">
+    <input
+      bind:this={inputEl}
+      bind:value={buffer}
+      type="text"
+      inputmode="numeric"
+      autocomplete="off"
+      aria-label={ariaLabel}
+      aria-invalid={invalid}
+      aria-describedby={invalid ? hintId : undefined}
+      class:invalid
+      placeholder={placeholder}
+      onkeydown={onKeydown}
+      onblur={cancelEdit}
+    />
+    {#if invalid}
+      <span id={hintId} class="hint" role="status">use 42, +3, or −5</span>
+    {/if}
+  </span>
+{:else}
+  <button
+    type="button"
+    class="display {displayClass}"
+    aria-label={displayAriaLabel}
+    onclick={startEdit}
+  >
+    {#if value === 0 && emptyDisplay !== undefined}
+      {emptyDisplay}
+    {:else}
+      {value}
+    {/if}
+  </button>
+{/if}
+
+<style>
+  .inline-edit {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  input {
+    width: 5ch;
+    padding: 1px 4px;
+    font: inherit;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    border: 1px solid var(--input-border, #888);
+    border-radius: 3px;
+    background: var(--input-bg, #fff);
+    color: inherit;
+  }
+
+  input.invalid {
+    border-color: #c0392b;
+    outline: 2px solid rgba(192, 57, 43, 0.25);
+    outline-offset: 0;
+  }
+
+  .hint {
+    font-size: 0.75em;
+    color: #c0392b;
+    line-height: 1;
+  }
+
+  .display {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 3px;
+    text-decoration-color: rgba(0, 0, 0, 0.25);
+  }
+
+  .display:hover,
+  .display:focus-visible {
+    text-decoration-color: currentColor;
+  }
+
+  .display:focus-visible {
+    outline: 2px solid var(--focus, #2c7be5);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+</style>

--- a/src/lib/hp-input.test.ts
+++ b/src/lib/hp-input.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { parseHpExpression, resolveHpEdit } from './hp-input';
+
+describe('parseHpExpression', () => {
+  describe('cancel', () => {
+    it('treats empty string as cancel', () => {
+      expect(parseHpExpression('')).toEqual({ kind: 'cancel' });
+    });
+
+    it('treats whitespace-only input as cancel', () => {
+      expect(parseHpExpression('   ')).toEqual({ kind: 'cancel' });
+      expect(parseHpExpression('\t')).toEqual({ kind: 'cancel' });
+    });
+  });
+
+  describe('set', () => {
+    it('parses bare positive integer as set', () => {
+      expect(parseHpExpression('42')).toEqual({ kind: 'set', n: 42 });
+    });
+
+    it('parses zero as set 0', () => {
+      expect(parseHpExpression('0')).toEqual({ kind: 'set', n: 0 });
+    });
+
+    it('tolerates surrounding whitespace', () => {
+      expect(parseHpExpression('  42  ')).toEqual({ kind: 'set', n: 42 });
+    });
+  });
+
+  describe('add', () => {
+    it('parses +N as add', () => {
+      expect(parseHpExpression('+5')).toEqual({ kind: 'add', n: 5 });
+    });
+
+    it('parses +0 as add 0', () => {
+      expect(parseHpExpression('+0')).toEqual({ kind: 'add', n: 0 });
+    });
+
+    it('tolerates surrounding whitespace on add', () => {
+      expect(parseHpExpression('  +3  ')).toEqual({ kind: 'add', n: 3 });
+    });
+  });
+
+  describe('sub', () => {
+    it('parses -N as sub', () => {
+      expect(parseHpExpression('-7')).toEqual({ kind: 'sub', n: 7 });
+    });
+
+    it('parses -0 as sub 0', () => {
+      expect(parseHpExpression('-0')).toEqual({ kind: 'sub', n: 0 });
+    });
+
+    it('tolerates surrounding whitespace on sub', () => {
+      expect(parseHpExpression('  -4  ')).toEqual({ kind: 'sub', n: 4 });
+    });
+  });
+
+  describe('invalid', () => {
+    it('rejects decimals', () => {
+      expect(parseHpExpression('2.5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('-2.5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('+2.5')).toEqual({ kind: 'invalid' });
+    });
+
+    it('rejects arithmetic expressions', () => {
+      expect(parseHpExpression('5+3')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('5-3')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('-5+3')).toEqual({ kind: 'invalid' });
+    });
+
+    it('rejects double signs', () => {
+      expect(parseHpExpression('--5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('++5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('+-5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('-+5')).toEqual({ kind: 'invalid' });
+    });
+
+    it('rejects bare signs', () => {
+      expect(parseHpExpression('-')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('+')).toEqual({ kind: 'invalid' });
+    });
+
+    it('rejects letters and mixed garbage', () => {
+      expect(parseHpExpression('abc')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('5a')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('a5')).toEqual({ kind: 'invalid' });
+      expect(parseHpExpression('5 5')).toEqual({ kind: 'invalid' });
+    });
+  });
+});
+
+describe('resolveHpEdit', () => {
+  const baseCurrent = { hp: 17, maxHp: 30, tempHp: 0 };
+
+  describe('HP field', () => {
+    it('returns null for cancel', () => {
+      expect(resolveHpEdit('hp', { kind: 'cancel' }, baseCurrent)).toBeNull();
+    });
+
+    it('returns null for invalid', () => {
+      expect(resolveHpEdit('hp', { kind: 'invalid' }, baseCurrent)).toBeNull();
+    });
+
+    it('maps set N (under max) to SET_HP literal', () => {
+      expect(resolveHpEdit('hp', { kind: 'set', n: 25 }, baseCurrent)).toEqual({
+        type: 'SET_HP',
+        amount: 25
+      });
+    });
+
+    it('clamps set N above max to maxHp', () => {
+      expect(resolveHpEdit('hp', { kind: 'set', n: 999 }, baseCurrent)).toEqual({
+        type: 'SET_HP',
+        amount: 30
+      });
+    });
+
+    it('clamps set N exactly at max', () => {
+      expect(resolveHpEdit('hp', { kind: 'set', n: 30 }, baseCurrent)).toEqual({
+        type: 'SET_HP',
+        amount: 30
+      });
+    });
+
+    it('passes set 0 through (death decisions live in the domain)', () => {
+      expect(resolveHpEdit('hp', { kind: 'set', n: 0 }, baseCurrent)).toEqual({
+        type: 'SET_HP',
+        amount: 0
+      });
+    });
+
+    it('maps add N to APPLY_HEALING (reducer clamps at max)', () => {
+      expect(resolveHpEdit('hp', { kind: 'add', n: 5 }, baseCurrent)).toEqual({
+        type: 'APPLY_HEALING',
+        amount: 5
+      });
+    });
+
+    it('maps sub N to APPLY_DAMAGE (reducer absorbs tempHP first)', () => {
+      expect(resolveHpEdit('hp', { kind: 'sub', n: 7 }, baseCurrent)).toEqual({
+        type: 'APPLY_DAMAGE',
+        amount: 7
+      });
+    });
+
+    it('never produces a SET_TEMP_HP intent', () => {
+      const kinds = ['set', 'add', 'sub'] as const;
+      for (const kind of kinds) {
+        const intent = resolveHpEdit('hp', { kind, n: 3 }, baseCurrent);
+        expect(intent?.type).not.toBe('SET_TEMP_HP');
+      }
+    });
+  });
+
+  describe('TempHP field', () => {
+    it('returns null for cancel', () => {
+      expect(resolveHpEdit('tempHp', { kind: 'cancel' }, baseCurrent)).toBeNull();
+    });
+
+    it('returns null for invalid', () => {
+      expect(resolveHpEdit('tempHp', { kind: 'invalid' }, baseCurrent)).toBeNull();
+    });
+
+    it('maps set N to SET_TEMP_HP literal', () => {
+      expect(resolveHpEdit('tempHp', { kind: 'set', n: 5 }, baseCurrent)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 5
+      });
+    });
+
+    it('maps set 0 to SET_TEMP_HP 0 (clear tempHP)', () => {
+      const current = { hp: 17, maxHp: 30, tempHp: 8 };
+      expect(resolveHpEdit('tempHp', { kind: 'set', n: 0 }, current)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 0
+      });
+    });
+
+    it('maps add N to literal current + N (no PF2e max-stack rule)', () => {
+      const current = { hp: 17, maxHp: 30, tempHp: 3 };
+      expect(resolveHpEdit('tempHp', { kind: 'add', n: 5 }, current)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 8
+      });
+    });
+
+    it('maps add N from zero tempHP to N', () => {
+      expect(resolveHpEdit('tempHp', { kind: 'add', n: 5 }, baseCurrent)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 5
+      });
+    });
+
+    it('maps sub N to current - N', () => {
+      const current = { hp: 17, maxHp: 30, tempHp: 8 };
+      expect(resolveHpEdit('tempHp', { kind: 'sub', n: 5 }, current)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 3
+      });
+    });
+
+    it('clamps sub N at 0 when N exceeds current tempHP', () => {
+      const current = { hp: 17, maxHp: 30, tempHp: 3 };
+      expect(resolveHpEdit('tempHp', { kind: 'sub', n: 5 }, current)).toEqual({
+        type: 'SET_TEMP_HP',
+        amount: 0
+      });
+    });
+
+    it('only ever produces SET_TEMP_HP (never touches HP)', () => {
+      const kinds = ['set', 'add', 'sub'] as const;
+      for (const kind of kinds) {
+        const intent = resolveHpEdit('tempHp', { kind, n: 3 }, baseCurrent);
+        expect(intent?.type).toBe('SET_TEMP_HP');
+      }
+    });
+  });
+});

--- a/src/lib/hp-input.ts
+++ b/src/lib/hp-input.ts
@@ -1,0 +1,70 @@
+export type ParsedHpEdit =
+  | { kind: 'cancel' }
+  | { kind: 'invalid' }
+  | { kind: 'set'; n: number }
+  | { kind: 'add'; n: number }
+  | { kind: 'sub'; n: number };
+
+export type CommittableEdit = Extract<ParsedHpEdit, { kind: 'set' | 'add' | 'sub' }>;
+
+export type HpEditField = 'hp' | 'tempHp';
+
+export type HpEditIntent =
+  | { type: 'SET_HP'; amount: number }
+  | { type: 'APPLY_HEALING'; amount: number }
+  | { type: 'APPLY_DAMAGE'; amount: number }
+  | { type: 'SET_TEMP_HP'; amount: number };
+
+export interface HpEditCurrent {
+  hp: number;
+  maxHp: number;
+  tempHp: number;
+}
+
+const SET_RE = /^(\d+)$/;
+const ADD_RE = /^\+(\d+)$/;
+const SUB_RE = /^-(\d+)$/;
+
+export function parseHpExpression(raw: string): ParsedHpEdit {
+  const trimmed = raw.trim();
+  if (trimmed === '') return { kind: 'cancel' };
+
+  const setMatch = SET_RE.exec(trimmed);
+  if (setMatch) return { kind: 'set', n: Number(setMatch[1]) };
+
+  const addMatch = ADD_RE.exec(trimmed);
+  if (addMatch) return { kind: 'add', n: Number(addMatch[1]) };
+
+  const subMatch = SUB_RE.exec(trimmed);
+  if (subMatch) return { kind: 'sub', n: Number(subMatch[1]) };
+
+  return { kind: 'invalid' };
+}
+
+export function resolveHpEdit(
+  field: HpEditField,
+  parsed: ParsedHpEdit,
+  current: HpEditCurrent
+): HpEditIntent | null {
+  if (parsed.kind === 'cancel' || parsed.kind === 'invalid') return null;
+
+  if (field === 'hp') {
+    switch (parsed.kind) {
+      case 'set':
+        return { type: 'SET_HP', amount: Math.min(parsed.n, current.maxHp) };
+      case 'add':
+        return { type: 'APPLY_HEALING', amount: parsed.n };
+      case 'sub':
+        return { type: 'APPLY_DAMAGE', amount: parsed.n };
+    }
+  }
+
+  switch (parsed.kind) {
+    case 'set':
+      return { type: 'SET_TEMP_HP', amount: parsed.n };
+    case 'add':
+      return { type: 'SET_TEMP_HP', amount: current.tempHp + parsed.n };
+    case 'sub':
+      return { type: 'SET_TEMP_HP', amount: Math.max(current.tempHp - parsed.n, 0) };
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,11 @@
     type ManualCombatantInput,
     type TemplateAdjustmentChoice
   } from '$lib/encounter-app';
+  import {
+    resolveHpEdit,
+    type CommittableEdit,
+    type HpEditField
+  } from '$lib/hp-input';
 
   const conditionOptions = listConditionOptions();
 
@@ -27,8 +32,6 @@
   let feedback: FeedbackEntry[] = [];
   let commandCounter = 1;
   let combatantCounter = 1;
-  let hpAmount = 5;
-  let tempHpAmount = 0;
 
   $: orderedCombatants = encounter.initiative.order
     .map((id) => encounter.combatants[id])
@@ -45,10 +48,6 @@
 
   function nextCommandId() {
     return `cmd-${commandCounter++}`;
-  }
-
-  function numberOrDefault(value: number, fallback: number) {
-    return Number.isFinite(value) ? Math.trunc(value) : fallback;
   }
 
   function addCombatant(combatant: CombatantState) {
@@ -105,20 +104,18 @@
     runCommand(toCommand('START_ENCOUNTER', undefined, nextCommandId()));
   }
 
-  function applyDamage(combatantId: string) {
-    runCommand(toCommand('APPLY_DAMAGE', { combatantId, amount: numberOrDefault(hpAmount, 1) }, nextCommandId()));
-  }
-
-  function applyHealing(combatantId: string) {
-    runCommand(toCommand('APPLY_HEALING', { combatantId, amount: numberOrDefault(hpAmount, 1) }, nextCommandId()));
-  }
-
-  function setTempHp(combatantId: string) {
-    runCommand(toCommand('SET_TEMP_HP', { combatantId, amount: numberOrDefault(tempHpAmount, 0) }, nextCommandId()));
-  }
-
-  function setHp(combatantId: string, amount: number) {
-    runCommand(toCommand('SET_HP', { combatantId, amount }, nextCommandId()));
+  function applyHpEdit(combatantId: string, field: HpEditField, parsed: CommittableEdit) {
+    const combatant = encounter.combatants[combatantId];
+    if (!combatant) return;
+    const intent = resolveHpEdit(field, parsed, {
+      hp: combatant.currentHp,
+      maxHp: combatant.baseStats.hp,
+      tempHp: combatant.tempHp
+    });
+    if (!intent) return;
+    runCommand(
+      toCommand(intent.type, { combatantId, amount: intent.amount }, nextCommandId())
+    );
   }
 
   function endTurn(_combatantId: string) {
@@ -205,17 +202,6 @@
     />
 
     <section class="combat-column" aria-label="Combatants">
-      <div class="quick-controls">
-        <label>
-          HP Amount
-          <input type="number" min="1" bind:value={hpAmount} />
-        </label>
-        <label>
-          Temp HP
-          <input type="number" min="0" bind:value={tempHpAmount} />
-        </label>
-      </div>
-
       <div class="cards">
         {#each orderedCombatants as combatant (combatant.id)}
           <CombatantCard
@@ -225,10 +211,7 @@
             actions={combatantCardActions(encounter, combatant.id)}
             appliedEffectsView={viewAppliedEffects(combatant, encounter)}
             {conditionOptions}
-            onDamage={applyDamage}
-            onHeal={applyHealing}
-            onSetTemp={setTempHp}
-            onSetZero={(id) => setHp(id, 0)}
+            onHpEdit={applyHpEdit}
             onEndTurn={endTurn}
             onMarkReactionUsed={markReactionUsed}
             onMarkDead={markDead}
@@ -274,37 +257,6 @@
     gap: 14px;
   }
 
-  .quick-controls {
-    display: flex;
-    align-items: center;
-    justify-content: start;
-    gap: 10px;
-    border: 1px solid #cfd6d1;
-    border-radius: 8px;
-    background: #fbfcfa;
-    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
-    padding: 14px;
-  }
-
-  .quick-controls label {
-    display: grid;
-    gap: 5px;
-    color: #526061;
-    font-size: 12px;
-    font-weight: 700;
-    max-width: 140px;
-  }
-
-  .quick-controls input {
-    min-width: 0;
-    border: 1px solid #b8c3be;
-    border-radius: 6px;
-    background: #ffffff;
-    color: #1d2528;
-    padding: 9px 10px;
-    font: inherit;
-  }
-
   .cards {
     display: grid;
     gap: 10px;
@@ -333,11 +285,6 @@
     .workspace > :nth-child(3),
     .workspace > :nth-child(4) {
       grid-column: auto;
-    }
-
-    .quick-controls {
-      align-items: stretch;
-      flex-direction: column;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
Redesigns Slice 5 (#39) from per-card Damage/Heal/Set Temp/Set 0 buttons to a single click-to-edit affordance on each HP value. Click the HP (or Temp HP) number, type a short expression, press Enter:

| Input | HP field | Temp HP field |
|---|---|---|
| `42` | `SET_HP` (clamped at max) | `SET_TEMP_HP 42` |
| `+5` | `APPLY_HEALING 5` (reducer caps at max) | `SET_TEMP_HP current+5` (literal add) |
| `-5` | `APPLY_DAMAGE 5` (reducer chews tempHP first) | `SET_TEMP_HP max(current-5, 0)` |
| empty / `Esc` / blur | cancel | cancel |
| invalid | red border, inline hint, Enter is a no-op | same |

Reuses the existing four domain commands; **no domain/reducer changes**.

## Design notes (confirmed during brainstorming)
- HP `set N` clamps at `baseStats.hp` in the orchestrator so GMs can type the post-heal total without doing math. (`SET_HP` reducer is still literal.)
- Temp HP `+N` is literal `current + N`, not the strict PF2e "doesn't stack, take max" rule, by design — predictable and lets GMs `set N` for the strict rule.
- Temp HP `-N` is kept (manual override for "buff that granted tempHP wears off").
- HP-field operations never touch `tempHp`; tempHP-field operations never touch `currentHp`.
- The shared HP-amount toolbar at the top of the combatants column is removed (was redundant with the card-level controls).

## Component-level test
Deliberately skipped — the repo has no Svelte component test infra (`@testing-library/svelte`, `jsdom`) and adding it for one slice is out of scope. The interaction logic is fully covered by 34 pure-TS tests on the parser + resolver, plus the manual end-to-end pass below.

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 151/151 pass (added 34 new tests in `src/lib/hp-input.test.ts`)
- [x] `npm run audit` — clean at moderate threshold
- [x] `npm run build` — static build succeeds
- [x] Manual E2E on a Goblin Warrior (HP 18 max):
  - [x] `-5` → HP 18→13 (APPLY_DAMAGE)
  - [x] `+5` → HP 13→18 (APPLY_HEALING, capped at max by reducer)
  - [x] `25` (set above max) → clamped to 18
  - [x] tempHP empty → `5` → tempHP 0→5, "temp" label appears
  - [x] tempHP `+3` → 5→8 (literal add)
  - [x] HP `-7` with tempHP=8 → tempHP 8→1, HP unchanged at 18 (reducer absorbs)
  - [x] HP `abc` → red border + hint "use 42, +3, or −5", no commit
  - [x] `Esc` after invalid → returns to display, no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)