### PR TITLE
UI overhaul PR 2: primitive component layer

### DIFF
--- a/src/components/ui/Button.svelte
+++ b/src/components/ui/Button.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  type Variant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+  type Size = 'sm' | 'md';
+
+  export let variant: Variant = 'primary';
+  export let size: Size = 'md';
+  export let type: 'button' | 'submit' = 'button';
+  export let disabled = false;
+  export let title: string | undefined = undefined;
+  export let ariaLabel: string | undefined = undefined;
+  export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
+</script>
+
+<button
+  {type}
+  {disabled}
+  {title}
+  aria-label={ariaLabel}
+  class="btn btn--{variant} btn--{size}"
+  {onclick}
+>
+  <slot />
+</button>
+
+<style>
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    border-radius: var(--radius-card);
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+
+  .btn--md {
+    padding: 6px 14px;
+    font-size: var(--text-sm);
+  }
+
+  .btn--sm {
+    padding: 4px 10px;
+    font-size: var(--text-xs);
+  }
+
+  .btn--primary {
+    background: var(--color-ink);
+    color: var(--color-panel);
+    border: 1px solid var(--color-ink);
+  }
+
+  .btn--primary:hover:not(:disabled) {
+    background: var(--color-ink-soft);
+    border-color: var(--color-ink-soft);
+  }
+
+  .btn--secondary {
+    background: transparent;
+    color: var(--color-ink);
+    border: var(--border-strong);
+  }
+
+  .btn--secondary:hover:not(:disabled) {
+    background: var(--color-panel-2);
+  }
+
+  .btn--ghost {
+    background: transparent;
+    color: var(--color-ink-soft);
+    border: 1px dashed var(--color-rule-strong);
+  }
+
+  .btn--ghost:hover:not(:disabled) {
+    background: var(--color-panel-2);
+    color: var(--color-ink);
+  }
+
+  .btn--destructive {
+    background: transparent;
+    color: var(--color-red);
+    border: 1px solid var(--color-red);
+  }
+
+  .btn--destructive:hover:not(:disabled) {
+    background: var(--color-red);
+    color: var(--color-panel);
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
+  }
+
+  .btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+</style>

