### PR TITLE
UI overhaul PR 5: LibraryPane (Party + minimal Bestiary)

### DIFF
--- a/src/components/BestiarySection.svelte
+++ b/src/components/BestiarySection.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import type { Creature } from '../domain';
+  import IconButton from './ui/IconButton.svelte';
+  import Input from './ui/Input.svelte';
+  import SectionLabel from './ui/SectionLabel.svelte';
+
+  export let creatures: Creature[];
+  export let onAddCreature: (creature: Creature) => void;
+
+  let query = '';
+
+  $: needle = query.trim().toLowerCase();
+  $: filtered = needle
+    ? creatures.filter((creature) => {
+        if (creature.name.toLowerCase().includes(needle)) return true;
+        return creature.traits.some((t) => t.toLowerCase().includes(needle));
+      })
+    : creatures;
+</script>
+
+<section class="bestiary" aria-labelledby="bestiary-label">
+  <header class="bestiary__header">
+    <SectionLabel as="h3" id="bestiary-label">Bestiary</SectionLabel>
+    <span class="count">{creatures.length}</span>
+  </header>
+
+  <div class="bestiary__search">
+    <Input
+      ariaLabel="Search bestiary"
+      type="search"
+      placeholder="Search…"
+      bind:value={query}
+    >
+      <span slot="leading" aria-hidden="true">⌕</span>
+    </Input>
+  </div>
+
+  {#if filtered.length === 0}
+    <p class="empty">No matching creatures.</p>
+  {:else}
+    <ul class="rows">
+      {#each filtered as creature (creature.id)}
+        <li class="row">
+          <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
+          <span class="row__body">
+            <span class="row__name">{creature.name}</span>
+            <span class="row__traits">{creature.traits.join(' · ')}</span>
+          </span>
+          <IconButton
+            ariaLabel="Add {creature.name}"
+            title="Add to encounter"
+            variant="primary"
+            size={26}
+            onclick={() => onAddCreature(creature)}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+              <path d="M7 2v10M2 7h10" />
+            </svg>
+          </IconButton>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .bestiary {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .bestiary__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+
+  .count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-ink-mute);
+  }
+
+  .empty {
+    margin: var(--space-2) 0 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0;
+    max-height: 320px;
+    overflow: auto;
+    border-top: var(--border-thin);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px dashed var(--color-rule);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .row__level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  .row__body {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .row__name {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__traits {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/components/BestiarySection.test.ts
+++ b/src/components/BestiarySection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Creature } from '../domain';
+import BestiarySection from './BestiarySection.svelte';
+
+function creature(id: string, name: string, traits: string[] = [], level = 1): Creature {
+  return {
+    id,
+    name,
+    level,
+    traits,
+    size: 'medium',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 5,
+    reflex: 5,
+    will: 5,
+    perception: 5,
+    hp: 20,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    skills: {},
+    source: 'test',
+    tags: []
+  };
+}
+
+describe('BestiarySection', () => {
+  test('renders one row per creature with name and level', () => {
+    const creatures = [
+      creature('a', 'Goblin Warrior', ['goblin', 'humanoid'], 1),
+      creature('b', 'Cave Wolf', ['animal'], 2)
+    ];
+    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    expect(screen.getByText('Goblin Warrior')).toBeInTheDocument();
+    expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
+  });
+
+  test('renders the empty-state message when the search filters everything out', async () => {
+    const creatures = [creature('a', 'Goblin Warrior', ['goblin'], 1)];
+    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
+    await fireEvent.input(search, { target: { value: 'dragon' } });
+    expect(screen.getByText('No matching creatures.')).toBeInTheDocument();
+  });
+
+  test('search filters creatures by name (case-insensitive)', async () => {
+    const creatures = [
+      creature('a', 'Goblin Warrior', ['goblin'], 1),
+      creature('b', 'Cave Wolf', ['animal'], 2)
+    ];
+    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
+    await fireEvent.input(search, { target: { value: 'WOLF' } });
+    expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
+    expect(screen.queryByText('Goblin Warrior')).not.toBeInTheDocument();
+  });
+
+  test('search also matches on creature traits', async () => {
+    const creatures = [
+      creature('a', 'Goblin Warrior', ['goblin', 'humanoid'], 1),
+      creature('b', 'Cave Wolf', ['animal'], 2)
+    ];
+    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
+    await fireEvent.input(search, { target: { value: 'animal' } });
+    expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
+    expect(screen.queryByText('Goblin Warrior')).not.toBeInTheDocument();
+  });
+
+  test('the per-row + button calls onAddCreature with that creature', async () => {
+    const onAddCreature = vi.fn();
+    const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
+    render(BestiarySection, { props: { creatures: [c], onAddCreature } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Add Goblin Warrior' }));
+    expect(onAddCreature).toHaveBeenCalledWith(c);
+  });
+});

--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { Creature } from '../domain';
+  import type { ManualCombatantInput, TemplateAdjustmentChoice } from '$lib/encounter-app';
+  import BestiarySection from './BestiarySection.svelte';
+  import PartySection from './PartySection.svelte';
+  import SetupPanel from './SetupPanel.svelte';
+
+  export let canStart: boolean;
+  export let creatures: Creature[];
+  export let onAddCreatures: (input: {
+    creature: Creature;
+    adjustment: TemplateAdjustmentChoice;
+    quantity: number;
+    namePrefix: string;
+  }) => void;
+  export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
+  export let onImportYamlFiles: (files: File[]) => void;
+  export let onStart: () => void;
+  export let onReset: () => void;
+
+  function quickAdd(creature: Creature) {
+    onAddCreatures({ creature, adjustment: 'normal', quantity: 1, namePrefix: '' });
+  }
+</script>
+
+<aside class="library" aria-labelledby="library-title">
+  <header class="library__header">
+    <h2 id="library-title">Library</h2>
+  </header>
+  <PartySection />
+  <BestiarySection {creatures} onAddCreature={quickAdd} />
+  <div class="library__configure">
+    <SetupPanel
+      {canStart}
+      {creatures}
+      {onAddCreatures}
+      {onAddManual}
+      {onImportYamlFiles}
+      {onStart}
+      {onReset}
+    />
+  </div>
+</aside>
+
+<style>
+  .library {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .library__header {
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-panel-2);
+    border-bottom: var(--border-thin);
+  }
+
+  h2 {
+    margin: 0;
+    font-family: var(--font-serif);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--color-ink);
+    line-height: var(--leading-tight);
+  }
+
+  /*
+   * SetupPanel still owns the configure-before-add form (template / quantity /
+   * name prefix), the manual-combatant form, the YAML import flow, and the
+   * Start / Reset buttons. A future slice can split those further (per-row
+   * configure UI in the bestiary) and strip SetupPanel's redundant creature
+   * dropdown; for now the dropdown coexists with the bestiary list above.
+   */
+  .library__configure {
+    border-top: var(--border-thin);
+    padding: var(--space-3) var(--space-4);
+  }
+</style>

--- a/src/components/PartySection.svelte
+++ b/src/components/PartySection.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import SectionLabel from './ui/SectionLabel.svelte';
+</script>
+
+<section class="party" aria-labelledby="party-label">
+  <SectionLabel as="h3" id="party-label">Party</SectionLabel>
+  <p class="empty">
+    PCs become first-class entities once issue
+    <a href="https://github.com/mbednarski/pf2e-encounter-tracker-v2/issues/52" target="_blank" rel="noopener">#52</a>
+    lands. For now, party members are added via the Bestiary or as custom combatants below.
+  </p>
+</section>
+
+<style>
+  .party {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: var(--border-thin);
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--color-ink-soft);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+  }
+
+  .empty a {
+    color: var(--color-blue);
+    text-decoration: underline dotted;
+  }
+</style>

--- a/src/components/ui/SectionLabel.svelte
+++ b/src/components/ui/SectionLabel.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   export let as: 'span' | 'div' | 'h2' | 'h3' | 'h4' = 'span';
+  export let id: string | undefined = undefined;
 </script>
 
-<svelte:element this={as} class="label">
+<svelte:element this={as} {id} class="label">
   <slot />
 </svelte:element>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,8 @@
   import CombatLogDrawer from '../components/CombatLogDrawer.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
   import CombatantDetailsPanel from '../components/CombatantDetailsPanel.svelte';
+  import LibraryPane from '../components/LibraryPane.svelte';
   import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
-  import SetupPanel from '../components/SetupPanel.svelte';
   import {
     combatantCardActions,
     currentCombatant,
@@ -346,8 +346,8 @@
   />
 
   <section class="workspace">
-    <aside class="workspace__library">
-      <SetupPanel
+    <div class="workspace__library">
+      <LibraryPane
         {canStart}
         creatures={availableCreatures}
         onAddCreatures={handleAddCreatures}
@@ -356,7 +356,7 @@
         onStart={startEncounter}
         onReset={resetLocal}
       />
-    </aside>
+    </div>
 
     <section class="workspace__track" aria-label="Combatants">
       <PromptResolutionPanel


### PR DESCRIPTION
Fifth slice of the UI overhaul. Introduces a dedicated Library pane in the left grid slot.

## Summary

Three new sub-components under `src/components/`:

- **PartySection** — empty-state placeholder. Points users at the Bestiary or custom-combatant flow until PCs become first-class entities (#52).
- **BestiarySection** — Library search experience: name + trait substring search, level badge, traits in tracked uppercase, per-row \"+\" quick-add (calls `onAddCreatures` with `adjustment: 'normal'`, `quantity: 1`).
- **LibraryPane** — composes Party + Bestiary + the existing `SetupPanel` underneath as the \"configure-before-add\" zone (template / quantity / name prefix, manual-combatant form, YAML import, Start / Reset).

The `+page.svelte` mount swaps `<SetupPanel>` for `<LibraryPane>` with the same prop set; no orchestrator changes.

A small primitive change: `SectionLabel` now accepts an `id` prop so callers can wire `aria-labelledby`. Used by both new sub-sections.

## Scope decision

The plan called for stripping the duplicate creature dropdown from `SetupPanel`. **I left it in.** Reason: stripping the dropdown without designing a per-row template/qty/prefix UI in the Bestiary would lose the configure-before-add workflow. The Bestiary's quick-add covers the common case; the dropdown coexists as the configure path. A future slice can collapse them once the per-row config is built.

This means users see two ways to pick a creature for now (the Bestiary list and the dropdown below it). Functional but visually busy — that's the transitional state.

## Out of scope

- Per-row template / quantity / name-prefix configuration in BestiarySection
- Stripping `SetupPanel`'s creature dropdown (deferred — see above)
- Level-range chips and trait filter pills (the design has both; deferred to a later slice)
- Drag-to-add (still click + button)
- True Party support (#52)

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 382 / 382 passing (added 5 for BestiarySection)
- [x] `npm run audit` — 3 low-severity (below threshold)
- [x] `npm run build` — clean
- [ ] Run an encounter end-to-end: search filters live; \"+\" adds a creature with defaults; the configure form below still works for template + quantity (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)