### PR TITLE
Add IndexedDB active encounter persistence (#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,16 @@
     "": {
       "name": "pf2e-tracker-v2",
       "version": "0.1.0",
+      "dependencies": {
+        "idb": "^8.0.3"
+      },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.9",
         "@sveltejs/kit": "^2.48.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "svelte": "^5.38.0",
         "svelte-check": "^4.3.1",
@@ -403,31 +407,6 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2489,6 +2468,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2534,6 +2523,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -409,6 +409,31 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "svelte": "^5.38.0",
     "svelte-check": "^4.3.1",
@@ -26,5 +27,8 @@
     "vite": "^8.0.10",
     "vitest": "^4.0.0",
     "wrangler": "^4.86.0"
+  },
+  "dependencies": {
+    "idb": "^8.0.3"
   }
 }

--- a/src/lib/storage/active-encounter.test.ts
+++ b/src/lib/storage/active-encounter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   activeEncounter,
   completedEncounter,
@@ -59,5 +59,16 @@ describe('active encounter storage', () => {
     await saveActiveEncounter(activeEncounter());
     await clearActiveEncounter();
     expect(await loadActiveEncounter()).toBeNull();
+  });
+
+  it('no-ops safely when indexedDB is unavailable (SSR / locked-down browsers)', async () => {
+    vi.stubGlobal('indexedDB', undefined);
+    try {
+      expect(await loadActiveEncounter()).toBeNull();
+      await expect(saveActiveEncounter(activeEncounter())).resolves.toBeUndefined();
+      await expect(clearActiveEncounter()).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/lib/storage/active-encounter.test.ts
+++ b/src/lib/storage/active-encounter.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  activeEncounter,
+  completedEncounter,
+  preparingEncounter,
+  resolvingEncounter
+} from '../../domain/test-support';
+import {
+  clearActiveEncounter,
+  loadActiveEncounter,
+  saveActiveEncounter
+} from './active-encounter';
+
+beforeEach(async () => {
+  await clearActiveEncounter();
+});
+
+afterEach(async () => {
+  await clearActiveEncounter();
+});
+
+describe('active encounter storage', () => {
+  it('returns null when no encounter has been saved', async () => {
+    expect(await loadActiveEncounter()).toBeNull();
+  });
+
+  it('round-trips an active encounter', async () => {
+    const state = activeEncounter();
+    await saveActiveEncounter(state);
+    expect(await loadActiveEncounter()).toEqual(state);
+  });
+
+  it('overwrites the prior record on subsequent save', async () => {
+    await saveActiveEncounter(preparingEncounter({ name: 'first' }));
+    await saveActiveEncounter(activeEncounter({ name: 'second' }));
+    const restored = await loadActiveEncounter();
+    expect(restored?.name).toBe('second');
+    expect(restored?.phase).toBe('ACTIVE');
+  });
+
+  it('restores PREPARING encounters', async () => {
+    const state = preparingEncounter();
+    await saveActiveEncounter(state);
+    expect(await loadActiveEncounter()).toEqual(state);
+  });
+
+  it('restores RESOLVING encounters', async () => {
+    const state = resolvingEncounter();
+    await saveActiveEncounter(state);
+    expect(await loadActiveEncounter()).toEqual(state);
+  });
+
+  it('does not auto-resume COMPLETED encounters', async () => {
+    await saveActiveEncounter(completedEncounter());
+    expect(await loadActiveEncounter()).toBeNull();
+  });
+
+  it('clearActiveEncounter removes the record', async () => {
+    await saveActiveEncounter(activeEncounter());
+    await clearActiveEncounter();
+    expect(await loadActiveEncounter()).toBeNull();
+  });
+});

--- a/src/lib/storage/active-encounter.ts
+++ b/src/lib/storage/active-encounter.ts
@@ -1,0 +1,51 @@
+import { openDB, type IDBPDatabase } from 'idb';
+import type { EncounterState } from '../../domain/types';
+
+const DB_NAME = 'pf2e-tracker-v2';
+const DB_VERSION = 1;
+const STORE = 'activeEncounter';
+const KEY = 'current';
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function getDb(): Promise<IDBPDatabase> | null {
+  if (!hasIndexedDb()) return null;
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE);
+        }
+      }
+    });
+  }
+  return dbPromise;
+}
+
+export async function saveActiveEncounter(state: EncounterState): Promise<void> {
+  const promise = getDb();
+  if (!promise) return;
+  const db = await promise;
+  await db.put(STORE, state, KEY);
+}
+
+export async function loadActiveEncounter(): Promise<EncounterState | null> {
+  const promise = getDb();
+  if (!promise) return null;
+  const db = await promise;
+  const stored = (await db.get(STORE, KEY)) as EncounterState | undefined;
+  if (!stored) return null;
+  if (stored.phase === 'COMPLETED') return null;
+  return stored;
+}
+
+export async function clearActiveEncounter(): Promise<void> {
+  const promise = getDb();
+  if (!promise) return;
+  const db = await promise;
+  await db.delete(STORE, KEY);
+}

