### PR TITLE
Add party members as first-class persistent entities (#52, foundation slice)

### DIFF
--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-  import type { Creature } from '../domain';
-  import type { ManualCombatantInput, TemplateAdjustmentChoice } from '$lib/encounter-app';
+  import type { Creature, PartyMember } from '../domain';
+  import type {
+    ConditionOption,
+    ManualCombatantInput,
+    TemplateAdjustmentChoice
+  } from '$lib/encounter-app';
   import BestiarySection from './BestiarySection.svelte';
   import PartySection from './PartySection.svelte';
   import SetupPanel from './SetupPanel.svelte';
 
   export let canStart: boolean;
   export let creatures: Creature[];
+  export let partyMembers: PartyMember[];
+  export let conditionOptions: ConditionOption[];
   export let onAddCreatures: (input: {
     creature: Creature;
     adjustment: TemplateAdjustmentChoice;
@@ -16,6 +22,10 @@
   export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
   export let onImportYamlFiles: (files: File[]) => void;
   export let onRemoveCreature: (id: string) => void;
+  export let onAddPartyMemberToEncounter: (partyMember: PartyMember) => void;
+  export let onRemovePartyMember: (id: string) => void;
+  export let onSavePartyMember: (partyMember: PartyMember) => void;
+  export let onImportPartyMemberYamlFiles: (files: File[]) => void;
   export let onStart: () => void;
   export let onReset: () => void;
 
@@ -28,7 +38,14 @@
   <header class="library__header">
     <h2 id="library-title">Library</h2>
   </header>
-  <PartySection />
+  <PartySection
+    {partyMembers}
+    {conditionOptions}
+    {onAddPartyMemberToEncounter}
+    {onRemovePartyMember}
+    {onSavePartyMember}
+    {onImportPartyMemberYamlFiles}
+  />
   <BestiarySection {creatures} onAddCreature={quickAdd} {onRemoveCreature} />
   <div class="library__configure">
     <SetupPanel

--- a/src/components/PartyMemberEditModal.svelte
+++ b/src/components/PartyMemberEditModal.svelte
@@ -1,0 +1,576 @@
+<script lang="ts">
+  import type { AppliedEffect, PartyMember } from '../domain';
+  import type { ConditionOption } from '$lib/encounter-app';
+  import Button from './ui/Button.svelte';
+  import IconButton from './ui/IconButton.svelte';
+
+  export let partyMember: PartyMember | null;
+  export let conditionOptions: ConditionOption[];
+  export let existingIds: string[];
+  export let onSave: (member: PartyMember) => void;
+  export let onClose: () => void;
+
+  type SpeedRow = { key: string; value: number };
+  type SkillRow = { key: string; value: number };
+  type DamageRow = { type: string; value: number };
+  type EffectRow = AppliedEffect;
+
+  const initial = partyMember;
+
+  let id = initial?.id ?? '';
+  let name = initial?.name ?? '';
+  let playerName = initial?.playerName ?? '';
+  let level = initial?.level ?? 1;
+  let ancestry = initial?.ancestry ?? '';
+  let className = initial?.class ?? '';
+
+  let ac = initial?.ac ?? 16;
+  let fortitude = initial?.fortitude ?? 5;
+  let reflex = initial?.reflex ?? 5;
+  let will = initial?.will ?? 5;
+  let perception = initial?.perception ?? 5;
+  let hp = initial?.hp ?? 20;
+
+  let speedRows: SpeedRow[] = recordToRows(initial?.speed);
+  let skillRows: SkillRow[] = recordToRows(initial?.skills);
+  let resistanceRows: DamageRow[] = (initial?.resistances ?? []).map((r) => ({ ...r }));
+  let weaknessRows: DamageRow[] = (initial?.weaknesses ?? []).map((w) => ({ ...w }));
+  let immunitiesText = (initial?.immunities ?? []).join(', ');
+  let tagsText = (initial?.tags ?? []).join(', ');
+  let notes = initial?.notes ?? '';
+
+  let effectRows: EffectRow[] = (initial?.persistentEffects ?? []).map((e) => structuredClone(e));
+  let effectToAdd = conditionOptions[0]?.id ?? '';
+  let effectValueToAdd = 1;
+
+  let validationError: string | null = null;
+
+  function recordToRows(record: Record<string, number> | undefined): { key: string; value: number }[] {
+    if (!record) return [];
+    return Object.entries(record).map(([key, value]) => ({ key, value }));
+  }
+
+  function rowsToRecord(rows: { key: string; value: number }[]): Record<string, number> | undefined {
+    const out: Record<string, number> = {};
+    for (const row of rows) {
+      const k = row.key.trim();
+      if (k && Number.isFinite(row.value)) out[k] = row.value;
+    }
+    return Object.keys(out).length === 0 ? undefined : out;
+  }
+
+  function parseList(text: string): string[] {
+    return text
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
+  function slugify(s: string): string {
+    return s
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  function generateId(): string {
+    const base = slugify(name) || 'party-member';
+    if (!existingIds.includes(base)) return base;
+    let i = 2;
+    while (existingIds.includes(`${base}-${i}`)) i++;
+    return `${base}-${i}`;
+  }
+
+  function generateInstanceId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `pm-effect-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  }
+
+  function selectedConditionOption(): ConditionOption | undefined {
+    return conditionOptions.find((c) => c.id === effectToAdd);
+  }
+
+  function addEffect() {
+    const option = selectedConditionOption();
+    if (!option) return;
+    const row: EffectRow = {
+      instanceId: generateInstanceId(),
+      effectId: option.id,
+      duration: { type: 'unlimited' }
+    };
+    if (option.value.kind === 'valued') {
+      row.value = Math.max(1, Math.trunc(effectValueToAdd) || 1);
+    }
+    effectRows = [...effectRows, row];
+  }
+
+  function removeEffect(instanceId: string) {
+    effectRows = effectRows.filter((e) => e.instanceId !== instanceId);
+  }
+
+  function effectName(effectId: string): string {
+    return conditionOptions.find((c) => c.id === effectId)?.name ?? effectId;
+  }
+
+  function addSpeedRow() {
+    speedRows = [...speedRows, { key: '', value: 0 }];
+  }
+  function removeSpeedRow(index: number) {
+    speedRows = speedRows.filter((_, i) => i !== index);
+  }
+  function addSkillRow() {
+    skillRows = [...skillRows, { key: '', value: 0 }];
+  }
+  function removeSkillRow(index: number) {
+    skillRows = skillRows.filter((_, i) => i !== index);
+  }
+  function addResistanceRow() {
+    resistanceRows = [...resistanceRows, { type: '', value: 0 }];
+  }
+  function removeResistanceRow(index: number) {
+    resistanceRows = resistanceRows.filter((_, i) => i !== index);
+  }
+  function addWeaknessRow() {
+    weaknessRows = [...weaknessRows, { type: '', value: 0 }];
+  }
+  function removeWeaknessRow(index: number) {
+    weaknessRows = weaknessRows.filter((_, i) => i !== index);
+  }
+
+  function handleSubmit(event: Event) {
+    event.preventDefault();
+    validationError = null;
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      validationError = 'Name is required.';
+      return;
+    }
+    if (!Number.isFinite(level) || level < 1) {
+      validationError = 'Level must be at least 1.';
+      return;
+    }
+    for (const [label, val] of Object.entries({ ac, fortitude, reflex, will, perception, hp })) {
+      if (!Number.isFinite(val) || val < 0) {
+        validationError = `${label.toUpperCase()} must be a non-negative number.`;
+        return;
+      }
+    }
+
+    const finalId = id || generateId();
+    const member: PartyMember = {
+      id: finalId,
+      name: trimmedName,
+      level: Math.trunc(level),
+      ac: Math.trunc(ac),
+      fortitude: Math.trunc(fortitude),
+      reflex: Math.trunc(reflex),
+      will: Math.trunc(will),
+      perception: Math.trunc(perception),
+      hp: Math.trunc(hp),
+      persistentEffects: effectRows.map((e) => structuredClone(e)),
+      companionIds: initial?.companionIds ?? [],
+      tags: parseList(tagsText)
+    };
+
+    const trimmedPlayerName = playerName.trim();
+    if (trimmedPlayerName) member.playerName = trimmedPlayerName;
+    const trimmedAncestry = ancestry.trim();
+    if (trimmedAncestry) member.ancestry = trimmedAncestry;
+    const trimmedClass = className.trim();
+    if (trimmedClass) member.class = trimmedClass;
+    const trimmedNotes = notes.trim();
+    if (trimmedNotes) member.notes = trimmedNotes;
+
+    const speed = rowsToRecord(speedRows);
+    if (speed) member.speed = speed;
+    const skills = rowsToRecord(skillRows);
+    if (skills) member.skills = skills;
+    if (resistanceRows.length > 0) {
+      member.resistances = resistanceRows
+        .filter((r) => r.type.trim())
+        .map((r) => ({ type: r.type.trim(), value: Math.trunc(r.value) }));
+      if (member.resistances.length === 0) delete member.resistances;
+    }
+    if (weaknessRows.length > 0) {
+      member.weaknesses = weaknessRows
+        .filter((w) => w.type.trim())
+        .map((w) => ({ type: w.type.trim(), value: Math.trunc(w.value) }));
+      if (member.weaknesses.length === 0) delete member.weaknesses;
+    }
+    const immunitiesList = parseList(immunitiesText);
+    if (immunitiesList.length > 0) member.immunities = immunitiesList;
+
+    onSave(member);
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) onClose();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') onClose();
+  }
+
+  $: selectedOption = selectedConditionOption();
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+  class="backdrop"
+  role="presentation"
+  onclick={handleBackdropClick}
+>
+  <div
+    class="modal"
+    role="dialog"
+    aria-labelledby="party-member-modal-title"
+    aria-modal="true"
+  >
+  <form class="modal__form" onsubmit={handleSubmit}>
+    <header class="modal__header">
+      <h2 id="party-member-modal-title">{initial ? 'Edit Party Member' : 'New Party Member'}</h2>
+      <IconButton ariaLabel="Close" variant="default" onclick={onClose}>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+          <path d="M2 2l8 8M10 2l-8 8" />
+        </svg>
+      </IconButton>
+    </header>
+
+    <div class="modal__body">
+      <fieldset class="block">
+        <legend>Identity</legend>
+        <label>Name<input bind:value={name} autocomplete="off" required /></label>
+        <label>Player<input bind:value={playerName} autocomplete="off" /></label>
+        <div class="row-3">
+          <label>Level<input type="number" min="1" bind:value={level} /></label>
+          <label>Ancestry<input bind:value={ancestry} autocomplete="off" /></label>
+          <label>Class<input bind:value={className} autocomplete="off" /></label>
+        </div>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Defenses</legend>
+        <div class="stat-grid">
+          <label>AC<input type="number" min="0" bind:value={ac} /></label>
+          <label>Fort<input type="number" min="0" bind:value={fortitude} /></label>
+          <label>Ref<input type="number" min="0" bind:value={reflex} /></label>
+          <label>Will<input type="number" min="0" bind:value={will} /></label>
+          <label>Per<input type="number" min="0" bind:value={perception} /></label>
+          <label>Max HP<input type="number" min="0" bind:value={hp} /></label>
+        </div>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Speed</legend>
+        {#each speedRows as row, i (i)}
+          <div class="kv-row">
+            <input bind:value={row.key} placeholder="land" autocomplete="off" />
+            <input type="number" bind:value={row.value} placeholder="30" />
+            <IconButton ariaLabel="Remove speed entry" variant="destructive" onclick={() => removeSpeedRow(i)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          </div>
+        {/each}
+        <Button variant="ghost" size="sm" onclick={addSpeedRow}>+ Speed</Button>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Skills</legend>
+        {#each skillRows as row, i (i)}
+          <div class="kv-row">
+            <input bind:value={row.key} placeholder="arcana" autocomplete="off" />
+            <input type="number" bind:value={row.value} placeholder="14" />
+            <IconButton ariaLabel="Remove skill entry" variant="destructive" onclick={() => removeSkillRow(i)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          </div>
+        {/each}
+        <Button variant="ghost" size="sm" onclick={addSkillRow}>+ Skill</Button>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Resistances</legend>
+        {#each resistanceRows as row, i (i)}
+          <div class="kv-row">
+            <input bind:value={row.type} placeholder="cold" autocomplete="off" />
+            <input type="number" bind:value={row.value} placeholder="2" />
+            <IconButton ariaLabel="Remove resistance" variant="destructive" onclick={() => removeResistanceRow(i)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          </div>
+        {/each}
+        <Button variant="ghost" size="sm" onclick={addResistanceRow}>+ Resistance</Button>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Weaknesses</legend>
+        {#each weaknessRows as row, i (i)}
+          <div class="kv-row">
+            <input bind:value={row.type} placeholder="fire" autocomplete="off" />
+            <input type="number" bind:value={row.value} placeholder="5" />
+            <IconButton ariaLabel="Remove weakness" variant="destructive" onclick={() => removeWeaknessRow(i)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          </div>
+        {/each}
+        <Button variant="ghost" size="sm" onclick={addWeaknessRow}>+ Weakness</Button>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Immunities</legend>
+        <input bind:value={immunitiesText} placeholder="sleep, poison" autocomplete="off" />
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Tags</legend>
+        <input bind:value={tagsText} placeholder="party-leader, arcane" autocomplete="off" />
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Persistent Effects</legend>
+        <p class="hint">Effects that carry between encounters (e.g. Wounded 1, Doomed 2). Applied to the combatant when this member joins an encounter.</p>
+        {#if effectRows.length > 0}
+          <ul class="effect-list">
+            {#each effectRows as effect (effect.instanceId)}
+              <li class="effect-row">
+                <span class="effect-name">{effectName(effect.effectId)}</span>
+                {#if effect.value !== undefined}
+                  <span class="effect-value">{effect.value}</span>
+                {/if}
+                <IconButton ariaLabel="Remove {effectName(effect.effectId)}" variant="destructive" onclick={() => removeEffect(effect.instanceId)}>
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                    <path d="M2 6h8" />
+                  </svg>
+                </IconButton>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="empty">No persistent effects.</p>
+        {/if}
+        <div class="add-effect">
+          <select bind:value={effectToAdd} aria-label="Select condition">
+            {#each conditionOptions as option (option.id)}
+              <option value={option.id}>{option.name}</option>
+            {/each}
+          </select>
+          {#if selectedOption?.value.kind === 'valued'}
+            <input type="number" min="1" max={selectedOption.value.maxValue ?? 999} bind:value={effectValueToAdd} aria-label="Effect value" />
+          {/if}
+          <Button variant="secondary" size="sm" onclick={addEffect}>Add Effect</Button>
+        </div>
+      </fieldset>
+
+      <fieldset class="block">
+        <legend>Notes</legend>
+        <textarea rows="3" bind:value={notes}></textarea>
+      </fieldset>
+    </div>
+
+    {#if validationError}
+      <p class="error" role="alert">{validationError}</p>
+    {/if}
+
+    <footer class="modal__footer">
+      <Button variant="ghost" onclick={onClose}>Cancel</Button>
+      <Button variant="primary" type="submit">Save</Button>
+    </footer>
+  </form>
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgb(0 0 0 / 35%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: var(--space-4);
+  }
+
+  .modal {
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    width: min(640px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgb(29 37 40 / 25%);
+  }
+
+  .modal__form {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    border-bottom: var(--border-thin);
+  }
+
+  .modal__header h2 {
+    margin: 0;
+    font-family: var(--font-serif);
+    font-size: var(--text-lg);
+    font-weight: 600;
+  }
+
+  .modal__body {
+    padding: var(--space-3) var(--space-4);
+    overflow-y: auto;
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .modal__footer {
+    display: flex;
+    gap: var(--space-2);
+    justify-content: flex-end;
+    padding: var(--space-3) var(--space-4);
+    border-top: var(--border-thin);
+  }
+
+  .block {
+    border: var(--border-thin);
+    border-radius: var(--radius-card);
+    padding: var(--space-2) var(--space-3);
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+  }
+
+  .block legend {
+    padding: 0 var(--space-2);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-ink-mute);
+  }
+
+  .block label {
+    display: grid;
+    gap: 2px;
+    font-size: var(--text-xs);
+    color: var(--color-ink-mute);
+  }
+
+  .block input,
+  .block textarea,
+  .block select {
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    color: var(--color-ink);
+    background: var(--color-panel);
+    border: var(--border-thin);
+    border-radius: var(--radius-card);
+    padding: 4px 8px;
+  }
+
+  .block input:focus,
+  .block textarea:focus,
+  .block select:focus {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-2);
+  }
+
+  .row-3 {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-2);
+  }
+
+  .kv-row {
+    display: grid;
+    grid-template-columns: 1fr 80px auto;
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .effect-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .effect-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: var(--space-2);
+    align-items: center;
+    padding: var(--space-2);
+    background: var(--color-panel-2);
+    border-radius: var(--radius-card);
+  }
+
+  .effect-name {
+    font-weight: 600;
+  }
+
+  .effect-value {
+    font-family: var(--font-mono);
+    color: var(--color-ink-mute);
+  }
+
+  .add-effect {
+    display: grid;
+    grid-template-columns: 1fr 80px auto;
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .add-effect:has(select:only-of-type:not(+ input)) {
+    grid-template-columns: 1fr auto;
+  }
+
+  .hint {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--color-ink-mute);
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-sm);
+    font-style: italic;
+  }
+
+  .error {
+    margin: 0;
+    padding: var(--space-2) var(--space-4);
+    color: var(--color-red);
+    font-size: var(--text-sm);
+  }
+</style>

--- a/src/components/PartySection.svelte
+++ b/src/components/PartySection.svelte
@@ -1,15 +1,167 @@
 <script lang="ts">
+  import type { PartyMember } from '../domain';
+  import type { ConditionOption } from '$lib/encounter-app';
+  import IconButton from './ui/IconButton.svelte';
+  import Input from './ui/Input.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import Button from './ui/Button.svelte';
+  import PartyMemberEditModal from './PartyMemberEditModal.svelte';
+
+  export let partyMembers: PartyMember[];
+  export let conditionOptions: ConditionOption[];
+  export let onAddPartyMemberToEncounter: (partyMember: PartyMember) => void;
+  export let onRemovePartyMember: (id: string) => void;
+  export let onSavePartyMember: (partyMember: PartyMember) => void;
+  export let onImportPartyMemberYamlFiles: (files: File[]) => void;
+
+  let query = '';
+  let editingMember: PartyMember | null = null;
+  let isCreatingNew = false;
+  let fileInput: HTMLInputElement | undefined;
+
+  $: needle = query.trim().toLowerCase();
+  $: filtered = needle
+    ? partyMembers.filter((pm) => {
+        if (pm.name.toLowerCase().includes(needle)) return true;
+        if (pm.playerName?.toLowerCase().includes(needle)) return true;
+        if (pm.class?.toLowerCase().includes(needle)) return true;
+        return pm.tags.some((t) => t.toLowerCase().includes(needle));
+      })
+    : partyMembers;
+
+  $: existingIds = partyMembers.map((pm) => pm.id);
+  $: modalOpen = isCreatingNew || editingMember !== null;
+
+  function openNew() {
+    editingMember = null;
+    isCreatingNew = true;
+  }
+
+  function openEdit(pm: PartyMember) {
+    isCreatingNew = false;
+    editingMember = pm;
+  }
+
+  function closeModal() {
+    editingMember = null;
+    isCreatingNew = false;
+  }
+
+  function handleSave(member: PartyMember) {
+    onSavePartyMember(member);
+    closeModal();
+  }
+
+  function handleFileChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    if (files.length > 0) {
+      onImportPartyMemberYamlFiles(files);
+    }
+    input.value = '';
+  }
+
+  function memberSubtext(pm: PartyMember): string {
+    if (pm.playerName && pm.class) return `${pm.playerName} · ${pm.class}`;
+    return pm.playerName ?? pm.class ?? pm.ancestry ?? '';
+  }
 </script>
 
 <section class="party" aria-labelledby="party-label">
-  <SectionLabel as="h3" id="party-label">Party</SectionLabel>
-  <p class="empty">
-    PCs become first-class entities once issue
-    <a href="https://github.com/mbednarski/pf2e-encounter-tracker-v2/issues/52" target="_blank" rel="noopener">#52</a>
-    lands. For now, party members are added via the Bestiary or as custom combatants below.
-  </p>
+  <header class="party__header">
+    <SectionLabel as="h3" id="party-label">Party</SectionLabel>
+    <span class="count">{partyMembers.length}</span>
+  </header>
+
+  <div class="party__actions">
+    <Button variant="secondary" size="sm" onclick={openNew}>New</Button>
+    <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
+    <input
+      bind:this={fileInput}
+      type="file"
+      accept=".yaml,.yml,application/yaml,text/yaml"
+      multiple
+      hidden
+      onchange={handleFileChange}
+    />
+  </div>
+
+  {#if partyMembers.length > 0}
+    <div class="party__search">
+      <Input
+        ariaLabel="Search party"
+        type="search"
+        placeholder="Search…"
+        bind:value={query}
+      >
+        <span slot="leading" aria-hidden="true">⌕</span>
+      </Input>
+    </div>
+  {/if}
+
+  {#if partyMembers.length === 0}
+    <p class="empty">Click <strong>New</strong> or <strong>Import YAML</strong> to add party members.</p>
+  {:else if filtered.length === 0}
+    <p class="empty">No matching party members.</p>
+  {:else}
+    <ul class="rows">
+      {#each filtered as pm (pm.id)}
+        <li class="row">
+          <span class="row__level" aria-label="Level {pm.level}">{pm.level}</span>
+          <span class="row__body">
+            <span class="row__name">{pm.name}</span>
+            <span class="row__sub">{memberSubtext(pm)}</span>
+          </span>
+          <span class="row__remove">
+            <IconButton
+              ariaLabel="Remove {pm.name} from library"
+              title="Remove from library"
+              variant="destructive"
+              size={22}
+              onclick={() => onRemovePartyMember(pm.id)}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          </span>
+          <IconButton
+            ariaLabel="Edit {pm.name}"
+            title="Edit"
+            variant="default"
+            size={22}
+            onclick={() => openEdit(pm)}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 10l1-3 5-5 2 2-5 5-3 1z" />
+            </svg>
+          </IconButton>
+          <IconButton
+            ariaLabel="Add {pm.name} to encounter"
+            title="Add to encounter"
+            variant="primary"
+            size={26}
+            onclick={() => onAddPartyMemberToEncounter(pm)}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+              <path d="M7 2v10M2 7h10" />
+            </svg>
+          </IconButton>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 </section>
+
+{#if modalOpen}
+  <PartyMemberEditModal
+    partyMember={editingMember}
+    {conditionOptions}
+    {existingIds}
+    onSave={handleSave}
+    onClose={closeModal}
+  />
+{/if}
 
 <style>
   .party {
@@ -19,15 +171,105 @@
     border-bottom: var(--border-thin);
   }
 
-  .empty {
-    margin: 0;
-    color: var(--color-ink-soft);
-    font-size: var(--text-base);
-    line-height: var(--leading-snug);
+  .party__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
   }
 
-  .empty a {
-    color: var(--color-blue);
-    text-decoration: underline dotted;
+  .count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-ink-mute);
+  }
+
+  .party__actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .empty {
+    margin: var(--space-2) 0 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .empty strong {
+    font-style: normal;
+    color: var(--color-ink);
+  }
+
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0;
+    max-height: 320px;
+    overflow: auto;
+    border-top: var(--border-thin);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 32px 1fr auto auto auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px dashed var(--color-rule);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .row__remove {
+    opacity: 0;
+    transition: opacity 0.12s;
+  }
+
+  .row:hover .row__remove,
+  .row:focus-within .row__remove {
+    opacity: 1;
+  }
+
+  .row__level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  .row__body {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .row__name {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__sub {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>

--- a/src/domain/creatures/clone.test.ts
+++ b/src/domain/creatures/clone.test.ts
@@ -15,7 +15,7 @@ describe('createCombatantFromCreature', () => {
 
     expect(combatant).toMatchObject({
       id: 'goblin-1',
-      creatureId: 'goblin-warrior',
+      sourceId: 'goblin-warrior',
       name: 'Goblin Warrior 1',
       sourceType: 'creature',
       baseStats: {
@@ -150,7 +150,7 @@ describe('createCombatantFromCreature', () => {
 
     expect(combatant).toMatchObject({
       id: 'elite-goblin-1',
-      creatureId: 'goblin-warrior',
+      sourceId: 'goblin-warrior',
       name: 'Goblin Warrior',
       baseStats: {
         hp: 28,

--- a/src/domain/creatures/clone.ts
+++ b/src/domain/creatures/clone.ts
@@ -18,7 +18,7 @@ export function createCombatantFromCreature({
 
   return {
     id: combatantId,
-    creatureId: creature.id,
+    sourceId: creature.id,
     name: name ?? combatantCreature.name,
     sourceType: 'creature',
     baseStats: {

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,5 +1,6 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
+export { createCombatantFromPartyMember } from './party/factory';
 export { applyEliteWeak } from './creatures/templates';
 export { effectLibrary } from './effects/library';
 export { deriveStats } from './effects/derivation';
@@ -39,6 +40,7 @@ export type {
   LogEntryTone,
   Modifier,
   ModifyEffectValuePayload,
+  PartyMember,
   Prompt,
   PromptBoundary,
   PromptResolution,

--- a/src/domain/party/factory.test.ts
+++ b/src/domain/party/factory.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest';
+import type { PartyMember } from '../types';
+import { expectSerializable } from '../test-support';
+import { createCombatantFromPartyMember } from './factory';
+
+function partyMember(overrides: Partial<PartyMember> = {}): PartyMember {
+  return {
+    id: 'lyra',
+    name: 'Lyra Sunwhisper',
+    level: 5,
+    ac: 19,
+    fortitude: 9,
+    reflex: 11,
+    will: 13,
+    perception: 11,
+    hp: 56,
+    persistentEffects: [],
+    companionIds: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+describe('createCombatantFromPartyMember', () => {
+  test('produces a combatant with sourceType "partyMember" and the source id wired through', () => {
+    const member = partyMember();
+    const combatant = createCombatantFromPartyMember({
+      partyMember: member,
+      combatantId: 'lyra-1'
+    });
+
+    expect(combatant).toMatchObject({
+      id: 'lyra-1',
+      sourceId: 'lyra',
+      name: 'Lyra Sunwhisper',
+      sourceType: 'partyMember',
+      level: 5,
+      isAlive: true,
+      currentHp: 56,
+      tempHp: 0,
+      reactionUsedThisRound: false
+    });
+  });
+
+  test('builds defensive baseStats from the party member fields', () => {
+    const member = partyMember({
+      ac: 21,
+      fortitude: 12,
+      reflex: 14,
+      will: 16,
+      perception: 13,
+      hp: 72,
+      skills: { arcana: 14, occultism: 14 }
+    });
+
+    const combatant = createCombatantFromPartyMember({ partyMember: member, combatantId: 'lyra-1' });
+
+    expect(combatant.baseStats).toEqual({
+      hp: 72,
+      ac: 21,
+      fortitude: 12,
+      reflex: 14,
+      will: 16,
+      perception: 13,
+      speed: 0,
+      skills: { arcana: 14, occultism: 14 }
+    });
+  });
+
+  test('leaves attacks, abilities, and spellcasting empty (PCs are run by players)', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember(),
+      combatantId: 'lyra-1'
+    });
+
+    expect(combatant.attacks).toEqual([]);
+    expect(combatant.passiveAbilities).toEqual([]);
+    expect(combatant.reactiveAbilities).toEqual([]);
+    expect(combatant.activeAbilities).toEqual([]);
+    expect(combatant.spellcasting).toBeUndefined();
+    expect(combatant.traits).toBeUndefined();
+    expect(combatant.size).toBeUndefined();
+    expect(combatant.templateAdjustment).toBeUndefined();
+  });
+
+  test('uses the optional name override', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember(),
+      combatantId: 'lyra-1',
+      name: 'Lyra (haunted)'
+    });
+    expect(combatant.name).toBe('Lyra (haunted)');
+  });
+
+  test('uses speed.land when present', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember({ speed: { land: 30, swim: 15 } }),
+      combatantId: 'lyra-1'
+    });
+    expect(combatant.baseStats.speed).toBe(30);
+  });
+
+  test('falls back to the first speed entry when land is missing', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember({ speed: { fly: 40 } }),
+      combatantId: 'lyra-1'
+    });
+    expect(combatant.baseStats.speed).toBe(40);
+  });
+
+  test('defaults speed to 0 when undefined', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember(),
+      combatantId: 'lyra-1'
+    });
+    expect(combatant.baseStats.speed).toBe(0);
+  });
+
+  test('expands persistentEffects into appliedEffects with sourceId set to the combatant id and duration unlimited', () => {
+    const member = partyMember({
+      persistentEffects: [
+        {
+          instanceId: 'wounded-instance',
+          effectId: 'wounded',
+          value: 1,
+          duration: { type: 'rounds', count: 3 }
+        }
+      ]
+    });
+
+    const combatant = createCombatantFromPartyMember({ partyMember: member, combatantId: 'lyra-1' });
+
+    expect(combatant.appliedEffects).toEqual([
+      {
+        instanceId: 'wounded-instance',
+        effectId: 'wounded',
+        value: 1,
+        sourceId: 'lyra-1',
+        duration: { type: 'unlimited' }
+      }
+    ]);
+  });
+
+  test('preserves parentInstanceId on persistent implied effects', () => {
+    const member = partyMember({
+      persistentEffects: [
+        { instanceId: 'dying-1', effectId: 'dying', value: 2, duration: { type: 'unlimited' } },
+        {
+          instanceId: 'unconscious-1',
+          effectId: 'unconscious',
+          parentInstanceId: 'dying-1',
+          duration: { type: 'unlimited' }
+        }
+      ]
+    });
+
+    const combatant = createCombatantFromPartyMember({ partyMember: member, combatantId: 'lyra-1' });
+
+    expect(combatant.appliedEffects[1]).toMatchObject({
+      instanceId: 'unconscious-1',
+      parentInstanceId: 'dying-1'
+    });
+  });
+
+  test('deep-clones skills so mutating combatant baseStats does not affect the source', () => {
+    const member = partyMember({ skills: { arcana: 14 } });
+    const combatant = createCombatantFromPartyMember({ partyMember: member, combatantId: 'lyra-1' });
+    combatant.baseStats.skills.arcana = 99;
+    expect(member.skills?.arcana).toBe(14);
+  });
+
+  test('deep-clones persistentEffects so the combatant does not alias the source', () => {
+    const member = partyMember({
+      persistentEffects: [
+        { instanceId: 'w-1', effectId: 'wounded', value: 1, duration: { type: 'unlimited' } }
+      ]
+    });
+    const combatant = createCombatantFromPartyMember({ partyMember: member, combatantId: 'lyra-1' });
+    combatant.appliedEffects[0].value = 99;
+    expect(member.persistentEffects[0].value).toBe(1);
+  });
+
+  test('the produced combatant is JSON-serializable', () => {
+    const combatant = createCombatantFromPartyMember({
+      partyMember: partyMember({
+        persistentEffects: [
+          { instanceId: 'd-1', effectId: 'doomed', value: 1, duration: { type: 'unlimited' } }
+        ]
+      }),
+      combatantId: 'lyra-1'
+    });
+    expectSerializable(combatant);
+  });
+});

--- a/src/domain/party/factory.ts
+++ b/src/domain/party/factory.ts
@@ -1,0 +1,53 @@
+import type { AppliedEffect, CombatantState, PartyMember } from '../types';
+
+export interface CreateCombatantFromPartyMemberInput {
+  partyMember: PartyMember;
+  combatantId: string;
+  name?: string;
+}
+
+export function createCombatantFromPartyMember({
+  partyMember,
+  combatantId,
+  name
+}: CreateCombatantFromPartyMemberInput): CombatantState {
+  return {
+    id: combatantId,
+    sourceId: partyMember.id,
+    name: name ?? partyMember.name,
+    sourceType: 'partyMember',
+    baseStats: {
+      hp: partyMember.hp,
+      ac: partyMember.ac,
+      fortitude: partyMember.fortitude,
+      reflex: partyMember.reflex,
+      will: partyMember.will,
+      perception: partyMember.perception,
+      speed: primarySpeed(partyMember.speed),
+      skills: structuredClone(partyMember.skills ?? {})
+    },
+    currentHp: partyMember.hp,
+    tempHp: 0,
+    appliedEffects: expandPersistentEffects(partyMember.persistentEffects, combatantId),
+    reactionUsedThisRound: false,
+    isAlive: true,
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    level: partyMember.level
+  };
+}
+
+function primarySpeed(speed: Record<string, number> | undefined): number {
+  if (!speed) return 0;
+  return speed.land ?? Object.values(speed)[0] ?? 0;
+}
+
+function expandPersistentEffects(effects: AppliedEffect[], combatantId: string): AppliedEffect[] {
+  return structuredClone(effects).map((effect) => ({
+    ...effect,
+    sourceId: combatantId,
+    duration: { type: 'unlimited' as const }
+  }));
+}

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -6,6 +6,7 @@ import {
   activeEncounter,
   combatant,
   command,
+  completedEncounter,
   emptyEffects,
   encounter,
   expectEvents,
@@ -2311,5 +2312,114 @@ describe('applyCommand effect slice', () => {
         reason: 'cascade'
       }
     ]);
+  });
+});
+
+describe('REMOVE_COMBATANT', () => {
+  test('rejects when the combatant does not exist', () => {
+    const state = encounter();
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'ghost' }), emptyEffects);
+    expectRejected(result, 'REMOVE_COMBATANT', 'Combatant ghost not found', state);
+  });
+
+  test('removes a combatant from a PREPARING encounter and prunes initiative.order', () => {
+    const state = encounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1')
+      },
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: -1, delaying: [] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
+
+    expect(result.newState.combatants['goblin-1']).toBeUndefined();
+    expect(result.newState.combatants['fighter-1']).toBeDefined();
+    expect(result.newState.initiative.order).toEqual(['fighter-1']);
+    expect(result.newState.initiative.currentIndex).toBe(-1);
+    expectEvents(result, [{ type: 'combatant-removed', combatantId: 'goblin-1', name: 'goblin-1' }]);
+  });
+
+  test('decrements currentIndex when removing a combatant before the active one in ACTIVE phase', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1', { name: 'Goblin' }),
+        'fighter-1': combatant('fighter-1', { name: 'Fighter' }),
+        'wizard-1': combatant('wizard-1', { name: 'Wizard' })
+      },
+      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 2, delaying: [] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
+
+    expect(result.newState.initiative.order).toEqual(['fighter-1', 'wizard-1']);
+    expect(result.newState.initiative.currentIndex).toBe(1);
+  });
+
+  test('leaves currentIndex unchanged when removing a combatant after the active one', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'wizard-1': combatant('wizard-1')
+      },
+      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 0, delaying: [] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'wizard-1' }), emptyEffects);
+
+    expect(result.newState.initiative.order).toEqual(['goblin-1', 'fighter-1']);
+    expect(result.newState.initiative.currentIndex).toBe(0);
+  });
+
+  test('clamps currentIndex when removing the active combatant', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1')
+      },
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 1, delaying: [] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'fighter-1' }), emptyEffects);
+
+    expect(result.newState.initiative.order).toEqual(['goblin-1']);
+    expect(result.newState.initiative.currentIndex).toBe(0);
+  });
+
+  test('removes a combatant from initiative.delaying as well as combatants', () => {
+    const state = activeEncounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'fighter-1': combatant('fighter-1'),
+        'wizard-1': combatant('wizard-1')
+      },
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 0, delaying: ['wizard-1'] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'wizard-1' }), emptyEffects);
+
+    expect(result.newState.combatants['wizard-1']).toBeUndefined();
+    expect(result.newState.initiative.delaying).toEqual([]);
+    expect(result.newState.initiative.order).toEqual(['goblin-1', 'fighter-1']);
+  });
+
+  test('emits a combatant-removed event with the original display name', () => {
+    const state = encounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1', { name: 'Goblin Warrior' })
+      },
+      initiative: { order: ['goblin-1'], currentIndex: -1, delaying: [] }
+    });
+
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
+
+    expectEvents(result, [{ type: 'combatant-removed', combatantId: 'goblin-1', name: 'Goblin Warrior' }]);
+  });
+
+  test('rejects in COMPLETED phase via the allowedPhases guard', () => {
+    const state = completedEncounter();
+    const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
+    expect(result.events[0].type).toBe('command-rejected');
   });
 });

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -65,6 +65,8 @@ export function applyCommand(state: EncounterState, command: Command, effectLibr
   switch (command.type) {
     case 'ADD_COMBATANT':
       return addCombatant(state, command.payload.combatant);
+    case 'REMOVE_COMBATANT':
+      return removeCombatant(state, command.payload.combatantId);
     case 'SET_INITIATIVE_ORDER':
       return setInitiativeOrder(state, command.payload.order);
     case 'START_ENCOUNTER':
@@ -160,6 +162,44 @@ function addCombatant(state: EncounterState, combatant: CombatantState): Command
   }
 
   return { newState, events: [event] };
+}
+
+function removeCombatant(state: EncounterState, combatantId: CombatantId): CommandResult {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return reject(state, 'REMOVE_COMBATANT', `Combatant ${combatantId} not found`);
+  }
+
+  const { [combatantId]: _removed, ...remainingCombatants } = state.combatants;
+
+  const removedIndex = state.initiative.order.indexOf(combatantId);
+  const newOrder = state.initiative.order.filter((id) => id !== combatantId);
+  const newDelaying = state.initiative.delaying.filter((id) => id !== combatantId);
+
+  let newCurrentIndex = state.initiative.currentIndex;
+  if (state.phase === 'ACTIVE' && removedIndex !== -1) {
+    if (removedIndex < state.initiative.currentIndex) {
+      newCurrentIndex = state.initiative.currentIndex - 1;
+    } else if (removedIndex === state.initiative.currentIndex) {
+      newCurrentIndex = newOrder.length === 0 ? 0 : Math.min(state.initiative.currentIndex, newOrder.length - 1);
+    }
+  }
+
+  const newState: EncounterState = {
+    ...state,
+    combatants: remainingCombatants,
+    initiative: {
+      ...state.initiative,
+      order: newOrder,
+      delaying: newDelaying,
+      currentIndex: newCurrentIndex
+    }
+  };
+
+  return {
+    newState,
+    events: [{ type: 'combatant-removed', combatantId, name: combatant.name }]
+  };
 }
 
 function setInitiativeOrder(state: EncounterState, order: CombatantId[]): CommandResult {

--- a/src/domain/test-support.ts
+++ b/src/domain/test-support.ts
@@ -54,7 +54,7 @@ export function prompt(overrides: PromptOverrides = {}): Prompt {
 export function combatant(id: string, overrides: Partial<CombatantState> = {}): CombatantState {
   return {
     id,
-    creatureId: `${id}-creature`,
+    sourceId: `${id}-creature`,
     name: id,
     sourceType: 'creature',
     baseStats: {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -119,6 +119,34 @@ export interface Creature {
   notes?: string;
 }
 
+export interface PartyMember {
+  id: string;
+  name: string;
+  playerName?: string;
+  level: number;
+  ancestry?: string;
+  class?: string;
+
+  ac: number;
+  fortitude: number;
+  reflex: number;
+  will: number;
+  perception: number;
+  hp: number;
+
+  speed?: Record<string, number>;
+  skills?: Record<string, number>;
+  resistances?: { type: string; value: number }[];
+  weaknesses?: { type: string; value: number }[];
+  immunities?: string[];
+
+  persistentEffects: AppliedEffect[];
+  companionIds: string[];
+
+  notes?: string;
+  tags: string[];
+}
+
 export type Duration =
   | { type: 'untilTurnEnd'; combatantId: CombatantId }
   | { type: 'untilTurnStart'; combatantId: CombatantId }
@@ -139,7 +167,7 @@ export interface AppliedEffect {
 
 export interface CombatantState {
   id: CombatantId;
-  creatureId: string;
+  sourceId: string;
   name: string;
   sourceType: SourceType;
   masterId?: CombatantId;

--- a/src/lib/combat-log/format.test.ts
+++ b/src/lib/combat-log/format.test.ts
@@ -18,7 +18,7 @@ const goblinAndFighter = stateWith({
 function makeCombatant(id: string, name: string) {
   return {
     id,
-    creatureId: `${id}-creature`,
+    sourceId: `${id}-creature`,
     name,
     sourceType: 'creature' as const,
     baseStats: { hp: 10, ac: 15, fortitude: 5, reflex: 5, will: 5, perception: 5, speed: 25, skills: {} },

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -29,7 +29,7 @@ describe('encounter app boundary', () => {
 
     expect(combatant).toMatchObject({
       id: 'goblin-1',
-      creatureId: 'goblin-warrior',
+      sourceId: 'goblin-warrior',
       name: 'Goblin Scout',
       currentHp: 18,
       baseStats: {

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -1,4 +1,9 @@
-import { applyCommand, createCombatantFromCreature, effectLibrary } from '../domain';
+import {
+  applyCommand,
+  createCombatantFromCreature,
+  createCombatantFromPartyMember,
+  effectLibrary
+} from '../domain';
 import type {
   AppliedEffect,
   CombatantState,
@@ -10,7 +15,8 @@ import type {
   Duration,
   EffectDefinition,
   EncounterState,
-  LogEntry
+  LogEntry,
+  PartyMember
 } from '../domain';
 import { formatEvents } from './combat-log/format';
 
@@ -70,7 +76,7 @@ export function newEncounterState(): EncounterState {
 export function makeCombatant(input: ManualCombatantInput): CombatantState {
   return {
     id: input.id,
-    creatureId: `${input.id}-manual`,
+    sourceId: `${input.id}-manual`,
     name: input.name,
     sourceType: 'creature',
     baseStats: {
@@ -101,6 +107,20 @@ export function makeCreatureCombatant(input: CreatureCombatantInput): CombatantS
     combatantId: input.combatantId,
     name: input.name,
     adjustment: input.adjustment === 'normal' ? undefined : input.adjustment
+  });
+}
+
+export interface PartyMemberCombatantInput {
+  partyMember: PartyMember;
+  combatantId: string;
+  name?: string;
+}
+
+export function makePartyMemberCombatant(input: PartyMemberCombatantInput): CombatantState {
+  return createCombatantFromPartyMember({
+    partyMember: input.partyMember,
+    combatantId: input.combatantId,
+    name: input.name
   });
 }
 

--- a/src/lib/storage/active-encounter.test.ts
+++ b/src/lib/storage/active-encounter.test.ts
@@ -61,6 +61,31 @@ describe('active encounter storage', () => {
     expect(await loadActiveEncounter()).toBeNull();
   });
 
+  it('back-fills sourceId from a legacy creatureId on load', async () => {
+    // Simulate an encounter saved before the creatureId -> sourceId rename
+    // by mutating the persisted record after save, since current types reject
+    // creatureId at compile time.
+    const state = activeEncounter();
+    await saveActiveEncounter(state);
+
+    const { getDb, ACTIVE_ENCOUNTER_STORE } = await import('./db');
+    const db = await (getDb() as Promise<import('idb').IDBPDatabase>);
+    const stored = (await db.get(ACTIVE_ENCOUNTER_STORE, 'current')) as Record<string, unknown>;
+    const combatants = stored.combatants as Record<string, Record<string, unknown>>;
+    for (const c of Object.values(combatants)) {
+      c.creatureId = c.sourceId;
+      delete c.sourceId;
+    }
+    await db.put(ACTIVE_ENCOUNTER_STORE, stored, 'current');
+
+    const restored = await loadActiveEncounter();
+    expect(restored).not.toBeNull();
+    for (const c of Object.values(restored!.combatants)) {
+      expect(c.sourceId).toBeDefined();
+      expect(c.sourceId).toBe(`${c.id}-creature`);
+    }
+  });
+
 });
 
 describe('active encounter storage when indexedDB is unavailable', () => {

--- a/src/lib/storage/active-encounter.ts
+++ b/src/lib/storage/active-encounter.ts
@@ -17,6 +17,16 @@ export async function loadActiveEncounter(): Promise<EncounterState | null> {
   const stored = (await db.get(ACTIVE_ENCOUNTER_STORE, KEY)) as EncounterState | undefined;
   if (!stored) return null;
   if (stored.phase === 'COMPLETED') return null;
+  // Back-compat: rename creatureId -> sourceId on combatants saved under DB
+  // versions <= 3. Keeps existing active encounters loadable after the rename.
+  if (stored.combatants) {
+    for (const c of Object.values(stored.combatants)) {
+      const legacy = c as unknown as { sourceId?: string; creatureId?: string };
+      if (legacy.sourceId === undefined && legacy.creatureId !== undefined) {
+        legacy.sourceId = legacy.creatureId;
+      }
+    }
+  }
   return stored;
 }
 

--- a/src/lib/storage/db.test.ts
+++ b/src/lib/storage/db.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIVE_ENCOUNTER_STORE,
   CREATURE_LIBRARY_STORE,
   DB_NAME,
+  PARTY_MEMBER_STORE,
   SETTINGS_STORE
 } from './db';
 
@@ -51,11 +52,39 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v1-data'
     });
+  });
+
+  it('preserves prior records when upgrading from v3 to v4 and adds the partyMembers store', async () => {
+    const v3 = await openDB(DB_NAME, 3, {
+      upgrade(db) {
+        db.createObjectStore(ACTIVE_ENCOUNTER_STORE);
+        db.createObjectStore(SETTINGS_STORE);
+        db.createObjectStore(CREATURE_LIBRARY_STORE);
+      }
+    });
+    await v3.put(ACTIVE_ENCOUNTER_STORE, { sentinel: 'v3-active' }, 'current');
+    await v3.put(SETTINGS_STORE, 'sk-test', 'llmApiKey');
+    await v3.put(CREATURE_LIBRARY_STORE, { id: 'goblin', name: 'Goblin' }, 'goblin');
+    v3.close();
+
+    const { getDb } = await import('./db');
+    const db = await getDb()!;
+    openConnections.push(db);
+
+    expect(Array.from(db.objectStoreNames).sort()).toEqual(
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+    );
+    expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
+      sentinel: 'v3-active'
+    });
+    expect(await db.get(SETTINGS_STORE, 'llmApiKey')).toBe('sk-test');
+    expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([{ id: 'goblin', name: 'Goblin' }]);
+    expect(await db.getAll(PARTY_MEMBER_STORE)).toEqual([]);
   });
 
   it('preserves prior activeEncounter + settings records when upgrading from v2 to v3', async () => {
@@ -75,7 +104,7 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v2-active'
@@ -89,7 +118,7 @@ describe('IndexedDB schema migration', () => {
     const db = await getDb()!;
     openConnections.push(db);
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
     );
   });
 });

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,10 +1,11 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 export const DB_NAME = 'pf2e-tracker-v2';
-export const DB_VERSION = 3;
+export const DB_VERSION = 4;
 export const ACTIVE_ENCOUNTER_STORE = 'activeEncounter';
 export const SETTINGS_STORE = 'settings';
 export const CREATURE_LIBRARY_STORE = 'creatureLibrary';
+export const PARTY_MEMBER_STORE = 'partyMembers';
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -28,6 +29,9 @@ export function getDb(): Promise<IDBPDatabase> | null {
         }
         if (!db.objectStoreNames.contains(CREATURE_LIBRARY_STORE)) {
           db.createObjectStore(CREATURE_LIBRARY_STORE);
+        }
+        if (!db.objectStoreNames.contains(PARTY_MEMBER_STORE)) {
+          db.createObjectStore(PARTY_MEMBER_STORE);
         }
       }
     }).catch((err) => {

--- a/src/lib/storage/party-members.test.ts
+++ b/src/lib/storage/party-members.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PartyMember } from '../../domain';
+import {
+  addPartyMembers,
+  clearPartyMembers,
+  loadPartyMembers,
+  removePartyMember,
+  savePartyMember
+} from './party-members';
+
+function makePartyMember(overrides: Partial<PartyMember> = {}): PartyMember {
+  return {
+    id: 'lyra',
+    name: 'Lyra Sunwhisper',
+    level: 5,
+    ac: 19,
+    fortitude: 9,
+    reflex: 11,
+    will: 13,
+    perception: 11,
+    hp: 56,
+    persistentEffects: [],
+    companionIds: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+async function loadOrThrow(): Promise<PartyMember[]> {
+  const result = await loadPartyMembers();
+  if (!result.ok) throw new Error(`loadPartyMembers failed: ${result.reason}`);
+  return result.partyMembers;
+}
+
+beforeEach(async () => {
+  await clearPartyMembers();
+});
+
+afterEach(async () => {
+  await clearPartyMembers();
+});
+
+describe('party member storage', () => {
+  it('returns an empty list when nothing has been imported', async () => {
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('round-trips an imported party member', async () => {
+    const lyra = makePartyMember({ id: 'lyra', name: 'Lyra' });
+    const result = await addPartyMembers([lyra]);
+    expect(result).toEqual({ ok: true, added: [lyra], rejected: [] });
+    expect(await loadOrThrow()).toEqual([lyra]);
+  });
+
+  it('persists multiple party members from a single import', async () => {
+    const lyra = makePartyMember({ id: 'lyra', name: 'Lyra' });
+    const dane = makePartyMember({ id: 'dane', name: 'Dane' });
+    await addPartyMembers([lyra, dane]);
+    const stored = await loadOrThrow();
+    expect(stored).toHaveLength(2);
+    expect(stored.map((m) => m.id).sort()).toEqual(['dane', 'lyra']);
+  });
+
+  it('rejects party members whose id is already present, accepting the rest', async () => {
+    const original = makePartyMember({ id: 'lyra', name: 'Original Lyra' });
+    await addPartyMembers([original]);
+
+    const collision = makePartyMember({ id: 'lyra', name: 'Different Lyra' });
+    const fresh = makePartyMember({ id: 'dane', name: 'Dane' });
+    const result = await addPartyMembers([collision, fresh]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.added).toEqual([fresh]);
+      expect(result.rejected).toEqual([collision]);
+    }
+
+    const stored = await loadOrThrow();
+    const lyra = stored.find((m) => m.id === 'lyra');
+    expect(lyra?.name).toBe('Original Lyra');
+  });
+
+  it('rejects internal duplicates within a single import batch', async () => {
+    const a = makePartyMember({ id: 'lyra', name: 'First' });
+    const b = makePartyMember({ id: 'lyra', name: 'Second' });
+    const result = await addPartyMembers([a, b]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.added).toEqual([a]);
+      expect(result.rejected).toEqual([b]);
+    }
+  });
+
+  it('savePartyMember writes a new record', async () => {
+    const lyra = makePartyMember({ id: 'lyra', name: 'Lyra' });
+    expect(await savePartyMember(lyra)).toEqual({ ok: true });
+    expect(await loadOrThrow()).toEqual([lyra]);
+  });
+
+  it('savePartyMember overwrites an existing record (upsert)', async () => {
+    const original = makePartyMember({ id: 'lyra', name: 'Original' });
+    await addPartyMembers([original]);
+
+    const updated = makePartyMember({ id: 'lyra', name: 'Updated', ac: 22 });
+    expect(await savePartyMember(updated)).toEqual({ ok: true });
+
+    const stored = await loadOrThrow();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe('Updated');
+    expect(stored[0].ac).toBe(22);
+  });
+
+  it('removePartyMember deletes a single record without touching siblings', async () => {
+    const lyra = makePartyMember({ id: 'lyra' });
+    const dane = makePartyMember({ id: 'dane' });
+    await addPartyMembers([lyra, dane]);
+    expect(await removePartyMember('lyra')).toEqual({ ok: true, existed: true });
+    const stored = await loadOrThrow();
+    expect(stored.map((m) => m.id)).toEqual(['dane']);
+  });
+
+  it('removePartyMember reports existed: false for unknown ids', async () => {
+    expect(await removePartyMember('does-not-exist')).toEqual({
+      ok: true,
+      existed: false
+    });
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('clearPartyMembers empties the store', async () => {
+    await addPartyMembers([makePartyMember({ id: 'a' }), makePartyMember({ id: 'b' })]);
+    expect(await clearPartyMembers()).toEqual({ ok: true });
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('persists party members across a simulated page reload', async () => {
+    const lyra = makePartyMember({ id: 'lyra', name: 'Lyra' });
+    await addPartyMembers([lyra]);
+
+    vi.resetModules();
+    const { loadPartyMembers: load } = await import('./party-members');
+    const result = await load();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.partyMembers.map((m) => m.id)).toEqual(['lyra']);
+    }
+  });
+});
+
+describe('party member storage when indexedDB is unavailable', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loadPartyMembers returns ok: false / unavailable', async () => {
+    const { loadPartyMembers: load } = await import('./party-members');
+    expect(await load()).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('addPartyMembers returns ok: false / unavailable', async () => {
+    const { addPartyMembers: add } = await import('./party-members');
+    const result = await add([makePartyMember({ id: 'x' })]);
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('savePartyMember returns ok: false / unavailable', async () => {
+    const { savePartyMember: save } = await import('./party-members');
+    const result = await save(makePartyMember({ id: 'x' }));
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('removePartyMember returns ok: false / unavailable', async () => {
+    const { removePartyMember: remove } = await import('./party-members');
+    expect(await remove('any')).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('clearPartyMembers returns ok: false / unavailable', async () => {
+    const { clearPartyMembers: clear } = await import('./party-members');
+    expect(await clear()).toEqual({ ok: false, reason: 'unavailable' });
+  });
+});
+
+describe('party member storage when indexedDB throws at runtime', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('idb');
+    vi.unstubAllGlobals();
+  });
+
+  it('loadPartyMembers returns ok: false / failed when openDB rejects', async () => {
+    vi.doMock('idb', async () => {
+      const actual = await vi.importActual<typeof import('idb')>('idb');
+      return {
+        ...actual,
+        openDB: vi.fn(() => Promise.reject(new Error('simulated open failure')))
+      };
+    });
+    const { loadPartyMembers: load } = await import('./party-members');
+    const result = await load();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('failed');
+      expect((result.error as Error).message).toBe('simulated open failure');
+    }
+  });
+
+  it('addPartyMembers returns ok: false / failed when openDB rejects', async () => {
+    vi.doMock('idb', async () => {
+      const actual = await vi.importActual<typeof import('idb')>('idb');
+      return {
+        ...actual,
+        openDB: vi.fn(() => Promise.reject(new Error('simulated open failure')))
+      };
+    });
+    const { addPartyMembers: add } = await import('./party-members');
+    const result = await add([makePartyMember({ id: 'x' })]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('failed');
+  });
+
+  it('savePartyMember returns ok: false / failed when openDB rejects', async () => {
+    vi.doMock('idb', async () => {
+      const actual = await vi.importActual<typeof import('idb')>('idb');
+      return {
+        ...actual,
+        openDB: vi.fn(() => Promise.reject(new Error('simulated open failure')))
+      };
+    });
+    const { savePartyMember: save } = await import('./party-members');
+    const result = await save(makePartyMember({ id: 'x' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('failed');
+  });
+
+  it('removePartyMember returns ok: false / failed when openDB rejects', async () => {
+    vi.doMock('idb', async () => {
+      const actual = await vi.importActual<typeof import('idb')>('idb');
+      return {
+        ...actual,
+        openDB: vi.fn(() => Promise.reject(new Error('simulated open failure')))
+      };
+    });
+    const { removePartyMember: remove } = await import('./party-members');
+    const result = await remove('any');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('failed');
+  });
+});

--- a/src/lib/storage/party-members.ts
+++ b/src/lib/storage/party-members.ts
@@ -1,0 +1,122 @@
+import type { PartyMember } from '../../domain';
+import { getDb, PARTY_MEMBER_STORE } from './db';
+
+export type StorageFailureReason = 'unavailable' | 'failed';
+
+export type LoadPartyMembersResult =
+  | { ok: true; partyMembers: PartyMember[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type AddPartyMembersResult =
+  | { ok: true; added: PartyMember[]; rejected: PartyMember[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type RemovePartyMemberResult =
+  | { ok: true; existed: boolean }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type SavePartyMemberResult =
+  | { ok: true }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type ClearPartyMembersResult =
+  | { ok: true }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export interface DedupeResult {
+  accepted: PartyMember[];
+  rejected: PartyMember[];
+}
+
+export function dedupeNewPartyMembers(
+  existingIds: ReadonlySet<string>,
+  incoming: readonly PartyMember[]
+): DedupeResult {
+  const accepted: PartyMember[] = [];
+  const rejected: PartyMember[] = [];
+  const seen = new Set(existingIds);
+  for (const member of incoming) {
+    if (seen.has(member.id)) {
+      rejected.push(member);
+    } else {
+      seen.add(member.id);
+      accepted.push(member);
+    }
+  }
+  return { accepted, rejected };
+}
+
+export async function loadPartyMembers(): Promise<LoadPartyMembersResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const stored = (await db.getAll(PARTY_MEMBER_STORE)) as PartyMember[];
+    return { ok: true, partyMembers: stored };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function addPartyMembers(
+  members: readonly PartyMember[]
+): Promise<AddPartyMembersResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    // Snapshot existing ids and write new records inside one readwrite tx so
+    // two rapid imports cannot both decide to write the same id against a
+    // stale snapshot — IDB serializes overlapping readwrite txns on the same
+    // store, which is what makes the dedupe contract racy-safe.
+    const tx = db.transaction(PARTY_MEMBER_STORE, 'readwrite');
+    const existingIds = new Set((await tx.store.getAllKeys()) as string[]);
+    const { accepted, rejected } = dedupeNewPartyMembers(existingIds, members);
+    for (const member of accepted) {
+      tx.store.put(member, member.id);
+    }
+    await tx.done;
+    return { ok: true, added: accepted, rejected };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function savePartyMember(member: PartyMember): Promise<SavePartyMemberResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    await db.put(PARTY_MEMBER_STORE, member, member.id);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function removePartyMember(id: string): Promise<RemovePartyMemberResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const tx = db.transaction(PARTY_MEMBER_STORE, 'readwrite');
+    const existed = (await tx.store.getKey(id)) !== undefined;
+    await tx.store.delete(id);
+    await tx.done;
+    return { ok: true, existed };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function clearPartyMembers(): Promise<ClearPartyMembersResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    await db.clear(PARTY_MEMBER_STORE);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}

--- a/src/lib/yaml/index.ts
+++ b/src/lib/yaml/index.ts
@@ -4,6 +4,11 @@ import { validateCreature } from './creature-validator';
 
 export type { ValidationIssue } from './envelope';
 export type { ParseOutcome } from './creature-validator';
+export {
+  importPartyMemberYaml,
+  type PartyMemberImportResult,
+  type PartyMemberSkippedDocument
+} from './party-member-import';
 
 export interface SkippedDocument {
   documentIndex: number;

--- a/src/lib/yaml/party-member-import.test.ts
+++ b/src/lib/yaml/party-member-import.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from 'vitest';
+import { importPartyMemberYaml } from './party-member-import';
+
+describe('importPartyMemberYaml', () => {
+  test('round-trips a fully populated party-member document', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: lyra-sunwhisper
+  name: Lyra Sunwhisper
+  playerName: Alice
+  level: 5
+  ancestry: Elf
+  class: Wizard
+  ac: 19
+  fortitude: 9
+  reflex: 11
+  will: 13
+  perception: 11
+  hp: 56
+  speed: { land: 30 }
+  skills: { arcana: 14, occultism: 14 }
+  resistances: [{ type: cold, value: 2 }]
+  weaknesses: [{ type: fire, value: 5 }]
+  immunities: [sleep]
+  notes: Studies the Esoteric Order of the Cypher Crown.
+  tags: [arcane, party-leader]
+  companionIds: []
+  persistentEffects:
+    - instanceId: wounded-1
+      effectId: wounded
+      value: 1
+      duration: { type: unlimited }
+`;
+
+    const { partyMembers, issues, skipped } = importPartyMemberYaml(text);
+
+    expect(issues).toEqual([]);
+    expect(skipped).toEqual([]);
+    expect(partyMembers).toHaveLength(1);
+    expect(partyMembers[0]).toEqual({
+      id: 'lyra-sunwhisper',
+      name: 'Lyra Sunwhisper',
+      playerName: 'Alice',
+      level: 5,
+      ancestry: 'Elf',
+      class: 'Wizard',
+      ac: 19,
+      fortitude: 9,
+      reflex: 11,
+      will: 13,
+      perception: 11,
+      hp: 56,
+      speed: { land: 30 },
+      skills: { arcana: 14, occultism: 14 },
+      resistances: [{ type: 'cold', value: 2 }],
+      weaknesses: [{ type: 'fire', value: 5 }],
+      immunities: ['sleep'],
+      notes: 'Studies the Esoteric Order of the Cypher Crown.',
+      tags: ['arcane', 'party-leader'],
+      companionIds: [],
+      persistentEffects: [
+        {
+          instanceId: 'wounded-1',
+          effectId: 'wounded',
+          value: 1,
+          duration: { type: 'unlimited' }
+        }
+      ]
+    });
+  });
+
+  test('accepts a minimal party-member document with only required fields', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  ac: 17
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects: []
+`;
+    const { partyMembers, issues } = importPartyMemberYaml(text);
+    expect(issues).toEqual([]);
+    expect(partyMembers).toHaveLength(1);
+    expect(partyMembers[0].id).toBe('dane');
+  });
+
+  test('defaults persistent-effect duration to unlimited when omitted', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  ac: 17
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects:
+    - instanceId: w-1
+      effectId: wounded
+      value: 1
+`;
+    const { partyMembers } = importPartyMemberYaml(text);
+    expect(partyMembers[0].persistentEffects[0].duration).toEqual({ type: 'unlimited' });
+  });
+
+  test('reports an issue when a required field is missing', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects: []
+`;
+    const { partyMembers, issues } = importPartyMemberYaml(text);
+    expect(partyMembers).toHaveLength(0);
+    expect(issues.some((i) => i.path === 'ac')).toBe(true);
+  });
+
+  test('rejects level < 1', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 0
+  ac: 17
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects: []
+`;
+    const { partyMembers, issues } = importPartyMemberYaml(text);
+    expect(partyMembers).toHaveLength(0);
+    const levelIssue = issues.find((i) => i.path === 'level');
+    expect(levelIssue?.message).toBe('must be >= 1');
+  });
+
+  test('rejects negative defensive stats', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  ac: -2
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects: []
+`;
+    const { partyMembers, issues } = importPartyMemberYaml(text);
+    expect(partyMembers).toHaveLength(0);
+    expect(issues.some((i) => i.path === 'ac' && />=/.test(i.message))).toBe(true);
+  });
+
+  test('reports a malformed persistent effect entry', () => {
+    const text = `kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  ac: 17
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects:
+    - effectId: wounded
+`;
+    const { partyMembers, issues } = importPartyMemberYaml(text);
+    expect(partyMembers).toHaveLength(0);
+    expect(issues.some((i) => i.path === 'persistentEffects[0].instanceId')).toBe(true);
+  });
+
+  test('skips non-party-member envelopes (e.g. creature)', () => {
+    const text = `kind: creature
+schemaVersion: 1
+data:
+  id: goblin
+  name: Goblin
+---
+kind: party-member
+schemaVersion: 1
+data:
+  id: dane
+  name: Dane
+  level: 1
+  ac: 17
+  fortitude: 7
+  reflex: 5
+  will: 6
+  perception: 5
+  hp: 22
+  tags: []
+  companionIds: []
+  persistentEffects: []
+`;
+    const { partyMembers, skipped } = importPartyMemberYaml(text);
+    expect(partyMembers).toHaveLength(1);
+    expect(partyMembers[0].id).toBe('dane');
+    expect(skipped).toEqual([{ documentIndex: 0, kind: 'creature' }]);
+  });
+
+  test('handles an empty input as an empty result', () => {
+    const { partyMembers, issues, skipped } = importPartyMemberYaml('');
+    expect(partyMembers).toEqual([]);
+    expect(skipped).toEqual([]);
+    // The envelope parser may surface an issue for an empty document; that's
+    // fine — what we're asserting is that nothing crashes and no party
+    // members are produced.
+    expect(Array.isArray(issues)).toBe(true);
+  });
+});

--- a/src/lib/yaml/party-member-import.ts
+++ b/src/lib/yaml/party-member-import.ts
@@ -1,0 +1,33 @@
+import type { PartyMember } from '../../domain';
+import { parseYamlEnvelopes, type ValidationIssue, type YamlDocumentKind } from './envelope';
+import { validatePartyMember } from './party-member-validator';
+
+export interface PartyMemberSkippedDocument {
+  documentIndex: number;
+  kind: Exclude<YamlDocumentKind, 'party-member'>;
+}
+
+export interface PartyMemberImportResult {
+  partyMembers: PartyMember[];
+  issues: ValidationIssue[];
+  skipped: PartyMemberSkippedDocument[];
+}
+
+export function importPartyMemberYaml(text: string): PartyMemberImportResult {
+  const { envelopes, issues } = parseYamlEnvelopes(text);
+  const partyMembers: PartyMember[] = [];
+  const skipped: PartyMemberSkippedDocument[] = [];
+  const allIssues: ValidationIssue[] = [...issues];
+
+  for (const envelope of envelopes) {
+    if (envelope.kind !== 'party-member') {
+      skipped.push({ documentIndex: envelope.documentIndex, kind: envelope.kind });
+      continue;
+    }
+    const result = validatePartyMember(envelope.data, envelope.documentIndex);
+    if (result.ok) partyMembers.push(result.value);
+    allIssues.push(...result.issues);
+  }
+
+  return { partyMembers, issues: allIssues, skipped };
+}

--- a/src/lib/yaml/party-member-validator.ts
+++ b/src/lib/yaml/party-member-validator.ts
@@ -1,0 +1,355 @@
+import type { AppliedEffect, Duration, PartyMember } from '../../domain';
+import type { ValidationIssue } from './envelope';
+
+export type ParseOutcome<T> =
+  | { ok: true; value: T; issues: ValidationIssue[] }
+  | { ok: false; issues: ValidationIssue[] };
+
+class IssueBag {
+  readonly issues: ValidationIssue[] = [];
+  constructor(private readonly documentIndex: number) {}
+
+  add(path: string, message: string): void {
+    this.issues.push({ documentIndex: this.documentIndex, path, message });
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function requireNumber(bag: IssueBag, path: string, value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    bag.add(path, 'must be a finite number');
+    return null;
+  }
+  return value;
+}
+
+function requireNonNegativeNumber(bag: IssueBag, path: string, value: unknown): number | null {
+  const n = requireNumber(bag, path, value);
+  if (n === null) return null;
+  if (n < 0) {
+    bag.add(path, 'must be >= 0');
+    return null;
+  }
+  return n;
+}
+
+function requireString(bag: IssueBag, path: string, value: unknown): string | null {
+  if (typeof value !== 'string') {
+    bag.add(path, 'must be a string');
+    return null;
+  }
+  return value;
+}
+
+function requireNonEmptyString(bag: IssueBag, path: string, value: unknown): string | null {
+  const s = requireString(bag, path, value);
+  if (s === null) return null;
+  if (s.trim() === '') {
+    bag.add(path, 'must not be empty');
+    return null;
+  }
+  return s;
+}
+
+function requireStringArray(bag: IssueBag, path: string, value: unknown): string[] | null {
+  if (!isStringArray(value)) {
+    bag.add(path, 'must be an array of strings');
+    return null;
+  }
+  return value;
+}
+
+function requireArray(bag: IssueBag, path: string, value: unknown): unknown[] | null {
+  if (!Array.isArray(value)) {
+    bag.add(path, 'must be an array');
+    return null;
+  }
+  return value;
+}
+
+function requireObject(bag: IssueBag, path: string, value: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    bag.add(path, 'must be a mapping (object)');
+    return null;
+  }
+  return value;
+}
+
+function validateRecordOfNumbers(
+  bag: IssueBag,
+  path: string,
+  value: unknown
+): Record<string, number> | null {
+  const obj = requireObject(bag, path, value);
+  if (!obj) return null;
+  const out: Record<string, number> = {};
+  let ok = true;
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      bag.add(`${path}.${k}`, 'must be a finite number');
+      ok = false;
+    } else {
+      out[k] = v;
+    }
+  }
+  return ok ? out : null;
+}
+
+function validateTypedValueArray(
+  bag: IssueBag,
+  path: string,
+  raw: unknown
+): { type: string; value: number }[] | null {
+  const arr = requireArray(bag, path, raw);
+  if (!arr) return null;
+  const out: { type: string; value: number }[] = [];
+  let ok = true;
+  for (let i = 0; i < arr.length; i++) {
+    const obj = requireObject(bag, `${path}[${i}]`, arr[i]);
+    if (!obj) {
+      ok = false;
+      continue;
+    }
+    const type = requireNonEmptyString(bag, `${path}[${i}].type`, obj.type);
+    const value = requireNumber(bag, `${path}[${i}].value`, obj.value);
+    if (type === null || value === null) ok = false;
+    else out.push({ type, value });
+  }
+  return ok ? out : null;
+}
+
+function validateDuration(bag: IssueBag, path: string, raw: unknown): Duration | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  const type = requireString(bag, `${path}.type`, obj.type);
+  if (type === null) return null;
+  switch (type) {
+    case 'untilTurnEnd':
+    case 'untilTurnStart': {
+      const combatantId = requireNonEmptyString(bag, `${path}.combatantId`, obj.combatantId);
+      if (combatantId === null) return null;
+      return { type, combatantId };
+    }
+    case 'rounds': {
+      const count = requireNumber(bag, `${path}.count`, obj.count);
+      if (count === null) return null;
+      return { type: 'rounds', count };
+    }
+    case 'unlimited':
+      return { type: 'unlimited' };
+    case 'conditional': {
+      const description = requireString(bag, `${path}.description`, obj.description);
+      if (description === null) return null;
+      return { type: 'conditional', description };
+    }
+    default:
+      bag.add(`${path}.type`, 'must be one of: untilTurnEnd, untilTurnStart, rounds, unlimited, conditional');
+      return null;
+  }
+}
+
+function validatePersistentEffect(bag: IssueBag, path: string, raw: unknown): AppliedEffect | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+
+  const instanceId = requireNonEmptyString(bag, `${path}.instanceId`, obj.instanceId);
+  if (instanceId === null) ok = false;
+  const effectId = requireNonEmptyString(bag, `${path}.effectId`, obj.effectId);
+  if (effectId === null) ok = false;
+
+  let value: number | undefined;
+  if (obj.value !== undefined) {
+    const n = requireNumber(bag, `${path}.value`, obj.value);
+    if (n === null) ok = false;
+    else value = n;
+  }
+
+  let note: string | undefined;
+  if (obj.note !== undefined) {
+    const s = requireString(bag, `${path}.note`, obj.note);
+    if (s === null) ok = false;
+    else note = s;
+  }
+
+  let parentInstanceId: string | undefined;
+  if (obj.parentInstanceId !== undefined) {
+    const s = requireNonEmptyString(bag, `${path}.parentInstanceId`, obj.parentInstanceId);
+    if (s === null) ok = false;
+    else parentInstanceId = s;
+  }
+
+  // Duration is optional in YAML; defaults to { type: 'unlimited' } since
+  // persisted effects between encounters have no encounter-scoped duration.
+  let duration: Duration = { type: 'unlimited' };
+  if (obj.duration !== undefined) {
+    const d = validateDuration(bag, `${path}.duration`, obj.duration);
+    if (d === null) ok = false;
+    else duration = d;
+  }
+
+  if (!ok || instanceId === null || effectId === null) return null;
+  const out: AppliedEffect = { instanceId, effectId, duration };
+  if (value !== undefined) out.value = value;
+  if (note !== undefined) out.note = note;
+  if (parentInstanceId !== undefined) out.parentInstanceId = parentInstanceId;
+  return out;
+}
+
+export function validatePartyMember(raw: unknown, documentIndex: number): ParseOutcome<PartyMember> {
+  const bag = new IssueBag(documentIndex);
+  const obj = requireObject(bag, '', raw);
+  if (!obj) return { ok: false, issues: bag.issues };
+
+  let ok = true;
+
+  const id = requireNonEmptyString(bag, 'id', obj.id);
+  if (id === null) ok = false;
+  const name = requireNonEmptyString(bag, 'name', obj.name);
+  if (name === null) ok = false;
+
+  const level = requireNumber(bag, 'level', obj.level);
+  if (level === null) ok = false;
+  else if (level < 1) {
+    bag.add('level', 'must be >= 1');
+    ok = false;
+  }
+
+  const ac = requireNonNegativeNumber(bag, 'ac', obj.ac);
+  if (ac === null) ok = false;
+  const fortitude = requireNonNegativeNumber(bag, 'fortitude', obj.fortitude);
+  if (fortitude === null) ok = false;
+  const reflex = requireNonNegativeNumber(bag, 'reflex', obj.reflex);
+  if (reflex === null) ok = false;
+  const will = requireNonNegativeNumber(bag, 'will', obj.will);
+  if (will === null) ok = false;
+  const perception = requireNonNegativeNumber(bag, 'perception', obj.perception);
+  if (perception === null) ok = false;
+  const hp = requireNonNegativeNumber(bag, 'hp', obj.hp);
+  if (hp === null) ok = false;
+
+  const tags = requireStringArray(bag, 'tags', obj.tags);
+  if (tags === null) ok = false;
+  const companionIds = requireStringArray(bag, 'companionIds', obj.companionIds);
+  if (companionIds === null) ok = false;
+
+  const persistentEffectsRaw = requireArray(bag, 'persistentEffects', obj.persistentEffects);
+  const persistentEffects: AppliedEffect[] = [];
+  if (persistentEffectsRaw === null) {
+    ok = false;
+  } else {
+    for (let i = 0; i < persistentEffectsRaw.length; i++) {
+      const e = validatePersistentEffect(bag, `persistentEffects[${i}]`, persistentEffectsRaw[i]);
+      if (e === null) ok = false;
+      else persistentEffects.push(e);
+    }
+  }
+
+  let playerName: string | undefined;
+  if (obj.playerName !== undefined) {
+    const s = requireString(bag, 'playerName', obj.playerName);
+    if (s === null) ok = false;
+    else playerName = s;
+  }
+  let ancestry: string | undefined;
+  if (obj.ancestry !== undefined) {
+    const s = requireString(bag, 'ancestry', obj.ancestry);
+    if (s === null) ok = false;
+    else ancestry = s;
+  }
+  let classField: string | undefined;
+  if (obj.class !== undefined) {
+    const s = requireString(bag, 'class', obj.class);
+    if (s === null) ok = false;
+    else classField = s;
+  }
+  let notes: string | undefined;
+  if (obj.notes !== undefined) {
+    const s = requireString(bag, 'notes', obj.notes);
+    if (s === null) ok = false;
+    else notes = s;
+  }
+
+  let speed: Record<string, number> | undefined;
+  if (obj.speed !== undefined) {
+    const r = validateRecordOfNumbers(bag, 'speed', obj.speed);
+    if (r === null) ok = false;
+    else speed = r;
+  }
+  let skills: Record<string, number> | undefined;
+  if (obj.skills !== undefined) {
+    const r = validateRecordOfNumbers(bag, 'skills', obj.skills);
+    if (r === null) ok = false;
+    else skills = r;
+  }
+
+  let resistances: { type: string; value: number }[] | undefined;
+  if (obj.resistances !== undefined) {
+    const v = validateTypedValueArray(bag, 'resistances', obj.resistances);
+    if (v === null) ok = false;
+    else resistances = v;
+  }
+  let weaknesses: { type: string; value: number }[] | undefined;
+  if (obj.weaknesses !== undefined) {
+    const v = validateTypedValueArray(bag, 'weaknesses', obj.weaknesses);
+    if (v === null) ok = false;
+    else weaknesses = v;
+  }
+
+  let immunities: string[] | undefined;
+  if (obj.immunities !== undefined) {
+    const a = requireStringArray(bag, 'immunities', obj.immunities);
+    if (a === null) ok = false;
+    else immunities = a;
+  }
+
+  if (
+    !ok ||
+    id === null ||
+    name === null ||
+    level === null ||
+    ac === null ||
+    fortitude === null ||
+    reflex === null ||
+    will === null ||
+    perception === null ||
+    hp === null ||
+    tags === null ||
+    companionIds === null
+  ) {
+    return { ok: false, issues: bag.issues };
+  }
+
+  const member: PartyMember = {
+    id,
+    name,
+    level,
+    ac,
+    fortitude,
+    reflex,
+    will,
+    perception,
+    hp,
+    persistentEffects,
+    companionIds,
+    tags
+  };
+  if (playerName !== undefined) member.playerName = playerName;
+  if (ancestry !== undefined) member.ancestry = ancestry;
+  if (classField !== undefined) member.class = classField;
+  if (notes !== undefined) member.notes = notes;
+  if (speed !== undefined) member.speed = speed;
+  if (skills !== undefined) member.skills = skills;
+  if (resistances !== undefined) member.resistances = resistances;
+  if (weaknesses !== undefined) member.weaknesses = weaknesses;
+  if (immunities !== undefined) member.immunities = immunities;
+
+  return { ok: true, value: member, issues: bag.issues };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Command, CombatantState, Creature, LogEntry, PromptResolution } from '../domain';
+  import type { Command, CombatantState, Creature, LogEntry, PartyMember, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
   import CombatLogDrawer from '../components/CombatLogDrawer.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
@@ -14,6 +14,7 @@
     listConditionOptions,
     makeCombatant,
     makeCreatureCombatant,
+    makePartyMemberCombatant,
     newEncounterState,
     toCommand,
     viewAppliedEffects,
@@ -44,8 +45,14 @@
     loadCreatures,
     removeCreature
   } from '$lib/storage/creature-library';
+  import {
+    addPartyMembers,
+    loadPartyMembers,
+    removePartyMember,
+    savePartyMember
+  } from '$lib/storage/party-members';
   import { createPersistenceController } from '$lib/storage/persistence-controller';
-  import { importCreatureYaml } from '$lib/yaml';
+  import { importCreatureYaml, importPartyMemberYaml } from '$lib/yaml';
 
   const conditionOptions = listConditionOptions();
 
@@ -56,6 +63,7 @@
   let feedbackCounter = 1;
   let selection: Selection = emptySelection;
   let storedCreatures: Creature[] = [];
+  let storedPartyMembers: PartyMember[] = [];
 
   $: availableCreatures = storedCreatures;
 
@@ -120,9 +128,10 @@
   }
 
   onMount(async () => {
-    const [restored, loadResult] = await Promise.all([
+    const [restored, loadResult, partyResult] = await Promise.all([
       persistence.restore(),
-      loadCreatures()
+      loadCreatures(),
+      loadPartyMembers()
     ]);
     if (restored) {
       encounter = { ...restored, combatLog: dedupeLogById(restored.combatLog) };
@@ -137,6 +146,16 @@
         loadResult.reason === 'unavailable'
           ? 'Could not load your creature library: storage is unavailable. Imports this session will not survive a reload.'
           : 'Could not load your creature library from storage. Try reloading the page; if it persists, your saved data may be inaccessible (another tab on a newer version, full storage, or browser policy).'
+      );
+    }
+    if (partyResult.ok) {
+      storedPartyMembers = partyResult.partyMembers;
+    } else {
+      appendFeedback(
+        nextFeedbackId('party-load-fail'),
+        partyResult.reason === 'unavailable'
+          ? 'Could not load your party members: storage is unavailable. Imports this session will not survive a reload.'
+          : 'Could not load your party members from storage. Try reloading the page; if it persists, your saved data may be inaccessible.'
       );
     }
   });
@@ -307,6 +326,131 @@
     storedCreatures = storedCreatures.filter((c) => c.id !== id);
   }
 
+  async function handleImportPartyMemberYamlFiles(files: File[]) {
+    for (const file of files) {
+      let text: string;
+      try {
+        text = await file.text();
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('pm-import-read-fail'),
+          `Could not read "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      let partyMembers: PartyMember[];
+      let issues: ReturnType<typeof importPartyMemberYaml>['issues'];
+      let skipped: ReturnType<typeof importPartyMemberYaml>['skipped'];
+      try {
+        ({ partyMembers, issues, skipped } = importPartyMemberYaml(text));
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('pm-import-fail'),
+          `Could not import "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      const persistResult = await addPartyMembers(partyMembers);
+
+      if (!persistResult.ok) {
+        appendFeedback(
+          nextFeedbackId('pm-import-persist-fail'),
+          persistResult.reason === 'unavailable'
+            ? `Could not save party members from "${file.name}": storage is unavailable.`
+            : `Could not save party members from "${file.name}": storage write failed.`
+        );
+        continue;
+      }
+
+      for (const member of persistResult.rejected) {
+        appendFeedback(
+          nextFeedbackId('pm-import-dup'),
+          `Skipped "${member.name}" from "${file.name}": id "${member.id}" is already in your party library.`
+        );
+      }
+
+      if (persistResult.added.length > 0) {
+        storedPartyMembers = [...storedPartyMembers, ...persistResult.added];
+        appendFeedback(
+          nextFeedbackId('pm-import-ok'),
+          `Imported ${persistResult.added.length} party member${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
+          'success'
+        );
+      }
+
+      for (const skip of skipped) {
+        appendFeedback(
+          nextFeedbackId('pm-import-skip'),
+          `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not handled by the party-member importer.`,
+          'info'
+        );
+      }
+
+      for (const issue of issues) {
+        const where = issue.path ? ` at "${issue.path}"` : '';
+        const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
+        appendFeedback(
+          nextFeedbackId('pm-import-issue'),
+          `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
+        );
+      }
+
+      if (
+        persistResult.added.length === 0 &&
+        persistResult.rejected.length === 0 &&
+        issues.length === 0 &&
+        skipped.length === 0 &&
+        partyMembers.length === 0
+      ) {
+        appendFeedback(
+          nextFeedbackId('pm-import-empty'),
+          `"${file.name}" contained no party-member documents.`
+        );
+      }
+    }
+  }
+
+  function handleAddPartyMemberToEncounter(partyMember: PartyMember) {
+    const combatant = makePartyMemberCombatant({
+      partyMember,
+      combatantId: `${partyMember.id}-${combatantCounter++}`
+    });
+    addCombatant(combatant);
+  }
+
+  async function handleRemovePartyMember(id: string) {
+    const result = await removePartyMember(id);
+    if (!result.ok) {
+      appendFeedback(
+        nextFeedbackId('pm-remove-fail'),
+        result.reason === 'unavailable'
+          ? 'Could not remove party member: storage is unavailable.'
+          : 'Could not remove party member: storage write failed.'
+      );
+      return;
+    }
+    storedPartyMembers = storedPartyMembers.filter((m) => m.id !== id);
+  }
+
+  async function handleSavePartyMember(member: PartyMember) {
+    const result = await savePartyMember(member);
+    if (!result.ok) {
+      appendFeedback(
+        nextFeedbackId('pm-save-fail'),
+        result.reason === 'unavailable'
+          ? 'Could not save party member: storage is unavailable.'
+          : 'Could not save party member: storage write failed.'
+      );
+      return;
+    }
+    const exists = storedPartyMembers.some((m) => m.id === member.id);
+    storedPartyMembers = exists
+      ? storedPartyMembers.map((m) => (m.id === member.id ? member : m))
+      : [...storedPartyMembers, member];
+  }
+
   function handleAddManual(input: Omit<ManualCombatantInput, 'id'>) {
     const slug = input.name
       .trim()
@@ -431,10 +575,16 @@
       <LibraryPane
         {canStart}
         creatures={availableCreatures}
+        partyMembers={storedPartyMembers}
+        {conditionOptions}
         onAddCreatures={handleAddCreatures}
         onAddManual={handleAddManual}
         onImportYamlFiles={handleImportYamlFiles}
         onRemoveCreature={handleRemoveCreature}
+        onAddPartyMemberToEncounter={handleAddPartyMemberToEncounter}
+        onRemovePartyMember={handleRemovePartyMember}
+        onSavePartyMember={handleSavePartyMember}
+        onImportPartyMemberYamlFiles={handleImportPartyMemberYamlFiles}
         onStart={startEncounter}
         onReset={resetLocal}
       />


### PR DESCRIPTION
## Summary

Foundation slice of issue #52 — `PartyMember` records as first-class persistent entities, distinct from creatures.

- New `PartyMember` domain type (PCs as defensive-stat records with `persistentEffects` carried between encounters), `createCombatantFromPartyMember` factory, and a new `partyMembers` IndexedDB store.
- New YAML `kind: party-member` import path mirroring the creature pattern, with its own validator and per-document issue surfacing.
- New `PartySection` UI replacing the placeholder: search + per-row Add-to-encounter / Edit / Remove, plus an `Import YAML` and `New Party Member` button. The edit modal covers required defenses, optional ancestry/class/skills/speed/resistances/weaknesses/immunities/tags/notes, and a persistent-effects editor that uses the existing condition library.
- Companion prerequisites bundled in: `creatureId` → `sourceId` on `CombatantState` (with a one-time back-compat shim on `loadActiveEncounter`), and a working `REMOVE_COMBATANT` reducer (was declared but fell through to the default reject branch).

The codebase was already 90% prepared for this work — `sourceType: 'creature' | 'partyMember' | 'companion' | 'hazard'`, `masterId?`, `EffectDefinition.persistAfterEncounter`, the `'party-member'` envelope kind, and a pre-existing `combatant-removed` event were all in place. This slice builds on top of that scaffolding.

## Out of scope (follow-up PRs)

- Companions (`Companion` type + store + factory)
- Parties as groups (the "Add Party" batch dispatch)
- Minion turn-boundary processing in the reducer
- Minion cascade in `REMOVE_COMBATANT`
- Sync-back of `persistAfterEncounter` effects on `COMPLETE_ENCOUNTER`

## Test plan

- [x] `npm run check` — clean
- [x] `npm run test:run` — 469 tests passing (added: 12 factory tests, 7 reducer tests for `REMOVE_COMBATANT`, 18 storage tests, 9 YAML import tests, 1 back-compat shim test, 1 db migration test)
- [x] `npm run audit` — no new findings (3 pre-existing low advisories)
- [x] `npm run build` — static export builds cleanly
- [ ] Manual: import a `kind: party-member` YAML doc → appears in PartySection
- [ ] Manual: re-import same YAML → duplicate id surfaced in feedback drawer
- [ ] Manual: New → fill form → add Wounded 1 persistent effect → Save → member appears
- [ ] Manual: Edit → change AC → Save → list reflects update
- [ ] Manual: Add to encounter → combatant card shows Wounded with `duration.type === 'unlimited'`
- [ ] Manual: reload tab → party list restored from IndexedDB
- [ ] Manual: Remove → disappears, survives reload
- [ ] Manual: dispatch `REMOVE_COMBATANT` for non-current combatant → card disappears, currentIndex sane
- [ ] Manual: import YAML missing `ac` → feedback shows issue at `data.ac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)