### PR TITLE
UI overhaul PR 3: 3-pane shell + bottom Combat Log drawer

### DIFF
--- a/src/components/CombatLogDrawer.svelte
+++ b/src/components/CombatLogDrawer.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { FeedbackEntry } from '$lib/encounter-app';
+
+  export let entries: FeedbackEntry[];
+
+  let open = true;
+
+  function toggle() {
+    open = !open;
+  }
+</script>
+
+<section class="drawer" class:drawer--open={open} aria-label="Combat log">
+  <button
+    type="button"
+    class="drawer__header"
+    aria-expanded={open}
+    aria-controls="combat-log-body"
+    onclick={toggle}
+  >
+    <span class="caret" aria-hidden="true">{open ? '▼' : '▲'}</span>
+    <span class="title">Combat Log</span>
+    <span class="count">{entries.length} entries</span>
+  </button>
+  {#if open}
+    <div id="combat-log-body" class="drawer__body">
+      {#if entries.length === 0}
+        <p class="empty">Domain events will appear here.</p>
+      {:else}
+        <ol class="entries">
+          {#each entries as entry (entry.id)}
+            <li
+              class="entry"
+              class:entry--warn={entry.severity === 'warn'}
+              class:entry--success={entry.severity === 'success'}
+            >{entry.message}</li>
+          {/each}
+        </ol>
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .drawer {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .drawer__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 0 var(--space-4);
+    height: 40px;
+    background: var(--color-panel-2);
+    border: none;
+    border-bottom: 1px solid transparent;
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    letter-spacing: var(--tracking-widest);
+    text-transform: uppercase;
+    text-align: left;
+    cursor: pointer;
+    width: 100%;
+  }
+
+  .drawer--open .drawer__header {
+    border-bottom-color: var(--color-rule);
+  }
+
+  .drawer__header:hover {
+    background: var(--color-panel);
+  }
+
+  .drawer__header:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -2px;
+  }
+
+  .caret {
+    color: var(--color-ink-mute);
+    font-size: var(--text-xs);
+  }
+
+  .title {
+    color: var(--color-ink);
+  }
+
+  .count {
+    margin-left: auto;
+    color: var(--color-ink-mute);
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+
+  .drawer__body {
+    max-height: 240px;
+    overflow: auto;
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .entries {
+    display: grid;
+    gap: var(--space-2);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .entry {
+    border-left: 4px solid var(--color-green);
+    background: var(--color-panel);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-base);
+    color: var(--color-ink);
+  }
+
+  .entry--warn {
+    border-left-color: var(--color-amber);
+    background: #fff7ee;
+  }
+
+  .entry--success {
+    border-left-color: var(--color-green);
+    background: #ecf6ee;
+    font-weight: 600;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import type { Command, CombatantState, Creature, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
-  import FeedbackPanel from '../components/FeedbackPanel.svelte';
+  import CombatLogDrawer from '../components/CombatLogDrawer.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
   import CombatantDetailsPanel from '../components/CombatantDetailsPanel.svelte';
   import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
@@ -345,25 +345,26 @@
     activeName={activeCombatant?.name}
   />
 
-  <PromptResolutionPanel
-    prompts={encounter.pendingPrompts}
-    combatantsById={encounter.combatants}
-    phase={encounter.phase}
-    onResolve={resolvePrompt}
-  />
-
   <section class="workspace">
-    <SetupPanel
-      {canStart}
-      creatures={availableCreatures}
-      onAddCreatures={handleAddCreatures}
-      onAddManual={handleAddManual}
-      onImportYamlFiles={handleImportYamlFiles}
-      onStart={startEncounter}
-      onReset={resetLocal}
-    />
+    <aside class="workspace__library">
+      <SetupPanel
+        {canStart}
+        creatures={availableCreatures}
+        onAddCreatures={handleAddCreatures}
+        onAddManual={handleAddManual}
+        onImportYamlFiles={handleImportYamlFiles}
+        onStart={startEncounter}
+        onReset={resetLocal}
+      />
+    </aside>
 
-    <section class="combat-column" aria-label="Combatants">
+    <section class="workspace__track" aria-label="Combatants">
+      <PromptResolutionPanel
+        prompts={encounter.pendingPrompts}
+        combatantsById={encounter.combatants}
+        phase={encounter.phase}
+        onResolve={resolvePrompt}
+      />
       {#if unorderedCombatants.length > 0}
         <div class="not-yet-rolled" aria-label="Not yet rolled">
           <h3>Not yet rolled</h3>
@@ -402,9 +403,13 @@
       </div>
     </section>
 
-    <CombatantDetailsPanel combatant={selectedCombatant} onSetNote={setNote} />
+    <aside class="workspace__details">
+      <CombatantDetailsPanel combatant={selectedCombatant} onSetNote={setNote} />
+    </aside>
 
-    <FeedbackPanel entries={feedback} />
+    <section class="workspace__log">
+      <CombatLogDrawer entries={feedback} />
+    </section>
   </section>
 </main>
 
@@ -416,16 +421,32 @@
 
   .workspace {
     display: grid;
-    grid-template-columns: minmax(260px, 320px) minmax(420px, 1fr) minmax(300px, 380px) minmax(260px, 340px);
+    grid-template-columns: minmax(260px, 320px) minmax(420px, 1fr) minmax(300px, 380px);
+    grid-template-areas:
+      'library track details'
+      'log     log   log';
     gap: 14px;
     max-width: 1440px;
     margin: 0 auto;
     align-items: start;
   }
 
-  .combat-column {
+  .workspace__library {
+    grid-area: library;
+  }
+
+  .workspace__track {
+    grid-area: track;
     display: grid;
     gap: 14px;
+  }
+
+  .workspace__details {
+    grid-area: details;
+  }
+
+  .workspace__log {
+    grid-area: log;
   }
 
   .cards {
@@ -464,11 +485,10 @@
   @media (max-width: 1180px) {
     .workspace {
       grid-template-columns: minmax(260px, 320px) 1fr;
-    }
-
-    .workspace > :nth-child(3),
-    .workspace > :nth-child(4) {
-      grid-column: span 2;
+      grid-template-areas:
+        'library track'
+        'details details'
+        'log     log';
     }
   }
 
@@ -479,11 +499,11 @@
 
     .workspace {
       grid-template-columns: 1fr;
-    }
-
-    .workspace > :nth-child(3),
-    .workspace > :nth-child(4) {
-      grid-column: auto;
+      grid-template-areas:
+        'library'
+        'track'
+        'details'
+        'log';
     }
   }
 </style>


### PR DESCRIPTION
Third slice of the UI overhaul. Reshapes the workspace into the design's layout shape; no component internals are touched (those land in PRs 5–8).

## Summary

The old 4-column shell (`SetupPanel | Cards | Details | Feedback`) becomes a 3-pane top row plus a full-width bottom drawer:

```
┌──────────┬──────────────┬─────────────┐
│ library  │ track        │ details     │
├──────────┴──────────────┴─────────────┤
│ log (collapsible drawer)              │
└───────────────────────────────────────┘
```

- **SetupPanel** moves into the new `library` slot. Still preserves its current PREPARING/ACTIVE behavior; the design's "collapse to empty-state strip during ACTIVE" lands in PR 5 when SetupPanel splits into a proper `LibraryPane`.
- **PromptResolutionPanel** moves inside the `track` column, above the card list — same place a future round/turn header strip will own.
- **FeedbackPanel** slot is replaced by a new **`CombatLogDrawer`** placeholder. The drawer ships its own header strip (collapse toggle, entry count, title), tokens-only styling, and renders the existing `FeedbackEntry` array inline. PR 4 will swap the body for the real by-round Combat Log component and delete `FeedbackPanel.svelte`.

## Responsive

Uses `grid-template-areas` at every breakpoint, so the area ordering is explicit instead of nth-child shuffling:

- **≥1180px**: 3-pane top row + full-width log
- **760–1180px**: `library | track` top row, then `details` full-width, then `log` full-width
- **<760px**: single column stacked `library → track → details → log`

## Out of scope

- Real Combat Log rendering with by-round grouping & color-coded kinds (PR 4)
- LibraryPane (PR 5)
- Component restyles to direction A — TopBar / SetupPanel / Card / Details / Prompt panels still use their existing palette (PRs 6–8)

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 370 / 370 passing
- [x] `npm run audit` — 3 low-severity (below threshold)
- [x] `npm run build` — clean
- [ ] Manual eyeball at 1440 / 1180 / 760 widths to confirm grid breakpoints (reviewer)
- [ ] Run an encounter end-to-end: prepare → add creatures → start → take a turn → apply HP delta → apply a condition → confirm log drawer collapses/expands and entries appear (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)