--- a/src/lib/storage/active-encounter.ts
+++ b/src/lib/storage/active-encounter.ts
@@ -21,6 +21,12 @@ function getDb(): Promise<IDBPDatabase> | null {
           db.createObjectStore(STORE);
         }
       }
+    }).catch((err) => {
+      // Don't pin a rejected promise to the cache: a transient first-open failure
+      // (Firefox private-browsing InvalidStateError, VersionError from another tab,
+      // QuotaExceededError) would otherwise stay broken until full page reload.
+      dbPromise = null;
+      throw err;
     });
   }
   return dbPromise;

--- a/src/lib/storage/persistence-controller.test.ts
+++ b/src/lib/storage/persistence-controller.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  activeEncounter,
+  completedEncounter,
+  preparingEncounter
+} from '../../domain/test-support';
+import { createPersistenceController } from './persistence-controller';
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeDeps(overrides: Partial<{
+  load: () => Promise<ReturnType<typeof activeEncounter> | null>;
+  save: (state: ReturnType<typeof activeEncounter>) => Promise<void>;
+  clear: () => Promise<void>;
+}> = {}) {
+  return {
+    load: overrides.load ?? vi.fn().mockResolvedValue(null),
+    save: overrides.save ?? vi.fn().mockResolvedValue(undefined),
+    clear: overrides.clear ?? vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe('createPersistenceController', () => {
+  describe('persist', () => {
+    it('saves non-COMPLETED states', async () => {
+      const deps = makeDeps();
+      const controller = createPersistenceController(deps);
+      const state = activeEncounter();
+
+      controller.persist(state);
+      await flush();
+
+      expect(deps.save).toHaveBeenCalledWith(state);
+      expect(deps.clear).not.toHaveBeenCalled();
+    });
+
+    it('clears COMPLETED states instead of saving', async () => {
+      const deps = makeDeps();
+      const controller = createPersistenceController(deps);
+
+      controller.persist(completedEncounter());
+      await flush();
+
+      expect(deps.clear).toHaveBeenCalledOnce();
+      expect(deps.save).not.toHaveBeenCalled();
+    });
+
+    it('saves PREPARING states (not just ACTIVE)', async () => {
+      const deps = makeDeps();
+      const controller = createPersistenceController(deps);
+      const state = preparingEncounter();
+
+      controller.persist(state);
+      await flush();
+
+      expect(deps.save).toHaveBeenCalledWith(state);
+    });
+
+    it('fires onPersistFailed once on save rejection', async () => {
+      const onPersistFailed = vi.fn();
+      const deps = makeDeps({
+        save: vi.fn().mockRejectedValue(new Error('quota'))
+      });
+      const controller = createPersistenceController({ ...deps, onPersistFailed });
+
+      controller.persist(activeEncounter());
+      controller.persist(activeEncounter());
+      controller.persist(activeEncounter());
+      await flush();
+
+      expect(onPersistFailed).toHaveBeenCalledOnce();
+    });
+
+    it('fires onPersistFailed when COMPLETED clear rejects', async () => {
+      const onPersistFailed = vi.fn();
+      const deps = makeDeps({
+        clear: vi.fn().mockRejectedValue(new Error('blocked'))
+      });
+      const controller = createPersistenceController({ ...deps, onPersistFailed });
+
+      controller.persist(completedEncounter());
+      await flush();
+
+      expect(onPersistFailed).toHaveBeenCalledOnce();
+    });
+
+    it('does not throw to the caller when save rejects', () => {
+      const deps = makeDeps({
+        save: vi.fn().mockRejectedValue(new Error('boom'))
+      });
+      const controller = createPersistenceController(deps);
+
+      expect(() => controller.persist(activeEncounter())).not.toThrow();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears storage', async () => {
+      const deps = makeDeps();
+      const controller = createPersistenceController(deps);
+
+      controller.reset();
+      await flush();
+
+      expect(deps.clear).toHaveBeenCalledOnce();
+      expect(deps.save).not.toHaveBeenCalled();
+    });
+
+    it('fires onPersistFailed when clear rejects', async () => {
+      const onPersistFailed = vi.fn();
+      const deps = makeDeps({
+        clear: vi.fn().mockRejectedValue(new Error('blocked'))
+      });
+      const controller = createPersistenceController({ ...deps, onPersistFailed });
+
+      controller.reset();
+      await flush();
+
+      expect(onPersistFailed).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('restore', () => {
+    it('returns null when storage is empty', async () => {
+      const deps = makeDeps();
+      const controller = createPersistenceController(deps);
+
+      expect(await controller.restore()).toBeNull();
+    });
+
+    it('returns the loaded state', async () => {
+      const state = activeEncounter();
+      const deps = makeDeps({ load: vi.fn().mockResolvedValue(state) });
+      const controller = createPersistenceController(deps);
+
+      expect(await controller.restore()).toBe(state);
+    });
+
+    it('returns null and fires onRestoreFailed on load rejection', async () => {
+      const onRestoreFailed = vi.fn();
+      const deps = makeDeps({
+        load: vi.fn().mockRejectedValue(new Error('corrupt'))
+      });
+      const controller = createPersistenceController({ ...deps, onRestoreFailed });
+
+      expect(await controller.restore()).toBeNull();
+      expect(onRestoreFailed).toHaveBeenCalledOnce();
+    });
+
+    it('does not gate onRestoreFailed by the persist warn-once flag', async () => {
+      const onRestoreFailed = vi.fn();
+      const onPersistFailed = vi.fn();
+      const deps = makeDeps({
+        load: vi.fn().mockRejectedValue(new Error('corrupt')),
+        save: vi.fn().mockRejectedValue(new Error('quota'))
+      });
+      const controller = createPersistenceController({
+        ...deps,
+        onRestoreFailed,
+        onPersistFailed
+      });
+
+      controller.persist(activeEncounter());
+      await flush();
+      await controller.restore();
+
+      expect(onPersistFailed).toHaveBeenCalledOnce();
+      expect(onRestoreFailed).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/lib/storage/persistence-controller.ts
+++ b/src/lib/storage/persistence-controller.ts
@@ -1,0 +1,48 @@
+import type { EncounterState } from '../../domain/types';
+
+export interface PersistenceControllerOptions {
+  load: () => Promise<EncounterState | null>;
+  save: (state: EncounterState) => Promise<void>;
+  clear: () => Promise<void>;
+  onRestoreFailed?: () => void;
+  onPersistFailed?: () => void;
+}
+
+export interface PersistenceController {
+  restore(): Promise<EncounterState | null>;
+  persist(state: EncounterState): void;
+  reset(): void;
+}
+
+export function createPersistenceController(
+  options: PersistenceControllerOptions
+): PersistenceController {
+  let persistWarned = false;
+
+  function notifyPersistFailure(err: unknown) {
+    console.error('Failed to persist encounter', err);
+    if (persistWarned) return;
+    persistWarned = true;
+    options.onPersistFailed?.();
+  }
+
+  return {
+    async restore() {
+      try {
+        return await options.load();
+      } catch (err) {
+        console.error('Failed to restore encounter', err);
+        options.onRestoreFailed?.();
+        return null;
+      }
+    },
+    persist(state: EncounterState) {
+      const op =
+        state.phase === 'COMPLETED' ? options.clear() : options.save(state);
+      op.catch(notifyPersistFailure);
+    },
+    reset() {
+      options.clear().catch(notifyPersistFailure);
+    }
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Command, CombatantState, Creature, EncounterState, PromptResolution } from '../domain';
+  import type { Command, CombatantState, Creature, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
   import FeedbackPanel from '../components/FeedbackPanel.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
@@ -35,9 +35,11 @@
     type Selection
   } from '$lib/selection-state';
   import {
+    clearActiveEncounter,
     loadActiveEncounter,
     saveActiveEncounter
   } from '$lib/storage/active-encounter';
+  import { createPersistenceController } from '$lib/storage/persistence-controller';
 
   const conditionOptions = listConditionOptions();
 
@@ -58,27 +60,40 @@
   $: selection = followActive(selection, activeCombatant?.id);
   $: selectedCombatant = selection.id ? encounter.combatants[selection.id] : undefined;
 
-  function persist(state: EncounterState) {
-    saveActiveEncounter(state).catch((err) => {
-      console.error('Failed to persist encounter', err);
-    });
+  function appendFeedback(id: string, message: string) {
+    feedback = [
+      ...feedback,
+      { id, commandId: id, severity: 'warn', message }
+    ];
   }
+
+  const persistence = createPersistenceController({
+    load: loadActiveEncounter,
+    save: saveActiveEncounter,
+    clear: clearActiveEncounter,
+    onRestoreFailed: () =>
+      appendFeedback(
+        `restore-fail-${Date.now()}`,
+        'Could not restore the previous encounter from storage. If you have this app open in another tab, close it and reload.'
+      ),
+    onPersistFailed: () =>
+      appendFeedback(
+        `persist-fail-${Date.now()}`,
+        'Auto-save is unavailable. Your encounter will not survive a reload. (Common causes: private-browsing mode, full storage, or another tab using a newer version.)'
+      )
+  });
 
   function runCommand(command: Command) {
     const result = dispatchEncounterCommand(encounter, feedback, command);
     encounter = result.state;
     feedback = result.feedback;
-    persist(result.state);
+    persistence.persist(result.state);
   }
 
   onMount(async () => {
-    try {
-      const restored = await loadActiveEncounter();
-      if (restored) {
-        encounter = restored;
-      }
-    } catch (err) {
-      console.error('Failed to restore encounter', err);
+    const restored = await persistence.restore();
+    if (restored) {
+      encounter = restored;
     }
   });
 
@@ -219,7 +234,7 @@
     commandCounter = 1;
     combatantCounter = 1;
     selection = emptySelection;
-    persist(encounter);
+    persistence.reset();
   }
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { Command, CombatantState, Creature, PromptResolution } from '../domain';
+  import { onMount } from 'svelte';
+  import type { Command, CombatantState, Creature, EncounterState, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
   import FeedbackPanel from '../components/FeedbackPanel.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
@@ -33,6 +34,10 @@
     reconcileWithCombatants,
     type Selection
   } from '$lib/selection-state';
+  import {
+    loadActiveEncounter,
+    saveActiveEncounter
+  } from '$lib/storage/active-encounter';
 
   const conditionOptions = listConditionOptions();
 
@@ -53,11 +58,29 @@
   $: selection = followActive(selection, activeCombatant?.id);
   $: selectedCombatant = selection.id ? encounter.combatants[selection.id] : undefined;
 
+  function persist(state: EncounterState) {
+    saveActiveEncounter(state).catch((err) => {
+      console.error('Failed to persist encounter', err);
+    });
+  }
+
   function runCommand(command: Command) {
     const result = dispatchEncounterCommand(encounter, feedback, command);
     encounter = result.state;
     feedback = result.feedback;
+    persist(result.state);
   }
+
+  onMount(async () => {
+    try {
+      const restored = await loadActiveEncounter();
+      if (restored) {
+        encounter = restored;
+      }
+    } catch (err) {
+      console.error('Failed to restore encounter', err);
+    }
+  });
 
   function nextCommandId() {
     return `cmd-${commandCounter++}`;
@@ -196,6 +219,7 @@
     commandCounter = 1;
     combatantCounter = 1;
     selection = emptySelection;
+    persist(encounter);
   }
 </script>
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/vitest';
+import 'fake-indexeddb/auto';


### PR DESCRIPTION
## Summary
- New `src/lib/storage/active-encounter.ts` module wraps `idb` with `saveActiveEncounter` / `loadActiveEncounter` / `clearActiveEncounter` against a single-store DB (`pf2e-tracker-v2` v1, store `activeEncounter`, key `current`).
- `src/routes/+page.svelte` restores any persisted state in `onMount` and fires a non-blocking save after every `runCommand` and `resetLocal`.
- Storage tests run under `fake-indexeddb` (added as devDep) registered globally via `src/test-setup.ts`.

Implements `pf2e-tracker-v2-architecture-spec.md` §13.1 (write on every dispatch, async, non-blocking) and §13.2 (restore only when present and `phase !== "COMPLETED"`). Undo history is not persisted — and does not exist yet (§12.1).

Closes #13. Unblocks #47 (settings storage will reuse the same DB).

## Test plan
- [x] `npm run check`
- [x] `npm run test:run` — 243 passing, 7 new in `active-encounter.test.ts`
- [x] `npm run audit` — clean at moderate (3 pre-existing low warnings)
- [x] `npm run build` — static output, no IndexedDB access during prerender
- [ ] Manual: dispatch commands, hard reload — state restores
- [ ] Manual: complete encounter, reload — empty creation screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)