--- a/src/components/ui/Button.test.ts
+++ b/src/components/ui/Button.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import Button from './Button.svelte';
+
+describe('Button', () => {
+  test('renders a button element with the default primary variant', () => {
+    render(Button, { props: { ariaLabel: 'Save' } });
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn.className).toContain('btn--primary');
+    expect(btn.className).toContain('btn--md');
+  });
+
+  test('applies the requested variant class', () => {
+    render(Button, { props: { variant: 'destructive', ariaLabel: 'Delete' } });
+    expect(screen.getByRole('button', { name: 'Delete' }).className).toContain('btn--destructive');
+  });
+
+  test('applies the requested size class', () => {
+    render(Button, { props: { size: 'sm', ariaLabel: 'Tiny' } });
+    expect(screen.getByRole('button', { name: 'Tiny' }).className).toContain('btn--sm');
+  });
+
+  test('fires onclick when clicked', async () => {
+    const onclick = vi.fn();
+    render(Button, { props: { ariaLabel: 'Click me', onclick } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Click me' }));
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  test('sets the disabled attribute when disabled', () => {
+    render(Button, { props: { ariaLabel: 'Off', disabled: true } });
+    expect(screen.getByRole('button', { name: 'Off' })).toBeDisabled();
+  });
+
+  test('passes title through to the DOM element', () => {
+    render(Button, { props: { ariaLabel: 'Save', title: 'Save the encounter' } });
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('title', 'Save the encounter');
+  });
+});

--- a/src/components/ui/Chip.svelte
+++ b/src/components/ui/Chip.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  type Variant = 'default' | 'pc' | 'enemy' | 'success' | 'warning' | 'danger';
+
+  export let variant: Variant = 'default';
+  export let selected = false;
+  export let title: string | undefined = undefined;
+</script>
+
+<span
+  {title}
+  class="chip chip--{variant}"
+  class:chip--selected={selected}
+>
+  <slot />
+</span>
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: var(--radius-chip);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .chip--default {
+    color: var(--color-ink-soft);
+    border: var(--border-thin);
+    background: transparent;
+  }
+
+  .chip--pc {
+    color: var(--color-blue);
+    border: 1px solid var(--color-blue);
+    background: transparent;
+  }
+
+  .chip--enemy {
+    color: var(--color-red);
+    border: 1px solid var(--color-red);
+    background: transparent;
+  }
+
+  .chip--success {
+    color: var(--color-green);
+    border: 1px solid var(--color-green);
+    background: transparent;
+  }
+
+  .chip--warning {
+    color: var(--color-amber);
+    border: 1px solid var(--color-amber);
+    background: transparent;
+  }
+
+  .chip--danger {
+    color: var(--color-panel);
+    border: 1px solid var(--color-red);
+    background: var(--color-red);
+  }
+
+  .chip--selected {
+    background: var(--color-ink);
+    color: var(--color-panel);
+    border-color: var(--color-ink);
+  }
+</style>

--- a/src/components/ui/Chip.test.svelte
+++ b/src/components/ui/Chip.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Chip from './Chip.svelte';
+
+  type Variant = 'default' | 'pc' | 'enemy' | 'success' | 'warning' | 'danger';
+
+  export let label: string;
+  export let variant: Variant = 'default';
+  export let selected = false;
+</script>
+
+<Chip {variant} {selected}>{label}</Chip>

--- a/src/components/ui/Chip.test.ts
+++ b/src/components/ui/Chip.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Wrapper from './Chip.test.svelte';
+
+describe('Chip', () => {
+  test('renders the slot content as text', () => {
+    const { container } = render(Wrapper, { props: { label: 'PC' } });
+    expect(container.textContent).toContain('PC');
+  });
+
+  test('applies the variant class', () => {
+    const { container } = render(Wrapper, { props: { label: 'Frightened', variant: 'warning' } });
+    const chip = container.querySelector('.chip');
+    expect(chip?.className).toContain('chip--warning');
+  });
+
+  test('applies the selected modifier class', () => {
+    const { container } = render(Wrapper, { props: { label: 'Selected', selected: true } });
+    const chip = container.querySelector('.chip');
+    expect(chip?.className).toContain('chip--selected');
+  });
+});

--- a/src/components/ui/IconButton.svelte
+++ b/src/components/ui/IconButton.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  type Variant = 'default' | 'primary' | 'destructive';
+  type Size = 22 | 26;
+
+  export let variant: Variant = 'default';
+  export let size: Size = 22;
+  export let type: 'button' | 'submit' = 'button';
+  export let disabled = false;
+  export let title: string | undefined = undefined;
+  export let ariaLabel: string;
+  export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
+</script>
+
+<button
+  {type}
+  {disabled}
+  {title}
+  aria-label={ariaLabel}
+  class="icon-btn icon-btn--{variant}"
+  style="--icon-btn-size: {size}px"
+  {onclick}
+>
+  <slot />
+</button>
+
+<style>
+  .icon-btn {
+    width: var(--icon-btn-size);
+    height: var(--icon-btn-size);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: var(--radius-card);
+    font-family: var(--font-sans);
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+
+  .icon-btn--default {
+    border: var(--border-thin);
+    color: var(--color-ink-mute);
+  }
+
+  .icon-btn--default:hover:not(:disabled) {
+    border-color: var(--color-ink);
+    color: var(--color-ink);
+  }
+
+  .icon-btn--primary {
+    border: var(--border-ink);
+    color: var(--color-ink);
+    font-weight: 600;
+  }
+
+  .icon-btn--primary:hover:not(:disabled) {
+    background: var(--color-ink);
+    color: var(--color-panel);
+  }
+
+  .icon-btn--destructive {
+    border: 1px solid var(--color-red);
+    color: var(--color-red);
+  }
+
+  .icon-btn--destructive:hover:not(:disabled) {
+    background: var(--color-red);
+    color: var(--color-panel);
+  }
+
+  .icon-btn:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
+  }
+
+  .icon-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+</style>

--- a/src/components/ui/IconButton.test.ts
+++ b/src/components/ui/IconButton.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import IconButton from './IconButton.svelte';
+
+describe('IconButton', () => {
+  test('renders with the required ariaLabel', () => {
+    render(IconButton, { props: { ariaLabel: 'Remove condition' } });
+    expect(screen.getByRole('button', { name: 'Remove condition' })).toBeInTheDocument();
+  });
+
+  test('applies the variant class', () => {
+    render(IconButton, { props: { variant: 'destructive', ariaLabel: 'Delete' } });
+    expect(screen.getByRole('button', { name: 'Delete' }).className).toContain('icon-btn--destructive');
+  });
+
+  test('inlines the size as a CSS custom property', () => {
+    render(IconButton, { props: { size: 26, ariaLabel: 'Add' } });
+    const btn = screen.getByRole('button', { name: 'Add' });
+    expect(btn.getAttribute('style')).toContain('--icon-btn-size: 26px');
+  });
+
+  test('fires onclick when clicked', async () => {
+    const onclick = vi.fn();
+    render(IconButton, { props: { ariaLabel: 'Tap', onclick } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Tap' }));
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  test('sets the disabled attribute when disabled', () => {
+    render(IconButton, { props: { ariaLabel: 'Off', disabled: true } });
+    expect(screen.getByRole('button', { name: 'Off' })).toBeDisabled();
+  });
+});

--- a/src/components/ui/Input.svelte
+++ b/src/components/ui/Input.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  export let value: string = '';
+  export let type: 'text' | 'search' | 'email' | 'password' = 'text';
+  export let placeholder = '';
+  export let ariaLabel: string;
+  export let disabled = false;
+  export let id: string | undefined = undefined;
+  export let oninput: ((value: string) => void) | undefined = undefined;
+
+  function handleInput(event: Event) {
+    const next = (event.target as HTMLInputElement).value;
+    value = next;
+    oninput?.(next);
+  }
+</script>
+
+<div class="field" class:field--disabled={disabled}>
+  {#if $$slots.leading}
+    <span class="field__leading"><slot name="leading" /></span>
+  {/if}
+  <input
+    {type}
+    {value}
+    {placeholder}
+    {disabled}
+    {id}
+    aria-label={ariaLabel}
+    oninput={handleInput}
+  />
+  {#if $$slots.trailing}
+    <span class="field__trailing"><slot name="trailing" /></span>
+  {/if}
+</div>
+
+<style>
+  .field {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    padding: 6px 10px;
+    transition: border-color 0.12s;
+  }
+
+  .field:focus-within {
+    border-color: var(--color-ink);
+  }
+
+  .field--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+  }
+
+  input::placeholder {
+    color: var(--color-ink-mute);
+  }
+
+  .field__leading,
+  .field__trailing {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-ink-mute);
+    font-size: var(--text-sm);
+  }
+</style>

--- a/src/components/ui/Input.test.ts
+++ b/src/components/ui/Input.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import Input from './Input.svelte';
+
+describe('Input', () => {
+  test('renders with the required ariaLabel', () => {
+    render(Input, { props: { ariaLabel: 'Search bestiary' } });
+    expect(screen.getByRole('textbox', { name: 'Search bestiary' })).toBeInTheDocument();
+  });
+
+  test('reflects the initial value', () => {
+    render(Input, { props: { ariaLabel: 'Name', value: 'Kael' } });
+    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('Kael');
+  });
+
+  test('fires oninput with the new string when typed', async () => {
+    const oninput = vi.fn();
+    render(Input, { props: { ariaLabel: 'Name', oninput } });
+    const input = screen.getByRole('textbox', { name: 'Name' });
+    await fireEvent.input(input, { target: { value: 'Kael' } });
+    expect(oninput).toHaveBeenCalledWith('Kael');
+  });
+
+  test('renders the placeholder', () => {
+    render(Input, { props: { ariaLabel: 'Name', placeholder: 'Search…' } });
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
+  });
+
+  test('honors the type prop for search inputs', () => {
+    render(Input, { props: { ariaLabel: 'Search', type: 'search' } });
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Pane.svelte
+++ b/src/components/ui/Pane.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  export let ariaLabel: string | undefined = undefined;
+  export let scrollable = false;
+</script>
+
+<section class="pane" aria-label={ariaLabel}>
+  {#if $$slots.header}
+    <header class="pane__header">
+      <slot name="header" />
+    </header>
+  {/if}
+  <div class="pane__body" class:pane__body--scrollable={scrollable}>
+    <slot />
+  </div>
+  {#if $$slots.footer}
+    <footer class="pane__footer">
+      <slot name="footer" />
+    </footer>
+  {/if}
+</section>
+
+<style>
+  .pane {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+  }
+
+  .pane__header {
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-panel-2);
+    border-bottom: var(--border-thin);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .pane__body {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .pane__body--scrollable {
+    overflow: auto;
+  }
+
+  .pane__footer {
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-panel-2);
+    border-top: var(--border-thin);
+  }
+</style>

--- a/src/components/ui/Pane.test.svelte
+++ b/src/components/ui/Pane.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Pane from './Pane.svelte';
+
+  export let ariaLabel: string;
+  export let scrollable = false;
+</script>
+
+<Pane {ariaLabel} {scrollable}>
+  <span slot="header">Header content</span>
+  <span slot="footer">Footer content</span>
+  Body content
+</Pane>

--- a/src/components/ui/Pane.test.ts
+++ b/src/components/ui/Pane.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Wrapper from './Pane.test.svelte';
+
+describe('Pane', () => {
+  test('renders the section with the supplied aria-label', () => {
+    render(Wrapper, { props: { ariaLabel: 'Library' } });
+    expect(screen.getByRole('region', { name: 'Library' })).toBeInTheDocument();
+  });
+
+  test('renders header, footer, and body slot content', () => {
+    render(Wrapper, { props: { ariaLabel: 'Details' } });
+    expect(screen.getByText('Header content')).toBeInTheDocument();
+    expect(screen.getByText('Footer content')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  test('applies the scrollable modifier when scrollable=true', () => {
+    const { container } = render(Wrapper, { props: { ariaLabel: 'Scroll', scrollable: true } });
+    expect(container.querySelector('.pane__body--scrollable')).not.toBeNull();
+  });
+});

--- a/src/components/ui/SectionLabel.svelte
+++ b/src/components/ui/SectionLabel.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  export let as: 'span' | 'div' | 'h2' | 'h3' | 'h4' = 'span';
+</script>
+
+<svelte:element this={as} class="label">
+  <slot />
+</svelte:element>
+
+<style>
+  .label {
+    display: inline-block;
+    margin: 0;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-widest);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+  }
+</style>

--- a/src/components/ui/SectionLabel.test.svelte
+++ b/src/components/ui/SectionLabel.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import SectionLabel from './SectionLabel.svelte';
+
+  export let text: string;
+  export let as: 'span' | 'div' | 'h2' | 'h3' | 'h4' = 'span';
+</script>
+
+<SectionLabel {as}>{text}</SectionLabel>

--- a/src/components/ui/SectionLabel.test.ts
+++ b/src/components/ui/SectionLabel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Wrapper from './SectionLabel.test.svelte';
+
+describe('SectionLabel', () => {
+  test('renders a span by default with the supplied content', () => {
+    const { container } = render(Wrapper, { props: { text: 'Defenses' } });
+    const el = container.querySelector('.label');
+    expect(el?.tagName).toBe('SPAN');
+    expect(el?.textContent).toBe('Defenses');
+  });
+
+  test('renders the requested element via the as prop', () => {
+    const { container } = render(Wrapper, { props: { text: 'Strikes', as: 'h3' } });
+    const el = container.querySelector('.label');
+    expect(el?.tagName).toBe('H3');
+  });
+});

--- a/src/components/ui/Select.svelte
+++ b/src/components/ui/Select.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  export let value: string;
+  export let ariaLabel: string;
+  export let id: string | undefined = undefined;
+  export let disabled = false;
+  export let onchange: ((value: string) => void) | undefined = undefined;
+
+  function handleChange(event: Event) {
+    const next = (event.target as HTMLSelectElement).value;
+    value = next;
+    onchange?.(next);
+  }
+</script>
+
+<div class="select" class:select--disabled={disabled}>
+  <select
+    {value}
+    {disabled}
+    {id}
+    aria-label={ariaLabel}
+    onchange={handleChange}
+  >
+    <slot />
+  </select>
+  <span class="select__caret" aria-hidden="true">▾</span>
+</div>
+
+<style>
+  .select {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    transition: border-color 0.12s;
+  }
+
+  .select:focus-within {
+    border-color: var(--color-ink);
+  }
+
+  .select--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  select {
+    appearance: none;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+    padding: 6px 28px 6px 10px;
+    cursor: pointer;
+  }
+
+  select:disabled {
+    cursor: not-allowed;
+  }
+
+  .select__caret {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-ink-mute);
+    font-size: var(--text-sm);
+    pointer-events: none;
+  }
+</style>

--- a/src/components/ui/Select.test.svelte
+++ b/src/components/ui/Select.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Select from './Select.svelte';
+
+  export let value: string;
+  export let onchange: ((value: string) => void) | undefined = undefined;
+</script>
+
+<Select ariaLabel="Condition" {value} {onchange}>
+  <option value="frightened">Frightened</option>
+  <option value="stunned">Stunned</option>
+  <option value="prone">Prone</option>
+</Select>

--- a/src/components/ui/Select.test.ts
+++ b/src/components/ui/Select.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Wrapper from './Select.test.svelte';
+
+describe('Select', () => {
+  test('renders with the required ariaLabel and selected option', () => {
+    render(Wrapper, { props: { value: 'frightened' } });
+    const select = screen.getByRole('combobox', { name: 'Condition' }) as HTMLSelectElement;
+    expect(select.value).toBe('frightened');
+  });
+
+  test('fires onchange with the new value when the selection changes', async () => {
+    const onchange = vi.fn();
+    render(Wrapper, { props: { value: 'frightened', onchange } });
+    const select = screen.getByRole('combobox', { name: 'Condition' }) as HTMLSelectElement;
+    select.value = 'stunned';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onchange).toHaveBeenCalledWith('stunned');
+  });
+});


### PR DESCRIPTION
Second slice of the UI overhaul. Establishes the small primitive layer that subsequent slices (PRs 3–8) compose from; no existing components are modified yet.

## Summary

Seven primitives under `src/components/ui/`, all reading styling exclusively from the tokens introduced in PR 1 (`src/styles/tokens.css`):

- **Button** — `primary` / `secondary` / `ghost` / `destructive` variants, `sm` / `md` sizes
- **IconButton** — square 22/26px, `default` / `primary` / `destructive` variants
- **Input** — `text` / `search` / `email` / `password`, with optional `leading` / `trailing` icon slots
- **Select** — wraps native `<select>` with consistent chrome and a caret indicator (popup is still native)
- **Chip** — uppercase pill, `default` / `pc` / `enemy` / `success` / `warning` / `danger` variants, plus a `selected` modifier
- **Pane** — `header` / `footer` / body slots, scrollable modifier; the chrome used for Library / Details / Combat-Log surfaces in later PRs
- **SectionLabel** — uppercase tracked-letter label, polymorphic via `as` prop (`span` / `div` / `h2` / `h3` / `h4`)

## Tests

26 new tests, colocated as `*.test.ts`. Slot-bearing primitives (Select, Chip, Pane, SectionLabel) use minimal `*.test.svelte` fixtures since slot content can't be passed through `render()` directly. Coverage focuses on prop→DOM behavior, variant→class application, and event-handler firing.

One test pattern note: `fireEvent.click` in jsdom dispatches MouseEvents directly and bypasses the browser's disabled-button click suppression. So "disabled buttons" assertions verify the `disabled` attribute is present rather than testing browser behavior.

## Out of scope

- Wiring primitives into existing components (PRs 6–8)
- The 3-pane shell restructure (PR 3)
- Combat Log (PR 4) and Library Pane (PR 5)

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings, 366 files
- [x] `npm run test:run` — 370 / 370 passing (added 26 new)
- [x] `npm run audit` — only 3 low-severity (below moderate threshold)
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)