### PR TITLE
UI overhaul PR 8: TopBar + PromptResolutionPanel restyle

### DIFF
--- a/src/components/PromptResolutionPanel.svelte
+++ b/src/components/PromptResolutionPanel.svelte
@@ -6,6 +6,8 @@
     PromptResolution,
     TurnBoundarySuggestion
   } from '../domain';
+  import Button from './ui/Button.svelte';
+  import SectionLabel from './ui/SectionLabel.svelte';
 
   export let prompts: Prompt[];
   export let combatantsById: Record<string, CombatantState>;
@@ -92,31 +94,34 @@
 
 {#if focused}
   <aside
-    class="panel prompt-panel"
+    class="prompt-panel"
     aria-labelledby="prompt-resolution-title"
     aria-live="polite"
   >
-    <div class="panel-heading">
+    <header class="prompt-panel__header">
       <h2 id="prompt-resolution-title">Awaiting GM resolution</h2>
-      <span>{prompts.length}</span>
-    </div>
+      <span class="prompt-panel__count">{prompts.length}</span>
+    </header>
     <ol class="prompt-list">
       {#each prompts as prompt (prompt.id)}
         {@const target = targetLabel(prompt)}
         <li class="prompt">
-          <div class="meta">
-            <span class="boundary">{boundaryLabel(prompt)}</span>
-            <span class="effect">{prompt.effectName}</span>
+          <div class="prompt__meta">
+            <SectionLabel>{boundaryLabel(prompt)}</SectionLabel>
+            <span class="prompt__effect">{prompt.effectName}</span>
             {#if target}
-              <span class="target">on {target}</span>
+              <span class="prompt__target">on {target}</span>
             {/if}
           </div>
-          <p class="description">{prompt.description}</p>
-          <div class="actions">
+          <p class="prompt__description">{prompt.description}</p>
+          <div class="prompt__actions">
             {#if showAccept(prompt.suggestionType)}
-              <button type="button" class="primary" on:click={() => handleAccept(prompt)}>
-                {acceptLabel(prompt.suggestionType)}
-              </button>
+              <Button
+                size="sm"
+                variant="primary"
+                ariaLabel={acceptLabel(prompt.suggestionType)}
+                onclick={() => handleAccept(prompt)}
+              >{acceptLabel(prompt.suggestionType)}</Button>
             {/if}
             {#if supportsSetValue(prompt.suggestionType)}
               <span class="set-value">
@@ -128,14 +133,27 @@
                     bind:value={setValueDrafts[prompt.id]}
                   />
                 </label>
-                <button type="button" on:click={() => handleSetValue(prompt)}>Set</button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  ariaLabel="Set"
+                  onclick={() => handleSetValue(prompt)}
+                >Set</Button>
               </span>
             {/if}
-            <button type="button" on:click={() => handleDismiss(prompt)}>Dismiss</button>
+            <Button
+              size="sm"
+              variant="secondary"
+              ariaLabel="Dismiss"
+              onclick={() => handleDismiss(prompt)}
+            >Dismiss</Button>
             {#if showRemove(prompt.suggestionType)}
-              <button type="button" class="danger" on:click={() => handleRemove(prompt)}>
-                Remove effect
-              </button>
+              <Button
+                size="sm"
+                variant="destructive"
+                ariaLabel="Remove effect"
+                onclick={() => handleRemove(prompt)}
+              >Remove effect</Button>
             {/if}
           </div>
         </li>
@@ -145,134 +163,117 @@
 {/if}
 
 <style>
-  .panel {
-    border: 1px solid #b6652e;
-    border-radius: 8px;
+  .prompt-panel {
     background: #fff7ee;
-    box-shadow: 0 1px 2px rgb(29 37 40 / 7%);
-    padding: 14px;
-    max-width: 1440px;
-    margin: 0 auto 18px;
+    border: 1px solid var(--color-amber);
+    border-left: 4px solid var(--color-amber);
+    border-radius: var(--radius-card);
+    padding: var(--space-3) var(--space-4);
   }
 
-  .panel-heading {
+  .prompt-panel__header {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 14px;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
   }
 
   h2 {
     margin: 0;
-    font-size: 17px;
-    line-height: 1.2;
-    color: #6f3f16;
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+    line-height: var(--leading-tight);
+    color: var(--color-amber);
   }
 
-  .panel-heading > span {
-    color: #6f3f16;
-    font-size: 13px;
+  .prompt-panel__count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     font-weight: 600;
+    color: var(--color-amber);
   }
 
   .prompt-list {
     display: grid;
-    gap: 10px;
+    gap: var(--space-2);
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
   .prompt {
-    border-left: 4px solid #b6652e;
-    border-radius: 6px;
-    background: #ffffff;
-    padding: 10px 12px;
+    background: var(--color-panel);
+    border: var(--border-thin);
+    border-left: 3px solid var(--color-amber);
+    padding: var(--space-2) var(--space-3);
     display: grid;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
-  .meta {
+  .prompt__meta {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
-    gap: 6px;
-    font-size: 12px;
-    color: #627171;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-ink-soft);
   }
 
-  .meta .boundary {
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-    color: #6f3f16;
-  }
-
-  .meta .effect {
-    color: #1d2528;
-    font-size: 14px;
+  .prompt__effect {
+    color: var(--color-ink);
+    font-size: var(--text-base);
     font-weight: 600;
   }
 
-  .description {
+  .prompt__target {
+    color: var(--color-ink-soft);
+    font-size: var(--text-sm);
+    font-style: italic;
+  }
+
+  .prompt__description {
     margin: 0;
-    font-size: 13px;
-    color: #1d2528;
+    font-size: var(--text-base);
+    color: var(--color-ink);
+    line-height: var(--leading-snug);
   }
 
-  .actions {
+  .prompt__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: var(--space-2);
     align-items: center;
-  }
-
-  .actions button {
-    border: 1px solid #cfd6d1;
-    background: #fbfcfa;
-    color: #1d2528;
-    border-radius: 6px;
-    padding: 6px 10px;
-    font-size: 13px;
-    cursor: pointer;
-  }
-
-  .actions button.primary {
-    background: #b6652e;
-    border-color: #6f3f16;
-    color: #ffffff;
-  }
-
-  .actions button.danger {
-    background: #fbfcfa;
-    border-color: #b6652e;
-    color: #6f3f16;
-  }
-
-  .actions button:hover {
-    filter: brightness(0.96);
   }
 
   .set-value {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--space-2);
   }
 
   .set-value label {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    font-size: 13px;
-    color: #1d2528;
+    gap: var(--space-2);
+    font-size: var(--text-base);
+    color: var(--color-ink);
   }
 
   .set-value input {
     width: 64px;
-    padding: 4px 6px;
-    border: 1px solid #cfd6d1;
-    border-radius: 6px;
-    font-size: 13px;
+    padding: 4px var(--space-2);
+    border: var(--border-thin);
+    background: var(--color-panel);
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+  }
+
+  .set-value input:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+    border-color: var(--color-ink);
   }
 </style>

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { EncounterState } from '../domain';
+  import Chip from './ui/Chip.svelte';
+  import SectionLabel from './ui/SectionLabel.svelte';
 
   export let name: string;
   export let phase: EncounterState['phase'];
@@ -8,15 +10,20 @@
 </script>
 
 <header class="topbar">
-  <div>
-    <p class="eyebrow">PF2e Encounter Tracker v2</p>
+  <div class="topbar__title">
+    <SectionLabel>PF2e Encounter Tracker v2</SectionLabel>
     <h1>{name}</h1>
   </div>
-  <div class="status-strip" aria-label="Encounter status">
-    <span class="status">{phase}</span>
-    <span>Round {round}</span>
-    <span>{activeName ? `${activeName}'s turn` : 'No active turn'}</span>
-    <a class="settings-link" href="/settings">Settings</a>
+  <div class="topbar__status" aria-label="Encounter status">
+    <Chip variant={phase === 'ACTIVE' ? 'success' : 'default'}>{phase}</Chip>
+    <div class="topbar__round">
+      <SectionLabel>Round</SectionLabel>
+      <span class="topbar__round-value">{round}</span>
+    </div>
+    <span class="topbar__turn">
+      {activeName ? `${activeName}'s turn` : 'No active turn'}
+    </span>
+    <a class="topbar__settings" href="/settings">Settings</a>
   </div>
 </header>
 
@@ -25,63 +32,85 @@
     display: flex;
     align-items: end;
     justify-content: space-between;
-    gap: 20px;
-    margin: 0 auto 18px;
+    gap: var(--space-5);
+    margin: 0 auto var(--space-4);
     max-width: 1440px;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
   }
 
-  .eyebrow,
+  .topbar__title {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+  }
+
   h1 {
     margin: 0;
+    font-family: var(--font-serif);
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    line-height: var(--leading-tight);
+    color: var(--color-ink);
+    letter-spacing: -0.2px;
   }
 
-  .eyebrow {
-    color: #697170;
-    font-size: 13px;
-    font-weight: 700;
-    text-transform: uppercase;
-  }
-
-  h1 {
-    font-size: 32px;
-    line-height: 1.1;
-  }
-
-  .status-strip {
+  .topbar__status {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 8px;
-    color: #415052;
-    font-size: 14px;
-  }
-
-  .status-strip span,
-  .status,
-  .settings-link {
-    border: 1px solid #c5ccc8;
-    border-radius: 6px;
-    background: #ffffff;
-    padding: 8px 10px;
-  }
-
-  .settings-link {
-    color: #28494c;
-    text-decoration: none;
-    font-weight: 600;
-    min-height: 44px;
-    display: inline-flex;
     align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    color: var(--color-ink-soft);
+    font-size: var(--text-base);
   }
 
-  .settings-link:hover {
-    background: #eef2f0;
+  .topbar__round {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0;
   }
 
-  .status {
-    color: #f3f6f5;
-    background: #28494c;
-    border-color: #28494c;
+  .topbar__round-value {
+    font-family: var(--font-mono);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--color-red);
+    line-height: var(--leading-tight);
+  }
+
+  .topbar__turn {
+    color: var(--color-ink-soft);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .topbar__settings {
+    color: var(--color-ink);
+    text-decoration: none;
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    border: var(--border-thin);
+    background: transparent;
+    padding: 6px var(--space-3);
+    transition: background 0.12s, border-color 0.12s;
+  }
+
+  .topbar__settings:hover {
+    background: var(--color-panel-2);
+    border-color: var(--color-ink);
+  }
+
+  .topbar__settings:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
   }
 
   @media (max-width: 760px) {
@@ -90,7 +119,7 @@
       grid-template-columns: 1fr;
     }
 
-    .status-strip {
+    .topbar__status {
       justify-content: start;
     }
   }


### PR DESCRIPTION
Final slice of the UI overhaul. After this merges, every visible surface in the encounter screen reads from the design tokens.

## TopBar

- Parchment chrome (`--color-panel` + ruleStrong border)
- Eyebrow uses `SectionLabel`; serif `h1` for the encounter name
- Phase becomes a `Chip` (`success` variant when `ACTIVE`)
- Round counter: `SectionLabel` + mono red value (mirrors the design's red round indicator from `direction-a.jsx` line 605)
- Settings link: ghost outline with uppercase label and tracked letters, same focus ring pattern as the `Button` primitive

## PromptResolutionPanel

- Replace ad-hoc orange `#b6652e` with `--color-amber` across the panel border, accent rail, heading, and per-prompt left-bar
- Parchment chrome inside (`--color-panel` for the prompt cards), with the warm `#fff7ee` outer container left intact for the alert tone
- Boundary label promoted to `SectionLabel` (uppercase tracked letters) for parity with stat labels elsewhere
- Action row swapped to `Button` primitives: **Accept** primary, **Decrement / Confirm sustained / Set / Dismiss** secondary, **Remove effect** destructive
- `on:click` migrated to `onclick` to match the rest of the project

## Behavior preservation

Every aria contract the existing test asserts is intact:
- TopBar status strip retains `aria-label="Encounter status"`
- Prompt panel keeps `aria-labelledby="prompt-resolution-title"`, `aria-live="polite"`, `h2` "Awaiting GM resolution"
- Every button text label is preserved: `Accept` / `Decrement by N` / `Remove (expires)` / `Confirm sustained` / `Dismiss` / `Remove effect` / `Set` / `Set value for {effect}`

All 382 tests pass without modification.

## After this PR

The plan's 8-PR sequence is complete:
1. ✅ Tokens + self-hosted fonts
2. ✅ Primitive layer
3. ✅ 3-pane shell + bottom drawer
4. ✅ Combat Log component (degraded)
5. ✅ Library pane
6. ✅ CombatantCard restyle
7. ✅ DetailsPanel restyle
8. ✅ TopBar + Prompt restyle (this PR)

Deferred for later slices (called out in the plan): condition-picker UX rework, drag-to-add, level/trait filter pills, by-round + kind-coded combat log, true Party support (#52), Direction B (dark) palette, settings-page restyle.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 382 / 382 passing
- [x] `npm run audit` — 3 low-severity (below threshold)
- [x] `npm run build` — clean
- [ ] Run an encounter end-to-end: confirm TopBar phase chip, round counter, and settings link work; confirm a prompt-resolution scenario still resolves with Accept / Dismiss / Remove / Set (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)