### PR TITLE
Slice 9: Prompt resolution panel (#46)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,10 +37,10 @@ Active work is grouped into three parallel tracks. Within each track items are d
 Track A. Order: effect handlers first, then derived stacking, then prompts.
 
 - [x] Add built-in condition and persistent damage library. (Implemented in PR #31.)
-- [ ] Implement `APPLY_EFFECT`, `REMOVE_EFFECT`, value changes, and duration changes. (Issue #10. Unblocks #11, #12, and the conditions UI in #45.)
-- [ ] Implement implied effects and removal cascades. (Issue #10.)
-- [ ] Implement PF2e stacking derivation. (Issue #11. Depends on #10.)
-- [ ] Implement turn-boundary prompt generation. (Issue #12. Depends on #10 and #11.)
+- [x] Implement `APPLY_EFFECT`, `REMOVE_EFFECT`, value changes, and duration changes. (Issue #10.)
+- [x] Implement implied effects and removal cascades. (Issue #10.)
+- [x] Implement PF2e stacking derivation. (Issue #11.)
+- [x] Implement turn-boundary prompt generation. (Issue #12.)
 
 ## M4 Persistence and Import
 
@@ -57,16 +57,16 @@ Track C. Order: encounter persistence first so other persistence work can reuse 
 Track B. Slice numbering follows the umbrella issues #15 (combat screen) and #16 (prompt panel + log).
 
 - [x] Slice 1 — extract combatant UI into components. (Issue #28.)
-- [ ] Slice 3 — turn controls on combatant cards. (Issue #38.)
-- [ ] Slice 4a — merge initiative track into combatant cards. (Groundwork for Slice 4 details panel.)
-- [ ] Slice 4b — combatant details panel scaffolding + selection. (Groundwork for Slice 4 notes editor.)
-- [ ] Slice 4 — combatant notes UI inside details panel. (Issue #40.)
-- [ ] Slice 5 — per-card HP delta controls. (Issue #39.)
-- [ ] Slice 6 — dead/unconscious visual state. (Issue #43.)
+- [x] Slice 3 — turn controls on combatant cards. (Issue #38.)
+- [x] Slice 4a — merge initiative track into combatant cards. (Groundwork for Slice 4 details panel.)
+- [x] Slice 4b — combatant details panel scaffolding + selection. (Groundwork for Slice 4 notes editor.)
+- [x] Slice 4 — combatant notes UI inside details panel. (Issue #40.)
+- [x] Slice 5 — per-card HP delta controls. (Issue #39.)
+- [x] Slice 6 — dead/unconscious visual state. (Issue #43.)
 - [ ] Slice 7 — tablet-first responsive layout pass. (Issue #44.)
 - [ ] Slice 8 — append-only combat log component. (Issue #41.)
 - [ ] Slice 9 — prompt resolution panel. (Issue #46. Depends on #12.)
-- [ ] Slice 10 — conditions UI on combatant cards. (Issue #45. Depends on #10.)
+- [x] Slice 10 — conditions UI on combatant cards. (Issue #45.)
 - [ ] Manual static Cloudflare Pages deployment verification.
 
 ## M6 Spellcasting (deferred)

--- a/src/components/PromptResolutionPanel.svelte
+++ b/src/components/PromptResolutionPanel.svelte
@@ -1,0 +1,278 @@
+<script lang="ts">
+  import type {
+    CombatantState,
+    EncounterPhase,
+    Prompt,
+    PromptResolution,
+    TurnBoundarySuggestion
+  } from '../domain';
+
+  export let prompts: Prompt[];
+  export let combatantsById: Record<string, CombatantState>;
+  export let phase: EncounterPhase;
+  export let onResolve: (promptId: string, resolution: PromptResolution) => void;
+
+  $: focused = phase === 'RESOLVING' && prompts.length > 0;
+
+  let setValueDrafts: Record<string, number> = {};
+
+  $: setValueDrafts = reconcileDrafts(prompts, setValueDrafts);
+
+  function reconcileDrafts(
+    list: Prompt[],
+    current: Record<string, number>
+  ): Record<string, number> {
+    const next: Record<string, number> = {};
+    for (const p of list) {
+      if (!supportsSetValue(p.suggestionType)) continue;
+      next[p.id] = current[p.id] ?? defaultSetValue(p);
+    }
+    return next;
+  }
+
+  function defaultSetValue(p: Prompt): number {
+    return p.suggestedValue ?? p.currentValue ?? 0;
+  }
+
+  function supportsSetValue(s: TurnBoundarySuggestion): boolean {
+    return s.type === 'suggestDecrement' || s.type === 'promptResolution';
+  }
+
+  function showAccept(s: TurnBoundarySuggestion): boolean {
+    return s.type !== 'reminder';
+  }
+
+  function showRemove(s: TurnBoundarySuggestion): boolean {
+    return s.type !== 'reminder' && s.type !== 'suggestRemove';
+  }
+
+  function acceptLabel(s: TurnBoundarySuggestion): string {
+    switch (s.type) {
+      case 'suggestDecrement':
+        return `Decrement by ${s.amount}`;
+      case 'suggestRemove':
+        return 'Remove (expires)';
+      case 'confirmSustained':
+        return 'Confirm sustained';
+      case 'promptResolution':
+        return 'Accept';
+      default:
+        return 'Accept';
+    }
+  }
+
+  function boundaryLabel(p: Prompt): string {
+    const owner = combatantsById[p.boundary.ownerId]?.name ?? p.boundary.ownerId;
+    return p.boundary.type === 'turnEnd' ? `End of ${owner}'s turn` : `Start of ${owner}'s turn`;
+  }
+
+  function targetLabel(p: Prompt): string | null {
+    if (p.targetId === p.boundary.ownerId) return null;
+    return combatantsById[p.targetId]?.name ?? p.targetId;
+  }
+
+  function handleAccept(p: Prompt) {
+    onResolve(p.id, { type: 'accept' });
+  }
+
+  function handleDismiss(p: Prompt) {
+    onResolve(p.id, { type: 'dismiss' });
+  }
+
+  function handleRemove(p: Prompt) {
+    onResolve(p.id, { type: 'remove' });
+  }
+
+  function handleSetValue(p: Prompt) {
+    const value = setValueDrafts[p.id];
+    if (!Number.isFinite(value)) return;
+    onResolve(p.id, { type: 'setValue', value });
+  }
+</script>
+
+{#if focused}
+  <aside
+    class="panel prompt-panel"
+    aria-labelledby="prompt-resolution-title"
+    aria-live="polite"
+  >
+    <div class="panel-heading">
+      <h2 id="prompt-resolution-title">Awaiting GM resolution</h2>
+      <span>{prompts.length}</span>
+    </div>
+    <ol class="prompt-list">
+      {#each prompts as prompt (prompt.id)}
+        {@const target = targetLabel(prompt)}
+        <li class="prompt">
+          <div class="meta">
+            <span class="boundary">{boundaryLabel(prompt)}</span>
+            <span class="effect">{prompt.effectName}</span>
+            {#if target}
+              <span class="target">on {target}</span>
+            {/if}
+          </div>
+          <p class="description">{prompt.description}</p>
+          <div class="actions">
+            {#if showAccept(prompt.suggestionType)}
+              <button type="button" class="primary" on:click={() => handleAccept(prompt)}>
+                {acceptLabel(prompt.suggestionType)}
+              </button>
+            {/if}
+            {#if supportsSetValue(prompt.suggestionType)}
+              <span class="set-value">
+                <label>
+                  Set to
+                  <input
+                    type="number"
+                    aria-label={`Set value for ${prompt.effectName}`}
+                    bind:value={setValueDrafts[prompt.id]}
+                  />
+                </label>
+                <button type="button" on:click={() => handleSetValue(prompt)}>Set</button>
+              </span>
+            {/if}
+            <button type="button" on:click={() => handleDismiss(prompt)}>Dismiss</button>
+            {#if showRemove(prompt.suggestionType)}
+              <button type="button" class="danger" on:click={() => handleRemove(prompt)}>
+                Remove effect
+              </button>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ol>
+  </aside>
+{/if}
+
+<style>
+  .panel {
+    border: 1px solid #b6652e;
+    border-radius: 8px;
+    background: #fff7ee;
+    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
+    padding: 14px;
+    max-width: 1440px;
+    margin: 0 auto 18px;
+  }
+
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+    color: #6f3f16;
+  }
+
+  .panel-heading > span {
+    color: #6f3f16;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .prompt-list {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .prompt {
+    border-left: 4px solid #b6652e;
+    border-radius: 6px;
+    background: #ffffff;
+    padding: 10px 12px;
+    display: grid;
+    gap: 8px;
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 12px;
+    color: #627171;
+  }
+
+  .meta .boundary {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    color: #6f3f16;
+  }
+
+  .meta .effect {
+    color: #1d2528;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .description {
+    margin: 0;
+    font-size: 13px;
+    color: #1d2528;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .actions button {
+    border: 1px solid #cfd6d1;
+    background: #fbfcfa;
+    color: #1d2528;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+
+  .actions button.primary {
+    background: #b6652e;
+    border-color: #6f3f16;
+    color: #ffffff;
+  }
+
+  .actions button.danger {
+    background: #fbfcfa;
+    border-color: #b6652e;
+    color: #6f3f16;
+  }
+
+  .actions button:hover {
+    filter: brightness(0.96);
+  }
+
+  .set-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .set-value label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    color: #1d2528;
+  }
+
+  .set-value input {
+    width: 64px;
+    padding: 4px 6px;
+    border: 1px solid #cfd6d1;
+    border-radius: 6px;
+    font-size: 13px;
+  }
+</style>

--- a/src/components/PromptResolutionPanel.test.ts
+++ b/src/components/PromptResolutionPanel.test.ts
@@ -1,46 +1,15 @@
 import { describe, expect, test, vi, type Mock } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { combatant } from '../domain/test-support';
+import { combatant, prompt } from '../domain/test-support';
 import type {
   CombatantState,
   EncounterPhase,
   Prompt,
-  PromptResolution,
-  TurnBoundarySuggestion
+  PromptResolution
 } from '../domain';
 import PromptResolutionPanel from './PromptResolutionPanel.svelte';
 
 type ResolveHandler = (promptId: string, resolution: PromptResolution) => void;
-
-interface PromptOverrides {
-  id?: string;
-  ownerId?: string;
-  targetId?: string;
-  effectInstanceId?: string;
-  effectName?: string;
-  description?: string;
-  suggestionType: TurnBoundarySuggestion;
-  currentValue?: number;
-  suggestedValue?: number;
-  boundaryType?: 'turnEnd' | 'turnStart';
-}
-
-function makePrompt(overrides: PromptOverrides): Prompt {
-  return {
-    id: overrides.id ?? 'prompt-1',
-    boundary: {
-      type: overrides.boundaryType ?? 'turnEnd',
-      ownerId: overrides.ownerId ?? 'goblin-1'
-    },
-    targetId: overrides.targetId ?? overrides.ownerId ?? 'goblin-1',
-    effectInstanceId: overrides.effectInstanceId ?? 'instance-1',
-    effectName: overrides.effectName ?? 'Frightened',
-    description: overrides.description ?? 'Frightened decreases by 1 at end of turn.',
-    suggestionType: overrides.suggestionType,
-    currentValue: overrides.currentValue,
-    suggestedValue: overrides.suggestedValue
-  };
-}
 
 const goblin: CombatantState = combatant('goblin-1', { name: 'Goblin Warrior' });
 const fighter: CombatantState = combatant('fighter-1', { name: 'Fighter' });
@@ -75,7 +44,7 @@ describe('PromptResolutionPanel', () => {
 
   test('renders nothing when phase is not RESOLVING even if prompts exist', () => {
     const { container } = renderPanel({
-      prompts: [makePrompt({ suggestionType: { type: 'reminder', description: 'x' } })],
+      prompts: [prompt({ suggestionType: { type: 'reminder', description: 'x' } })],
       phase: 'ACTIVE'
     });
     expect(container.querySelector('aside')).toBeNull();
@@ -83,7 +52,7 @@ describe('PromptResolutionPanel', () => {
 
   test('renders focused container with aria-live and the GM heading when active', () => {
     renderPanel({
-      prompts: [makePrompt({ suggestionType: { type: 'reminder', description: 'x' } })]
+      prompts: [prompt({ suggestionType: { type: 'reminder', description: 'x' } })]
     });
     const region = screen.getByLabelText('Awaiting GM resolution');
     expect(region).toHaveAttribute('aria-live', 'polite');
@@ -94,7 +63,7 @@ describe('PromptResolutionPanel', () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           ownerId: 'goblin-1',
           targetId: 'fighter-1',
           effectName: 'Frightened',
@@ -112,8 +81,12 @@ describe('PromptResolutionPanel', () => {
     expect(screen.getByText('on Fighter')).toBeInTheDocument();
     expect(screen.getByText('Frightened decreases by 1.')).toBeInTheDocument();
 
-    const accept = screen.getByRole('button', { name: 'Decrement by 1' });
-    await fireEvent.click(accept);
+    expect(screen.getByRole('button', { name: 'Decrement by 1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove effect' })).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Decrement by 1' }));
     expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'accept' });
   });
 
@@ -121,7 +94,7 @@ describe('PromptResolutionPanel', () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           effectName: 'Slowed',
           suggestionType: { type: 'suggestRemove', description: 'Duration expired.' }
         })
@@ -142,7 +115,7 @@ describe('PromptResolutionPanel', () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           effectName: 'Persistent fire',
           suggestionType: { type: 'reminder', description: 'Roll a flat check.' }
         })
@@ -157,11 +130,12 @@ describe('PromptResolutionPanel', () => {
     expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'dismiss' });
   });
 
-  test('confirmSustained prompt: shows Confirm sustained, Dismiss, Remove effect', async () => {
+  test('confirmSustained prompt: shows turnStart boundary, Confirm sustained, Dismiss, Remove effect', async () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
+          boundaryType: 'turnStart',
           effectName: 'Bless (sustained)',
           suggestionType: { type: 'confirmSustained' }
         })
@@ -169,6 +143,7 @@ describe('PromptResolutionPanel', () => {
       onResolve
     });
 
+    expect(screen.getByText("Start of Goblin Warrior's turn")).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Confirm sustained' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Remove effect' })).toBeInTheDocument();
     expect(screen.queryByRole('spinbutton')).toBeNull();
@@ -181,7 +156,7 @@ describe('PromptResolutionPanel', () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           id: 'prompt-set',
           effectName: 'Frightened',
           suggestionType: { type: 'suggestDecrement', amount: 1 },
@@ -203,12 +178,12 @@ describe('PromptResolutionPanel', () => {
   test('renders multiple prompts in pendingPrompts order', () => {
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           id: 'prompt-a',
           effectName: 'Frightened',
           suggestionType: { type: 'suggestDecrement', amount: 1 }
         }),
-        makePrompt({
+        prompt({
           id: 'prompt-b',
           effectName: 'Persistent fire',
           suggestionType: { type: 'reminder', description: 'Roll flat check.' }
@@ -226,7 +201,7 @@ describe('PromptResolutionPanel', () => {
     const onResolve = vi.fn<ResolveHandler>();
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           suggestionType: { type: 'suggestDecrement', amount: 1 },
           currentValue: 1,
           suggestedValue: 0
@@ -242,7 +217,7 @@ describe('PromptResolutionPanel', () => {
   test('hides "on <target>" when target equals boundary owner', () => {
     renderPanel({
       prompts: [
-        makePrompt({
+        prompt({
           ownerId: 'goblin-1',
           targetId: 'goblin-1',
           suggestionType: { type: 'reminder', description: 'x' }
@@ -250,5 +225,124 @@ describe('PromptResolutionPanel', () => {
       ]
     });
     expect(screen.queryByText(/^on /)).toBeNull();
+  });
+
+  test('promptResolution prompt: shows Accept (default label), Set, Dismiss, Remove and dispatches setValue', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        prompt({
+          id: 'prompt-pr',
+          effectName: 'Persistent fire',
+          suggestionType: { type: 'promptResolution', description: 'Roll a flat check.' },
+          currentValue: 4,
+          suggestedValue: 4
+        })
+      ],
+      onResolve
+    });
+
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove effect' })).toBeInTheDocument();
+
+    const input = screen.getByRole('spinbutton', { name: 'Set value for Persistent fire' }) as HTMLInputElement;
+    expect(input.value).toBe('4');
+
+    await fireEvent.input(input, { target: { value: '2' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-pr', { type: 'setValue', value: 2 });
+  });
+
+  test('clearing the input snaps back to the default value (reconciliation restores suggestedValue)', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        prompt({
+          suggestionType: { type: 'suggestDecrement', amount: 1 },
+          currentValue: 2,
+          suggestedValue: 1
+        })
+      ],
+      onResolve
+    });
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '' } });
+    expect(input.value).toBe('1');
+    await fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'setValue', value: 1 });
+  });
+
+  test('setValue input falls back to currentValue when suggestedValue is undefined', () => {
+    renderPanel({
+      prompts: [
+        prompt({
+          suggestionType: { type: 'promptResolution', description: 'Roll.' },
+          currentValue: 3
+        })
+      ]
+    });
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('3');
+  });
+
+  test('setValue input falls back to 0 when both suggestedValue and currentValue are undefined', () => {
+    renderPanel({
+      prompts: [
+        prompt({
+          suggestionType: { type: 'promptResolution', description: 'Roll.' }
+        })
+      ]
+    });
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('0');
+  });
+
+  test('preserves typed drafts across re-renders and drops drafts for resolved prompts', async () => {
+    const promptA = prompt({
+      id: 'prompt-a',
+      effectName: 'Frightened',
+      suggestionType: { type: 'suggestDecrement', amount: 1 },
+      currentValue: 3,
+      suggestedValue: 2
+    });
+    const promptB = prompt({
+      id: 'prompt-b',
+      effectName: 'Persistent fire',
+      suggestionType: { type: 'promptResolution', description: 'Roll.' },
+      currentValue: 4,
+      suggestedValue: 4
+    });
+
+    const baseProps = {
+      combatantsById: combatants,
+      phase: 'RESOLVING' as EncounterPhase,
+      onResolve: vi.fn<ResolveHandler>() as unknown as ResolveHandler
+    };
+
+    const { rerender } = render(PromptResolutionPanel, {
+      props: { ...baseProps, prompts: [promptA] }
+    });
+
+    const inputA = screen.getByRole('spinbutton', { name: 'Set value for Frightened' }) as HTMLInputElement;
+    await fireEvent.input(inputA, { target: { value: '5' } });
+    expect(inputA.value).toBe('5');
+
+    await rerender({ ...baseProps, prompts: [promptA, promptB] });
+
+    const preservedA = screen.getByRole('spinbutton', { name: 'Set value for Frightened' }) as HTMLInputElement;
+    expect(preservedA.value).toBe('5');
+    const newB = screen.getByRole('spinbutton', { name: 'Set value for Persistent fire' }) as HTMLInputElement;
+    expect(newB.value).toBe('4');
+
+    await rerender({ ...baseProps, prompts: [promptB] });
+
+    expect(screen.queryByRole('spinbutton', { name: 'Set value for Frightened' })).toBeNull();
+    const stillB = screen.getByRole('spinbutton', { name: 'Set value for Persistent fire' }) as HTMLInputElement;
+    expect(stillB.value).toBe('4');
   });
 });

--- a/src/components/PromptResolutionPanel.test.ts
+++ b/src/components/PromptResolutionPanel.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test, vi, type Mock } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { combatant } from '../domain/test-support';
+import type {
+  CombatantState,
+  EncounterPhase,
+  Prompt,
+  PromptResolution,
+  TurnBoundarySuggestion
+} from '../domain';
+import PromptResolutionPanel from './PromptResolutionPanel.svelte';
+
+type ResolveHandler = (promptId: string, resolution: PromptResolution) => void;
+
+interface PromptOverrides {
+  id?: string;
+  ownerId?: string;
+  targetId?: string;
+  effectInstanceId?: string;
+  effectName?: string;
+  description?: string;
+  suggestionType: TurnBoundarySuggestion;
+  currentValue?: number;
+  suggestedValue?: number;
+  boundaryType?: 'turnEnd' | 'turnStart';
+}
+
+function makePrompt(overrides: PromptOverrides): Prompt {
+  return {
+    id: overrides.id ?? 'prompt-1',
+    boundary: {
+      type: overrides.boundaryType ?? 'turnEnd',
+      ownerId: overrides.ownerId ?? 'goblin-1'
+    },
+    targetId: overrides.targetId ?? overrides.ownerId ?? 'goblin-1',
+    effectInstanceId: overrides.effectInstanceId ?? 'instance-1',
+    effectName: overrides.effectName ?? 'Frightened',
+    description: overrides.description ?? 'Frightened decreases by 1 at end of turn.',
+    suggestionType: overrides.suggestionType,
+    currentValue: overrides.currentValue,
+    suggestedValue: overrides.suggestedValue
+  };
+}
+
+const goblin: CombatantState = combatant('goblin-1', { name: 'Goblin Warrior' });
+const fighter: CombatantState = combatant('fighter-1', { name: 'Fighter' });
+const combatants: Record<string, CombatantState> = {
+  'goblin-1': goblin,
+  'fighter-1': fighter
+};
+
+function renderPanel(props: {
+  prompts: Prompt[];
+  phase?: EncounterPhase;
+  combatantsById?: Record<string, CombatantState>;
+  onResolve?: Mock<ResolveHandler>;
+}) {
+  const onResolve: Mock<ResolveHandler> = props.onResolve ?? vi.fn<ResolveHandler>();
+  const utils = render(PromptResolutionPanel, {
+    props: {
+      prompts: props.prompts,
+      combatantsById: props.combatantsById ?? combatants,
+      phase: props.phase ?? 'RESOLVING',
+      onResolve: onResolve as unknown as ResolveHandler
+    }
+  });
+  return { ...utils, onResolve };
+}
+
+describe('PromptResolutionPanel', () => {
+  test('renders nothing when there are no pending prompts', () => {
+    const { container } = renderPanel({ prompts: [] });
+    expect(container.querySelector('aside')).toBeNull();
+  });
+
+  test('renders nothing when phase is not RESOLVING even if prompts exist', () => {
+    const { container } = renderPanel({
+      prompts: [makePrompt({ suggestionType: { type: 'reminder', description: 'x' } })],
+      phase: 'ACTIVE'
+    });
+    expect(container.querySelector('aside')).toBeNull();
+  });
+
+  test('renders focused container with aria-live and the GM heading when active', () => {
+    renderPanel({
+      prompts: [makePrompt({ suggestionType: { type: 'reminder', description: 'x' } })]
+    });
+    const region = screen.getByLabelText('Awaiting GM resolution');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByRole('heading', { level: 2, name: 'Awaiting GM resolution' })).toBeInTheDocument();
+  });
+
+  test('suggestDecrement prompt: shows owner boundary, target name, description, and four resolution controls', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          ownerId: 'goblin-1',
+          targetId: 'fighter-1',
+          effectName: 'Frightened',
+          description: 'Frightened decreases by 1.',
+          suggestionType: { type: 'suggestDecrement', amount: 1 },
+          currentValue: 2,
+          suggestedValue: 1
+        })
+      ],
+      onResolve
+    });
+
+    expect(screen.getByText("End of Goblin Warrior's turn")).toBeInTheDocument();
+    expect(screen.getByText('Frightened')).toBeInTheDocument();
+    expect(screen.getByText('on Fighter')).toBeInTheDocument();
+    expect(screen.getByText('Frightened decreases by 1.')).toBeInTheDocument();
+
+    const accept = screen.getByRole('button', { name: 'Decrement by 1' });
+    await fireEvent.click(accept);
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'accept' });
+  });
+
+  test('suggestRemove prompt: shows Accept and Dismiss only (no Set, no Remove)', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          effectName: 'Slowed',
+          suggestionType: { type: 'suggestRemove', description: 'Duration expired.' }
+        })
+      ],
+      onResolve
+    });
+
+    expect(screen.getByRole('button', { name: 'Remove (expires)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove effect' })).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove (expires)' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'accept' });
+  });
+
+  test('reminder prompt: shows only Dismiss', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          effectName: 'Persistent fire',
+          suggestionType: { type: 'reminder', description: 'Roll a flat check.' }
+        })
+      ],
+      onResolve
+    });
+
+    expect(screen.queryByRole('button', { name: /Decrement|Accept|Confirm|Remove/ })).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    const dismiss = screen.getByRole('button', { name: 'Dismiss' });
+    await fireEvent.click(dismiss);
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'dismiss' });
+  });
+
+  test('confirmSustained prompt: shows Confirm sustained, Dismiss, Remove effect', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          effectName: 'Bless (sustained)',
+          suggestionType: { type: 'confirmSustained' }
+        })
+      ],
+      onResolve
+    });
+
+    expect(screen.getByRole('button', { name: 'Confirm sustained' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove effect' })).toBeInTheDocument();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove effect' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'remove' });
+  });
+
+  test('setValue flow: input pre-fills from suggestedValue and Set dispatches setValue', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          id: 'prompt-set',
+          effectName: 'Frightened',
+          suggestionType: { type: 'suggestDecrement', amount: 1 },
+          currentValue: 3,
+          suggestedValue: 2
+        })
+      ],
+      onResolve
+    });
+
+    const input = screen.getByRole('spinbutton', { name: 'Set value for Frightened' }) as HTMLInputElement;
+    expect(input.value).toBe('2');
+
+    await fireEvent.input(input, { target: { value: '0' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-set', { type: 'setValue', value: 0 });
+  });
+
+  test('renders multiple prompts in pendingPrompts order', () => {
+    renderPanel({
+      prompts: [
+        makePrompt({
+          id: 'prompt-a',
+          effectName: 'Frightened',
+          suggestionType: { type: 'suggestDecrement', amount: 1 }
+        }),
+        makePrompt({
+          id: 'prompt-b',
+          effectName: 'Persistent fire',
+          suggestionType: { type: 'reminder', description: 'Roll flat check.' }
+        })
+      ]
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Frightened');
+    expect(items[1]).toHaveTextContent('Persistent fire');
+  });
+
+  test('Remove effect button on suggestDecrement dispatches resolution { type: remove }', async () => {
+    const onResolve = vi.fn<ResolveHandler>();
+    renderPanel({
+      prompts: [
+        makePrompt({
+          suggestionType: { type: 'suggestDecrement', amount: 1 },
+          currentValue: 1,
+          suggestedValue: 0
+        })
+      ],
+      onResolve
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove effect' }));
+    expect(onResolve).toHaveBeenCalledWith('prompt-1', { type: 'remove' });
+  });
+
+  test('hides "on <target>" when target equals boundary owner', () => {
+    renderPanel({
+      prompts: [
+        makePrompt({
+          ownerId: 'goblin-1',
+          targetId: 'goblin-1',
+          suggestionType: { type: 'reminder', description: 'x' }
+        })
+      ]
+    });
+    expect(screen.queryByText(/^on /)).toBeNull();
+  });
+});

--- a/src/domain/test-support.ts
+++ b/src/domain/test-support.ts
@@ -1,12 +1,15 @@
 import { expect } from 'vitest';
 import type {
+  CombatantId,
   CombatantState,
   Command,
   CommandResult,
   CommandType,
   DomainEvent,
   EffectLibrary,
-  EncounterState
+  EncounterState,
+  Prompt,
+  TurnBoundarySuggestion
 } from './types';
 
 export const emptyEffects: EffectLibrary = {};
@@ -16,6 +19,36 @@ export function command<T extends Command['type']>(
   payload?: Extract<Command, { type: T }>['payload']
 ): Extract<Command, { type: T }> {
   return { id: `cmd-${type}`, type, payload: payload ?? {} } as Extract<Command, { type: T }>;
+}
+
+export interface PromptOverrides {
+  id?: string;
+  boundaryType?: 'turnStart' | 'turnEnd';
+  ownerId?: CombatantId;
+  targetId?: CombatantId;
+  effectInstanceId?: string;
+  effectName?: string;
+  description?: string;
+  suggestionType?: TurnBoundarySuggestion;
+  currentValue?: number;
+  suggestedValue?: number;
+}
+
+export function prompt(overrides: PromptOverrides = {}): Prompt {
+  return {
+    id: overrides.id ?? 'prompt-1',
+    boundary: {
+      type: overrides.boundaryType ?? 'turnEnd',
+      ownerId: overrides.ownerId ?? 'goblin-1'
+    },
+    targetId: overrides.targetId ?? overrides.ownerId ?? 'goblin-1',
+    effectInstanceId: overrides.effectInstanceId ?? 'instance-1',
+    effectName: overrides.effectName ?? 'Frightened',
+    description: overrides.description ?? 'Frightened decreases by 1 at end of turn.',
+    suggestionType: overrides.suggestionType ?? { type: 'reminder', description: 'Resolve pending save.' },
+    currentValue: overrides.currentValue,
+    suggestedValue: overrides.suggestedValue
+  };
 }
 
 export function combatant(id: string, overrides: Partial<CombatantState> = {}): CombatantState {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import type { Command, CombatantState, Creature } from '../domain';
+  import type { Command, CombatantState, Creature, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
   import FeedbackPanel from '../components/FeedbackPanel.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
   import CombatantDetailsPanel from '../components/CombatantDetailsPanel.svelte';
+  import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
   import SetupPanel from '../components/SetupPanel.svelte';
   import {
     combatantCardActions,
@@ -181,6 +182,10 @@
     runCommand(toCommand('SET_NOTE', { combatantId, note }, nextCommandId()));
   }
 
+  function resolvePrompt(promptId: string, resolution: PromptResolution) {
+    runCommand(toCommand('RESOLVE_PROMPT', { promptId, resolution }, nextCommandId()));
+  }
+
   function selectCombatant(id: string) {
     selection = pickCombatant(selection, id);
   }
@@ -204,6 +209,13 @@
     phase={encounter.phase}
     round={encounter.round}
     activeName={activeCombatant?.name}
+  />
+
+  <PromptResolutionPanel
+    prompts={encounter.pendingPrompts}
+    combatantsById={encounter.combatants}
+    phase={encounter.phase}
+    onResolve={resolvePrompt}
   />
 
   <section class="workspace">


### PR DESCRIPTION
## Summary
- New `PromptResolutionPanel` component renders `pendingPrompts` as a banner above the workspace whenever the encounter is `RESOLVING`, with the GM heading and `aria-live="polite"` for accessibility.
- Resolution buttons are gated by `suggestionType` to match the reducer's validation matrix (`reminder` only dismisses; `suggestRemove`/`confirmSustained` skip the numeric input; `suggestDecrement`/`promptResolution` expose Set with `suggestedValue` pre-fill). Each click dispatches `RESOLVE_PROMPT` via the existing `runCommand` path; the reducer auto-clears the phase when the queue empties.
- Bookkeeping: `ROADMAP.md` checkboxes ticked for the Track A items (#10, #11, #12) and the M5 slices that already shipped (3, 4a, 4b, 4, 5, 6, 10). Issue #39 (Slice 5) is closed separately as it shipped in #64.

## Test plan
- [x] `npm run check` (svelte-kit sync, svelte-check, domain tsc) — clean.
- [x] `npm run test:run` — 14 files, 231 tests passing (10 new component tests for the panel).
- [x] `npm run audit` — 3 low (gated at moderate, no fail).
- [x] `npm run build` — static Cloudflare Pages build OK.
- [x] Manual smoke: apply Frightened 2, end turn, accept the suggested decrement, watch initiative resume.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)