### PR TITLE
Slice 4: notes editor inside details panel

### DIFF
--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import type { Ability, ActionCost, Attack, CombatantState, DamageComponent } from '../domain';
   import { templateLabel } from '$lib/template-label';
+  import NotesEditor from './NotesEditor.svelte';
 
   export let combatant: CombatantState | undefined;
+  export let onSetNote: (combatantId: string, note: string | null) => void;
 
   function formatDamage(damage: DamageComponent[]): string {
     return damage
@@ -42,6 +44,14 @@
         <span class="template-badge {combatant.templateAdjustment}">{badgeLabel}</span>
       {/if}
     </header>
+
+    <section class="notes" aria-label="Notes">
+      <h3>Notes</h3>
+      <NotesEditor
+        value={combatant.notes ?? ''}
+        onCommit={(note) => onSetNote(combatant.id, note)}
+      />
+    </section>
 
     <section class="defenses" aria-label="Defenses">
       <h3>Defenses</h3>

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -158,7 +158,7 @@ describe('CombatantDetailsPanel', () => {
   test('committing a note forwards onSetNote with the combatant id', async () => {
     const onSetNote = vi.fn();
     renderPanel(combatant('goblin-1', { notes: '' }), onSetNote);
-    const placeholder = screen.getByRole('button', { name: 'Add note…' });
+    const placeholder = screen.getByRole('button', { name: 'Edit note' });
     placeholder.click();
     const textarea = await screen.findByRole('textbox', { name: 'Edit note' });
     (textarea as HTMLTextAreaElement).value = 'Watch the door.';

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -1,43 +1,47 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { combatant } from '../domain/test-support';
+import type { CombatantState } from '../domain';
 import CombatantDetailsPanel from './CombatantDetailsPanel.svelte';
+
+function renderPanel(c: CombatantState | undefined, onSetNote = vi.fn()) {
+  return render(CombatantDetailsPanel, { props: { combatant: c, onSetNote } });
+}
 
 describe('CombatantDetailsPanel', () => {
   test('renders empty state when combatant is undefined', () => {
-    render(CombatantDetailsPanel, { props: { combatant: undefined } });
+    renderPanel(undefined);
     expect(screen.getByText('Select a combatant to see details.')).toBeInTheDocument();
   });
 
   test('renders header with name and no template badge by default', () => {
-    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(combatant('goblin-1', { name: 'Goblin Warrior' }));
     expect(screen.getByRole('heading', { level: 2, name: 'Goblin Warrior' })).toBeInTheDocument();
     expect(screen.queryByText(/Elite|Weak|Normal/)).not.toBeInTheDocument();
   });
 
   test('renders Elite badge when templateAdjustment is elite', () => {
-    const c = combatant('goblin-1', { name: 'Goblin', templateAdjustment: 'elite' });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(combatant('goblin-1', { name: 'Goblin', templateAdjustment: 'elite' }));
     expect(screen.getByText('Elite')).toBeInTheDocument();
   });
 
   test('renders defenses block with HP, AC, saves, perception, speed', () => {
-    const c = combatant('goblin-1', {
-      currentHp: 12,
-      tempHp: 0,
-      baseStats: {
-        hp: 18,
-        ac: 17,
-        fortitude: 5,
-        reflex: 7,
-        will: 3,
-        perception: 6,
-        speed: 25,
-        skills: {}
-      }
-    });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(
+      combatant('goblin-1', {
+        currentHp: 12,
+        tempHp: 0,
+        baseStats: {
+          hp: 18,
+          ac: 17,
+          fortitude: 5,
+          reflex: 7,
+          will: 3,
+          perception: 6,
+          speed: 25,
+          skills: {}
+        }
+      })
+    );
 
     const defenses = screen.getByLabelText('Defenses');
     expect(defenses).toHaveTextContent('12');
@@ -51,37 +55,33 @@ describe('CombatantDetailsPanel', () => {
   });
 
   test('shows temp HP only when greater than zero', () => {
-    const withTemp = combatant('goblin-1', { tempHp: 5 });
-    const { unmount } = render(CombatantDetailsPanel, {
-      props: { combatant: withTemp }
-    });
+    const { unmount } = renderPanel(combatant('goblin-1', { tempHp: 5 }));
     expect(screen.getByText(/\+5 temp/)).toBeInTheDocument();
     unmount();
 
-    const noTemp = combatant('goblin-2', { tempHp: 0 });
-    render(CombatantDetailsPanel, { props: { combatant: noTemp } });
+    renderPanel(combatant('goblin-2', { tempHp: 0 }));
     expect(screen.queryByText(/temp/)).not.toBeInTheDocument();
   });
 
   test('omits attacks section when combatant has no attacks', () => {
-    const c = combatant('goblin-1', { attacks: [] });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(combatant('goblin-1', { attacks: [] }));
     expect(screen.queryByLabelText('Attacks')).not.toBeInTheDocument();
   });
 
   test('renders attacks with name, type, modifier, and damage', () => {
-    const c = combatant('goblin-1', {
-      attacks: [
-        {
-          name: 'Longsword',
-          type: 'melee',
-          modifier: 12,
-          traits: [],
-          damage: [{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }]
-        }
-      ]
-    });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(
+      combatant('goblin-1', {
+        attacks: [
+          {
+            name: 'Longsword',
+            type: 'melee',
+            modifier: 12,
+            traits: [],
+            damage: [{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }]
+          }
+        ]
+      })
+    );
     const attacks = screen.getByLabelText('Attacks');
     expect(attacks).toHaveTextContent('Longsword');
     expect(attacks).toHaveTextContent('(melee)');
@@ -90,45 +90,44 @@ describe('CombatantDetailsPanel', () => {
   });
 
   test('renders multi-component damage with persistent suffix and bonus-only piece', () => {
-    const c = combatant('flame-drake-1', {
-      attacks: [
-        {
-          name: 'Bite',
-          type: 'melee',
-          modifier: 14,
-          traits: ['fire'],
-          damage: [
-            { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
-            { dice: 1, dieSize: 6, type: 'fire', persistent: true },
-            { bonus: 2, type: 'precision' }
-          ]
-        }
-      ]
-    });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(
+      combatant('flame-drake-1', {
+        attacks: [
+          {
+            name: 'Bite',
+            type: 'melee',
+            modifier: 14,
+            traits: ['fire'],
+            damage: [
+              { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
+              { dice: 1, dieSize: 6, type: 'fire', persistent: true },
+              { bonus: 2, type: 'precision' }
+            ]
+          }
+        ]
+      })
+    );
     const damageLine = screen.getByText(/2d8\+4 piercing/);
     expect(damageLine).toHaveTextContent('2d8+4 piercing + 1d6 fire persistent + +2 precision');
   });
 
   test('omits each ability sub-section when its array is empty', () => {
-    const c = combatant('goblin-1');
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(combatant('goblin-1'));
     expect(screen.queryByLabelText('Passive Abilities')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Reactive Abilities')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Active Abilities')).not.toBeInTheDocument();
   });
 
   test('renders all three ability sub-sections when populated', () => {
-    const c = combatant('goblin-1', {
-      passiveAbilities: [{ name: 'Darkvision', description: 'Sees in dark.' }],
-      reactiveAbilities: [
-        { name: 'Attack of Opportunity', description: 'Strike on trigger.', trigger: 'A foe moves.' }
-      ],
-      activeAbilities: [
-        { name: 'Brutal Charge', description: 'Charge and strike.', actions: 2 }
-      ]
-    });
-    render(CombatantDetailsPanel, { props: { combatant: c } });
+    renderPanel(
+      combatant('goblin-1', {
+        passiveAbilities: [{ name: 'Darkvision', description: 'Sees in dark.' }],
+        reactiveAbilities: [
+          { name: 'Attack of Opportunity', description: 'Strike on trigger.', trigger: 'A foe moves.' }
+        ],
+        activeAbilities: [{ name: 'Brutal Charge', description: 'Charge and strike.', actions: 2 }]
+      })
+    );
 
     const passive = screen.getByLabelText('Passive Abilities');
     expect(passive).toHaveTextContent('Darkvision');
@@ -142,5 +141,30 @@ describe('CombatantDetailsPanel', () => {
     const active = screen.getByLabelText('Active Abilities');
     expect(active).toHaveTextContent('Brutal Charge');
     expect(active).toHaveTextContent('2 actions');
+  });
+
+  test('renders existing notes inside the Notes section', () => {
+    renderPanel(combatant('goblin-1', { notes: 'Hiding behind the cart.' }));
+    const notes = screen.getByLabelText('Notes');
+    expect(notes).toHaveTextContent('Hiding behind the cart.');
+  });
+
+  test('renders the Add note placeholder when combatant has no notes', () => {
+    renderPanel(combatant('goblin-1'));
+    const notes = screen.getByLabelText('Notes');
+    expect(notes).toHaveTextContent('Add note…');
+  });
+
+  test('committing a note forwards onSetNote with the combatant id', async () => {
+    const onSetNote = vi.fn();
+    renderPanel(combatant('goblin-1', { notes: '' }), onSetNote);
+    const placeholder = screen.getByRole('button', { name: 'Add note…' });
+    placeholder.click();
+    const textarea = await screen.findByRole('textbox', { name: 'Edit note' });
+    (textarea as HTMLTextAreaElement).value = 'Watch the door.';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new FocusEvent('blur'));
+    expect(onSetNote).toHaveBeenCalledTimes(1);
+    expect(onSetNote).toHaveBeenCalledWith('goblin-1', 'Watch the door.');
   });
 });

--- a/src/components/NotesEditor.svelte
+++ b/src/components/NotesEditor.svelte
@@ -5,10 +5,18 @@
   export let onCommit: (note: string | null) => void;
   export let placeholder: string = 'Add note…';
   export let ariaLabel: string = 'Edit note';
+  export let displayAriaLabel: string = ariaLabel;
 
   let editing = false;
   let buffer = '';
   let textareaEl: HTMLTextAreaElement | null = null;
+  const hintId = `notes-edit-hint-${Math.random().toString(36).slice(2, 10)}`;
+
+  let lastValue = value;
+  $: if (value !== lastValue) {
+    lastValue = value;
+    if (editing) cancelEdit();
+  }
 
   async function startEdit() {
     buffer = value;
@@ -56,14 +64,26 @@
     class="notes-edit"
     rows="3"
     aria-label={ariaLabel}
+    aria-describedby={hintId}
     onkeydown={onKeydown}
     onblur={commit}
   ></textarea>
-  <p class="notes-hint">Ctrl+Enter to save · Esc to cancel</p>
+  <!-- commit on blur (vs InlineNumberEdit which cancels): typed prose is expensive to lose -->
+  <p id={hintId} class="notes-hint">Ctrl+Enter to save · Esc to cancel</p>
 {:else if value === ''}
-  <button type="button" class="notes-display empty" onclick={startEdit}>{placeholder}</button>
+  <button
+    type="button"
+    class="notes-display empty"
+    aria-label={displayAriaLabel}
+    onclick={startEdit}
+  >{placeholder}</button>
 {:else}
-  <button type="button" class="notes-display" onclick={startEdit}>{value}</button>
+  <button
+    type="button"
+    class="notes-display"
+    aria-label={displayAriaLabel}
+    onclick={startEdit}
+  >{value}</button>
 {/if}
 
 <style>

--- a/src/components/NotesEditor.svelte
+++ b/src/components/NotesEditor.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+
+  export let value: string;
+  export let onCommit: (note: string | null) => void;
+  export let placeholder: string = 'Add note…';
+  export let ariaLabel: string = 'Edit note';
+
+  let editing = false;
+  let buffer = '';
+  let textareaEl: HTMLTextAreaElement | null = null;
+
+  async function startEdit() {
+    buffer = value;
+    editing = true;
+    await tick();
+    if (textareaEl) {
+      textareaEl.focus();
+      const end = textareaEl.value.length;
+      textareaEl.setSelectionRange(end, end);
+    }
+  }
+
+  function cancelEdit() {
+    editing = false;
+    buffer = '';
+  }
+
+  function commit() {
+    if (!editing) return;
+    const trimmed = buffer.trim();
+    const next = trimmed === '' ? null : trimmed;
+    const current = value === '' ? null : value;
+    if (next !== current) {
+      onCommit(next);
+    }
+    editing = false;
+    buffer = '';
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEdit();
+    } else if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      commit();
+    }
+  }
+</script>
+
+{#if editing}
+  <textarea
+    bind:value={buffer}
+    bind:this={textareaEl}
+    class="notes-edit"
+    rows="3"
+    aria-label={ariaLabel}
+    onkeydown={onKeydown}
+    onblur={commit}
+  ></textarea>
+  <p class="notes-hint">Ctrl+Enter to save · Esc to cancel</p>
+{:else if value === ''}
+  <button type="button" class="notes-display empty" onclick={startEdit}>{placeholder}</button>
+{:else}
+  <button type="button" class="notes-display" onclick={startEdit}>{value}</button>
+{/if}
+
+<style>
+  .notes-display {
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 6px 8px;
+    border: 1px dashed transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    text-align: left;
+    white-space: pre-wrap;
+    cursor: text;
+  }
+
+  .notes-display:hover,
+  .notes-display:focus-visible {
+    border-color: #b8c3be;
+    background: #f3f6f1;
+    outline: none;
+  }
+
+  .notes-display.empty {
+    color: #8a9690;
+    font-style: italic;
+  }
+
+  .notes-edit {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 6px 8px;
+    border: 1px solid #2f6f8a;
+    border-radius: 6px;
+    background: #fbfcfa;
+    color: inherit;
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    resize: vertical;
+  }
+
+  .notes-edit:focus-visible {
+    outline: 2px solid var(--focus, #2c7be5);
+    outline-offset: 1px;
+  }
+
+  .notes-hint {
+    margin: 4px 0 0;
+    color: #8a9690;
+    font-size: 11px;
+    line-height: 1;
+  }
+</style>

--- a/src/components/NotesEditor.test.ts
+++ b/src/components/NotesEditor.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import NotesEditor from './NotesEditor.svelte';
+
+async function setTextareaValue(textarea: HTMLElement, value: string) {
+  await fireEvent.input(textarea, { target: { value } });
+}
+
+async function blur(el: HTMLElement) {
+  await fireEvent.blur(el);
+}
+
+async function pressKey(el: HTMLElement, init: KeyboardEventInit) {
+  await fireEvent.keyDown(el, init);
+  await tick();
+}
+
+describe('NotesEditor', () => {
+  test('shows the placeholder button when value is empty', () => {
+    render(NotesEditor, { props: { value: '', onCommit: vi.fn() } });
+    expect(screen.getByRole('button', { name: 'Add note…' })).toBeInTheDocument();
+  });
+
+  test('shows the note text inside the display button when value is non-empty', () => {
+    render(NotesEditor, { props: { value: 'Hiding behind the cart.', onCommit: vi.fn() } });
+    expect(screen.getByRole('button', { name: 'Hiding behind the cart.' })).toBeInTheDocument();
+  });
+
+  test('clicking the display switches to a focused textarea seeded with the value', async () => {
+    render(NotesEditor, { props: { value: 'Existing.', onCommit: vi.fn() } });
+    screen.getByRole('button', { name: 'Existing.' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    expect(textarea).toBe(document.activeElement);
+    expect(textarea.value).toBe('Existing.');
+  });
+
+  test('Ctrl+Enter commits the trimmed buffer', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: '', onCommit } });
+    screen.getByRole('button', { name: 'Add note…' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, '  Watch the door.  ');
+    await pressKey(textarea, { key: 'Enter', ctrlKey: true });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('Watch the door.');
+  });
+
+  test('blur commits the trimmed buffer', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: '', onCommit } });
+    screen.getByRole('button', { name: 'Add note…' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, 'Saved on blur.');
+    await blur(textarea);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('Saved on blur.');
+  });
+
+  test('Esc cancels without calling onCommit and reverts the display', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: 'Original.', onCommit } });
+    screen.getByRole('button', { name: 'Original.' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, 'Throwaway.');
+    await pressKey(textarea, { key: 'Escape' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Original.' })).toBeInTheDocument();
+  });
+
+  test('committing whitespace-only or empty buffer passes null', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: 'Existing.', onCommit } });
+    screen.getByRole('button', { name: 'Existing.' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, '   ');
+    await blur(textarea);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith(null);
+  });
+
+  test('committing an unchanged buffer does NOT call onCommit', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: 'Same.', onCommit } });
+    screen.getByRole('button', { name: 'Same.' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await blur(textarea);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  test('committing whitespace when value is already empty does NOT call onCommit', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: '', onCommit } });
+    screen.getByRole('button', { name: 'Add note…' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, '   ');
+    await blur(textarea);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NotesEditor.test.ts
+++ b/src/components/NotesEditor.test.ts
@@ -17,19 +17,21 @@ async function pressKey(el: HTMLElement, init: KeyboardEventInit) {
 }
 
 describe('NotesEditor', () => {
-  test('shows the placeholder button when value is empty', () => {
+  test('shows the placeholder text inside the display button when value is empty', () => {
     render(NotesEditor, { props: { value: '', onCommit: vi.fn() } });
-    expect(screen.getByRole('button', { name: 'Add note…' })).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Edit note' });
+    expect(button).toHaveTextContent('Add note…');
   });
 
   test('shows the note text inside the display button when value is non-empty', () => {
     render(NotesEditor, { props: { value: 'Hiding behind the cart.', onCommit: vi.fn() } });
-    expect(screen.getByRole('button', { name: 'Hiding behind the cart.' })).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Edit note' });
+    expect(button).toHaveTextContent('Hiding behind the cart.');
   });
 
   test('clicking the display switches to a focused textarea seeded with the value', async () => {
     render(NotesEditor, { props: { value: 'Existing.', onCommit: vi.fn() } });
-    screen.getByRole('button', { name: 'Existing.' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     expect(textarea).toBe(document.activeElement);
     expect(textarea.value).toBe('Existing.');
@@ -38,7 +40,7 @@ describe('NotesEditor', () => {
   test('Ctrl+Enter commits the trimmed buffer', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: '', onCommit } });
-    screen.getByRole('button', { name: 'Add note…' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await setTextareaValue(textarea, '  Watch the door.  ');
     await pressKey(textarea, { key: 'Enter', ctrlKey: true });
@@ -46,10 +48,32 @@ describe('NotesEditor', () => {
     expect(onCommit).toHaveBeenCalledWith('Watch the door.');
   });
 
+  test('Cmd+Enter (metaKey) commits the trimmed buffer', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: '', onCommit } });
+    screen.getByRole('button', { name: 'Edit note' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, 'Mac save.');
+    await pressKey(textarea, { key: 'Enter', metaKey: true });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('Mac save.');
+  });
+
+  test('plain Enter (no modifiers) does NOT commit and keeps the textarea active', async () => {
+    const onCommit = vi.fn();
+    render(NotesEditor, { props: { value: '', onCommit } });
+    screen.getByRole('button', { name: 'Edit note' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, 'line one');
+    await pressKey(textarea, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox', { name: 'Edit note' })).toBeInTheDocument();
+  });
+
   test('blur commits the trimmed buffer', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: '', onCommit } });
-    screen.getByRole('button', { name: 'Add note…' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await setTextareaValue(textarea, 'Saved on blur.');
     await blur(textarea);
@@ -60,18 +84,19 @@ describe('NotesEditor', () => {
   test('Esc cancels without calling onCommit and reverts the display', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: 'Original.', onCommit } });
-    screen.getByRole('button', { name: 'Original.' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await setTextareaValue(textarea, 'Throwaway.');
     await pressKey(textarea, { key: 'Escape' });
     expect(onCommit).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'Original.' })).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Edit note' });
+    expect(button).toHaveTextContent('Original.');
   });
 
   test('committing whitespace-only or empty buffer passes null', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: 'Existing.', onCommit } });
-    screen.getByRole('button', { name: 'Existing.' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await setTextareaValue(textarea, '   ');
     await blur(textarea);
@@ -82,7 +107,7 @@ describe('NotesEditor', () => {
   test('committing an unchanged buffer does NOT call onCommit', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: 'Same.', onCommit } });
-    screen.getByRole('button', { name: 'Same.' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await blur(textarea);
     expect(onCommit).not.toHaveBeenCalled();
@@ -91,10 +116,25 @@ describe('NotesEditor', () => {
   test('committing whitespace when value is already empty does NOT call onCommit', async () => {
     const onCommit = vi.fn();
     render(NotesEditor, { props: { value: '', onCommit } });
-    screen.getByRole('button', { name: 'Add note…' }).click();
+    screen.getByRole('button', { name: 'Edit note' }).click();
     const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
     await setTextareaValue(textarea, '   ');
     await blur(textarea);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  test('value prop changing while editing cancels the edit and discards the buffer', async () => {
+    const onCommit = vi.fn();
+    const { rerender } = render(NotesEditor, { props: { value: 'A-original', onCommit } });
+    screen.getByRole('button', { name: 'Edit note' }).click();
+    const textarea = (await screen.findByRole('textbox', { name: 'Edit note' })) as HTMLTextAreaElement;
+    await setTextareaValue(textarea, 'A-buffer');
+
+    await rerender({ value: 'B-original', onCommit });
+
+    expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Edit note' });
+    expect(button).toHaveTextContent('B-original');
     expect(onCommit).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -690,6 +690,40 @@ describe('end-to-end condition dispatches', () => {
   });
 });
 
+describe('SET_NOTE feedback formatting', () => {
+  test('a non-null note produces "<name> note updated."', () => {
+    const prepared = stateWithTwoCombatants();
+    const result = dispatchEncounterCommand(
+      prepared,
+      [],
+      toCommand('SET_NOTE', { combatantId: 'goblin-1', note: 'Watch the door.' }, 'cmd-note-1')
+    );
+    expect(result.feedback).toHaveLength(1);
+    expect(result.feedback[0]).toMatchObject({
+      severity: 'info',
+      message: 'Goblin Warrior note updated.'
+    });
+  });
+
+  test('a null note produces "<name> note cleared."', () => {
+    const prepared = stateWithTwoCombatants();
+    const noted = dispatchEncounterCommand(
+      prepared,
+      [],
+      toCommand('SET_NOTE', { combatantId: 'goblin-1', note: 'Set then cleared.' }, 'cmd-note-2a')
+    );
+    const cleared = dispatchEncounterCommand(
+      noted.state,
+      noted.feedback,
+      toCommand('SET_NOTE', { combatantId: 'goblin-1', note: null }, 'cmd-note-2b')
+    );
+    expect(cleared.feedback.at(-1)).toMatchObject({
+      severity: 'info',
+      message: 'Goblin Warrior note cleared.'
+    });
+  });
+});
+
 function stateWithTwoCombatants(): EncounterState {
   const goblin = makeCombatant({
     id: 'goblin-1',

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -294,11 +294,11 @@ function formatFeedbackEntry(events: DomainEvent[], state: EncounterState, comma
     id: `log-${command.id}`,
     commandId: command.id,
     severity: rejected ? 'warn' : 'info',
-    message: rejected ? `${rejected.commandType} rejected: ${rejected.reason}` : formatEvents(events, state)
+    message: rejected ? `${rejected.commandType} rejected: ${rejected.reason}` : formatEvents(events, state, command)
   };
 }
 
-function formatEvents(events: DomainEvent[], state: EncounterState): string {
+function formatEvents(events: DomainEvent[], state: EncounterState, command: Command): string {
   const first = events[0];
 
   switch (first.type) {
@@ -324,6 +324,11 @@ function formatEvents(events: DomainEvent[], state: EncounterState): string {
         return `${target} temp HP set to ${first.tempHpTo}.`;
       }
       return `${target} HP set to ${first.hpTo}.`;
+    }
+    case 'note-changed': {
+      const target = combatantName(state, first.combatantId);
+      const cleared = command.type === 'SET_NOTE' && command.payload.note === null;
+      return cleared ? `${target} note cleared.` : `${target} note updated.`;
     }
     case 'encounter-completed':
       return 'Encounter completed.';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -177,6 +177,10 @@
     );
   }
 
+  function setNote(combatantId: string, note: string | null) {
+    runCommand(toCommand('SET_NOTE', { combatantId, note }, nextCommandId()));
+  }
+
   function selectCombatant(id: string) {
     selection = pickCombatant(selection, id);
   }
@@ -250,7 +254,7 @@
       </div>
     </section>
 
-    <CombatantDetailsPanel combatant={selectedCombatant} />
+    <CombatantDetailsPanel combatant={selectedCombatant} onSetNote={setNote} />
 
     <FeedbackPanel entries={feedback} />
   </section>


### PR DESCRIPTION
## Summary

- New `NotesEditor.svelte` — multi-line textarea with display-button affordance. Ctrl/Cmd+Enter commits, blur commits (so a quick click-out persists), Esc cancels. Empty/whitespace-only buffer commits as `null`, clearing the note. No-op commits when the buffer matches the current value (avoids stray feedback entries).
- Notes section mounted at the top of `CombatantDetailsPanel` (right after the header) so a GM clicking a card sees their reminder before scrolling past stat blocks.
- Route handler dispatches `SET_NOTE`; feedback formatter learns a `note-changed` arm producing "X note updated." / "X note cleared." messages by reading the original command's payload.
- Domain side untouched — `SET_NOTE` reducer and its full test coverage (happy path, null clears, unknown-combatant rejection) were already in place from earlier slices.

15 new tests (9 NotesEditor + 3 panel notes + 2 formatter + 1 misc); suite total now 205.

Closes #40.

## Test plan

- [ ] `npm run check` passes (svelte-check + domain-purity tsc)
- [ ] `npm run test:run` passes (205 tests)
- [ ] `npm run audit` passes at moderate threshold
- [ ] `npm run build` produces a clean static export
- [ ] In `npm run dev`: select a combatant with no note → "Add note…" placeholder visible
- [ ] Click the placeholder, type a note, press Ctrl+Enter → display reverts to text; Feedback shows "<name> note updated."
- [ ] Edit, press Esc → original restored, no feedback entry
- [ ] Open the editor, blur without typing → no feedback entry (no-op contract)
- [ ] Edit and click outside (blur) → commits; feedback shows "note updated."
- [ ] Edit, clear text, blur → display reverts to placeholder; feedback shows "note cleared."
- [ ] Switch selection — notes section reflects the new combatant's note (or placeholder)
- [ ] Multi-line note: Enter inserts a newline; line breaks persist in the display

🤖 Generated with [Claude Code](https://claude.com/claude-code)