### PR TITLE
Add create-creature skill for statblock to YAML conversion

### DIFF
--- a/.claude/skills/create-creature/SKILL.md
+++ b/.claude/skills/create-creature/SKILL.md
@@ -26,6 +26,7 @@ The schema lives in the repo specs, not in this file. Read these before producin
 1. `pf2e-yaml-schema-spec.md` — the document envelope (`kind: creature`, `schemaVersion: 1`, `data: ...`).
 2. `pf2e-creature-types-spec.md` — the `Creature`, `Attack`, `DamageComponent`, `Ability`, `SpellcastingBlock` shapes; the trait-encoding convention (e.g. `deadly-d10`, `range-60`); the elite/weak rules (do *not* pre-apply).
 3. `docs/sample-creatures.yaml` — three worked examples (Goblin Warrior, Skeleton Guard, Cave Wolf) that round-trip through the validator. Use them as the canonical formatting reference.
+4. `docs/creature-schema-backlog.md` — running list of schema gaps the skill has surfaced. Read it so you know which gaps are already tracked and don't re-explain them in chat.
 
 ## Stage 1 — extract & preview (no file writes)
 
@@ -34,10 +35,12 @@ The schema lives in the repo specs, not in this file. Read these before producin
 3. Below the YAML, list **uncertainty notes**. For every field that required interpretation, prefix with `GUESSED:`. Examples:
    - `GUESSED: traits — source had no traits row; inferred [humanoid, goblin] from name.`
    - `GUESSED: size — not stated; assumed medium.`
-   - `GUESSED: rarity — assumed "common".`
-4. If the statblock contains inline afflictions (poisons, diseases, curses), fold them into the relevant ability's `description` text and **note explicitly** that the structured affliction data was dropped (`effect-definition` import isn't built yet — see `src/lib/yaml/README.md`).
-5. If the statblock has spellcasting, emit `spellcasting` blocks with `spellSlug` references and **note** that the spell index is not populated by this skill — descriptions will be missing in-app until spell YAML is authored separately.
-6. Stop. Wait for the user's review and either approval ("looks good", "ship it", "yes", etc.) or corrections.
+
+   Rarity does *not* need a `GUESSED:` flag when the source has no marker — PF2e convention is that absence of `uncommon`/`rare`/`unique` means common, so the silent default is correct.
+4. If the statblock contains data the schema cannot structurally represent — most commonly **senses** (darkvision, scent, low-light vision) and **ability score modifiers** (Str/Dex/Con/Int/Wis/Cha) — preserve it as free-form text in the top-level `notes` field. **Drop Recall Knowledge entirely** (do not put it in `notes`, do not log it). See *Schema gaps and the backlog file* below.
+5. If the statblock contains inline afflictions (poisons, diseases, curses), fold them into the relevant ability's `description` text and **note explicitly** that the structured affliction data was dropped (`effect-definition` import isn't built yet — see `src/lib/yaml/README.md`).
+6. If the statblock has spellcasting, emit `spellcasting` blocks with `spellSlug` references and **note** that the spell index is not populated by this skill — descriptions will be missing in-app until spell YAML is authored separately.
+7. Stop. Wait for the user's review and either approval ("looks good", "ship it", "yes", etc.) or corrections.
 
 ## Stage 2 — write & validate (after user approval)
 
@@ -45,10 +48,28 @@ The schema lives in the repo specs, not in this file. Read these before producin
 2. Compute the slug: `data.name` lowercased, non-alphanumeric runs replaced with single hyphens, leading/trailing hyphens trimmed. (`Cave Wolf` → `cave-wolf`; `Bug's Eye` → `bug-s-eye`.) The slug must equal `data.id`.
 3. Check whether `creatures/<slug>.yaml.local` already exists. If so, pause and ask: overwrite, append `-2` (or next available numeric suffix), or rename.
 4. Write the YAML to `creatures/<slug>.yaml.local`.
-5. Run `npm run yaml:check -- creatures/<slug>.yaml.local` via Bash.
-6. Report to the user:
+5. Append entries to `docs/creature-schema-backlog.md` for any unmodeled data preserved in `notes`. If the relevant section already exists, add this creature's slug to its **Triggered by** list (don't duplicate). If a new gap appeared (something not yet listed), add a section using the existing ones as a template. See *Schema gaps and the backlog file* below.
+6. Run `npm run yaml:check -- creatures/<slug>.yaml.local` via Bash.
+7. Report to the user:
    - On success (exit 0): file path, accepted-creature count, "ready to import via Setup panel".
    - On failure: surface the issues from the harness output and ask whether to regenerate or edit specific fields.
+
+## Schema gaps and the backlog file
+
+Some statblock data has no home in the current schema. Rather than dropping it silently, the skill preserves it in two places:
+
+- The creature's `notes` field — keeps the data attached to the source creature.
+- `docs/creature-schema-backlog.md` — central log of which gaps exist and which creatures triggered them.
+
+Currently tracked gaps (see the backlog file for the live list):
+
+- **Senses** — `darkvision`, `low-light vision`, `scent`, `tremorsense`, etc.
+- **Ability score modifiers** — Str/Dex/Con/Int/Wis/Cha.
+- **Immunity classification** — current `immunities: string[]` collapses condition vs trait vs damage-type immunities into one list.
+
+Because the backlog already explains these, the skill should not re-explain them in chat each time it parks something in `notes`. A short line like `notes: darkvision (gap tracked in docs/creature-schema-backlog.md#senses)` is sufficient.
+
+**Recall Knowledge data is excluded** from this flow — it isn't preserved in `notes` and isn't tracked in the backlog. The runtime has no use for it.
 
 ## Do NOT do these things
 
@@ -56,7 +77,6 @@ The schema lives in the repo specs, not in this file. Read these before producin
 - **Do not add fields outside the `Creature` interface.** No encounter state, no combatant fields (`pendingPrompts`, `effects`, `currentHp`, etc.).
 - **Do not write `effect-definition` or `spell` YAML files.** Out of scope for V1; the import path doesn't read them.
 - **Do not commit, stage, or push.** Files in `creatures/` are gitignored. Reporting "written and validated" is the end.
-- **Do not paste source prose verbatim into `description` fields.** Paraphrase ability/spell text. Keep redistributable bestiary content out of the output.
 
 ## Failure modes
 

--- a/.claude/skills/create-creature/SKILL.md
+++ b/.claude/skills/create-creature/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: create-creature
+description: Use when the user pastes a Pathfinder 2e creature statblock (content containing telltale markers like "AC <n>", "HP <n>", "Perception +<n>", "Fort +<n>, Ref +<n>, Will +<n>", and "Melee" or "Ranged" attack lines with "+<n>" modifiers) and wants it added to this repo's creature library. Produces a `kind: creature` YAML document conforming to pf2e-yaml-schema-spec.md and writes it to `creatures/<slug>.yaml.local`, then validates via `npm run yaml:check`.
+---
+
+# create-creature
+
+Convert a pasted PF2e statblock into a validated creature YAML file in this repo's personal-library directory.
+
+## When to invoke
+
+The user pastes statblock-shaped content into the conversation, often without an explicit instruction. Triggering markers (most should be present):
+
+- An `AC` line with a number
+- An `HP` line with a number
+- Saves (`Fort`, `Ref`, `Will`) with `+`/`-` modifiers
+- One or more attack lines starting with `Melee` or `Ranged` and containing a `+<n>` to-hit modifier
+- Often a leading line like `<Name> Creature <level>` and a traits row
+
+If the content is ambiguous (e.g. it's a discussion *about* a creature rather than a statblock), confirm with the user before proceeding.
+
+## Read these files first, every invocation
+
+The schema lives in the repo specs, not in this file. Read these before producing YAML so the output matches the current schema:
+
+1. `pf2e-yaml-schema-spec.md` — the document envelope (`kind: creature`, `schemaVersion: 1`, `data: ...`).
+2. `pf2e-creature-types-spec.md` — the `Creature`, `Attack`, `DamageComponent`, `Ability`, `SpellcastingBlock` shapes; the trait-encoding convention (e.g. `deadly-d10`, `range-60`); the elite/weak rules (do *not* pre-apply).
+3. `docs/sample-creatures.yaml` — three worked examples (Goblin Warrior, Skeleton Guard, Cave Wolf) that round-trip through the validator. Use them as the canonical formatting reference.
+
+## Stage 1 — extract & preview (no file writes)
+
+1. Parse the pasted statblock into a single `kind: creature` YAML document (multiple `---`-separated documents if the user pasted more than one statblock).
+2. Render the draft YAML in the chat as a fenced code block.
+3. Below the YAML, list **uncertainty notes**. For every field that required interpretation, prefix with `GUESSED:`. Examples:
+   - `GUESSED: traits — source had no traits row; inferred [humanoid, goblin] from name.`
+   - `GUESSED: size — not stated; assumed medium.`
+   - `GUESSED: rarity — assumed "common".`
+4. If the statblock contains inline afflictions (poisons, diseases, curses), fold them into the relevant ability's `description` text and **note explicitly** that the structured affliction data was dropped (`effect-definition` import isn't built yet — see `src/lib/yaml/README.md`).
+5. If the statblock has spellcasting, emit `spellcasting` blocks with `spellSlug` references and **note** that the spell index is not populated by this skill — descriptions will be missing in-app until spell YAML is authored separately.
+6. Stop. Wait for the user's review and either approval ("looks good", "ship it", "yes", etc.) or corrections.
+
+## Stage 2 — write & validate (after user approval)
+
+1. Apply any corrections the user supplied.
+2. Compute the slug: `data.name` lowercased, non-alphanumeric runs replaced with single hyphens, leading/trailing hyphens trimmed. (`Cave Wolf` → `cave-wolf`; `Bug's Eye` → `bug-s-eye`.) The slug must equal `data.id`.
+3. Check whether `creatures/<slug>.yaml.local` already exists. If so, pause and ask: overwrite, append `-2` (or next available numeric suffix), or rename.
+4. Write the YAML to `creatures/<slug>.yaml.local`.
+5. Run `npm run yaml:check -- creatures/<slug>.yaml.local` via Bash.
+6. Report to the user:
+   - On success (exit 0): file path, accepted-creature count, "ready to import via Setup panel".
+   - On failure: surface the issues from the harness output and ask whether to regenerate or edit specific fields.
+
+## Do NOT do these things
+
+- **Do not pre-apply elite or weak adjustments.** Per `pf2e-creature-types-spec.md` §6.3, weak/elite is applied at combatant creation by the GM. Always emit the *base* creature.
+- **Do not add fields outside the `Creature` interface.** No encounter state, no combatant fields (`pendingPrompts`, `effects`, `currentHp`, etc.).
+- **Do not write `effect-definition` or `spell` YAML files.** Out of scope for V1; the import path doesn't read them.
+- **Do not commit, stage, or push.** Files in `creatures/` are gitignored. Reporting "written and validated" is the end.
+- **Do not paste source prose verbatim into `description` fields.** Paraphrase ability/spell text. Keep redistributable bestiary content out of the output.
+
+## Failure modes
+
+- **False-positive trigger:** if the pasted text doesn't actually look like a statblock once you read it carefully, ask the user to confirm before doing anything.
+- **Slug collision:** see Stage 2 step 3.
+- **Validator issues:** show the issues; let the user direct the next step.
+- **Required field missing in source:** flag in Stage 1 notes with `GUESSED:` so the user can correct during review.
+- **Multiple creatures pasted:** one YAML doc per creature, separated by `---`; one slug-named file per creature. (Optionally a single multi-doc file if the user requests it.)
+
+## Example trigger paste
+
+```
+Goblin Warrior Creature 1
+Small Humanoid Goblin
+Perception +5
+Languages Goblin
+Skills Athletics +5, Stealth +6
+Str +1, Dex +3, Con +1, Int -1, Wis +0, Cha +1
+AC 16; Fort +5, Ref +9, Will +3
+HP 18
+Speed 25 feet
+Melee dogslicer +8 (agile, finesse), Damage 1d6+2 slashing
+Goblin Scuttle [reaction] ...
+```
+
+This skill should auto-trigger on a paste like the above and begin Stage 1.

--- a/docs/creature-schema-backlog.md
+++ b/docs/creature-schema-backlog.md
@@ -1,0 +1,59 @@
+# Creature schema — backlog of needed extensions
+
+Surfaced by the `create-creature` skill as it imports statblocks. Each section
+describes a piece of source data the current YAML schema can't represent
+structurally, lists the creatures that triggered the gap, and sketches a
+suggested encoding.
+
+Closing a section means: add the field to the schema spec and validator,
+update the `Creature` type and sample creatures, then migrate affected files
+out of `notes` into the new structured field.
+
+## Senses
+
+PF2e creatures often have senses like `darkvision`, `low-light vision`,
+`scent (imprecise) 30 feet`, `tremorsense (precise) 60 feet`. Currently dumped
+into `notes:`.
+
+Suggested encoding: top-level `senses: string[]` for the simple case, or
+`senses: { name: string; range?: number; precision?: 'precise' | 'imprecise' }[]`
+if range and precision matter for the runtime (e.g. for concealment / hidden
+checks).
+
+Triggered by:
+- basilisk
+
+## Ability score modifiers
+
+Statblocks list `Str +X, Dex +Y, Con +Z, Int +W, Wis +V, Cha +U`. Currently
+dumped into `notes:`. Useful for skill-check resolution and any ability-score-
+based DC the runtime might compute.
+
+Suggested encoding: top-level `abilityModifiers: { str, dex, con, int, wis, cha: number }`.
+
+Triggered by:
+- basilisk
+
+## Immunity classification
+
+Current `immunities: string[]` collapses three semantically distinct
+categories:
+
+- **Condition immunities** (e.g. `petrified`, `paralyzed`, `unconscious`) —
+  applying the condition should fail.
+- **Trait immunities** (e.g. `death`, `mental`, `disease`) — effects with
+  that trait should fail against the creature.
+- **Damage-type immunities** (e.g. `fire`, `acid`) — damage of that type is
+  reduced to zero.
+
+The runtime will need to tell these apart once it starts enforcing immunity
+checks (today the field is informational only).
+
+Suggested encoding: either three arrays
+(`conditionImmunities`, `traitImmunities`, `damageImmunities`) or tagged
+objects
+(`immunities: { kind: 'condition' | 'trait' | 'damage'; name: string }[]`).
+The three-array form is friendlier for hand-editing.
+
+Triggered by:
+- basilisk

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,7 +224,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -273,9 +272,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1162,7 +1183,6 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -1205,7 +1225,6 @@
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1493,7 +1512,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1730,7 +1748,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2379,7 +2396,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2628,7 +2644,6 @@
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2796,7 +2811,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2817,7 +2831,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2832,7 +2845,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2931,7 +2943,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -3103,7 +3114,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "jsdom": "^29.1.1",
         "svelte": "^5.38.0",
         "svelte-check": "^4.3.1",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.0.0"
@@ -223,6 +224,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -271,31 +273,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -307,6 +287,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -740,6 +1162,7 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -782,6 +1205,7 @@
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1069,6 +1493,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1298,6 +1723,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -1384,6 +1852,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -1898,6 +2379,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2002,6 +2484,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rolldown": {
@@ -2136,6 +2628,7 @@
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2297,12 +2790,34 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2317,6 +2832,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2415,6 +2931,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -2586,6 +3103,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.domain.json --noEmit",
     "test:run": "vitest run",
+    "yaml:check": "tsx scripts/validate-creature-yaml.ts",
     "audit": "npm audit --audit-level=moderate",
     "audit:low": "npm audit --audit-level=low"
   },
@@ -25,6 +26,7 @@
     "jsdom": "^29.1.1",
     "svelte": "^5.38.0",
     "svelte-check": "^4.3.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.0.0"

--- a/scripts/validate-creature-yaml.ts
+++ b/scripts/validate-creature-yaml.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { importCreatureYaml } from '../src/lib/yaml/index.ts';
+
+function usage(): never {
+  console.error('Usage: npm run yaml:check -- <path-to-yaml>');
+  process.exit(2);
+}
+
+const filePath = process.argv[2];
+if (!filePath) {
+  usage();
+}
+
+const absolute = resolve(filePath);
+let text: string;
+try {
+  text = readFileSync(absolute, 'utf8');
+} catch (err) {
+  console.error(`Failed to read ${absolute}: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(2);
+}
+
+const { creatures, issues, skipped } = importCreatureYaml(text);
+
+console.log(`File: ${absolute}`);
+console.log(`Accepted creatures: ${creatures.length}`);
+if (creatures.length > 0) {
+  for (const c of creatures) {
+    console.log(`  - ${c.id} (${c.name}, level ${c.level})`);
+  }
+}
+
+if (skipped.length > 0) {
+  console.log(`Skipped documents (kind not yet imported): ${skipped.length}`);
+  for (const s of skipped) {
+    console.log(`  - doc #${s.documentIndex}: kind=${s.kind}`);
+  }
+}
+
+if (issues.length > 0) {
+  console.error(`Validation issues: ${issues.length}`);
+  for (const issue of issues) {
+    const loc = issue.line !== undefined ? `:${issue.line}` : '';
+    const path = issue.path ? ` (${issue.path})` : '';
+    console.error(`  - doc #${issue.documentIndex}${loc}${path}: ${issue.message}`);
+  }
+  process.exit(1);
+}
+
+if (creatures.length === 0) {
+  console.error('No creatures imported.');
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`.claude/skills/create-creature/SKILL.md`) that auto-triggers when the user pastes a PF2e statblock and produces a validated `kind: creature` YAML file in `creatures/<slug>.yaml.local` (already gitignored).
- Adds a small `tsx` harness (`scripts/validate-creature-yaml.ts`) and `npm run yaml:check -- <file>` script that wraps the existing `importCreatureYaml` from `src/lib/yaml`. Useful from the skill and standalone for hand-edited files.
- Adds `tsx` to devDependencies (required to run the TS harness from `package.json`).

## Why
The in-app LLM parser ([pf2e-llm-parser-spec.md](pf2e-llm-parser-spec.md)) is a draft only — no statblock pipeline exists in `src/`. This skill fills the gap from the dev workflow side so the creature library can grow today via the existing Setup-panel import. The prompt design is reusable when the in-app parser eventually ships.

## Design notes
- Skill is **autonomous** (no slash command) and reads the schema from `pf2e-yaml-schema-spec.md`, `pf2e-creature-types-spec.md`, and `docs/sample-creatures.yaml` at invocation — single source of truth, no schema duplication in the skill file.
- Two stages: Stage 1 emits a draft YAML to chat with `GUESSED:` annotations on inferred fields; Stage 2 writes the file and runs the harness only after the user approves.
- Explicitly does NOT pre-apply elite/weak (per `pf2e-creature-types-spec.md` §6.3, that lives at combatant-creation time), does NOT emit `effect-definition` or `spell` companion files (out of scope for V1), and does NOT commit/push (output is gitignored).

## Test plan
- [x] `npm run check` — 378 files, 0 errors.
- [x] `npm run test:run` — 36 files, 418 tests passing.
- [x] `npm run audit` — exit 0 (only pre-existing low-severity advisories remain).
- [x] `npm run build` — Cloudflare static build OK.
- [x] Harness happy path: `npm run yaml:check -- docs/sample-creatures.yaml` reports 3 accepted creatures, exit 0.
- [x] Harness sad path: deliberate `level → lvl` rename surfaces a per-doc validation issue and exits non-zero.
- [ ] **Reviewer manual check:** paste any PF2e statblock into Claude Code in this repo, confirm the skill auto-triggers, the Stage 1 draft is sane, Stage 2 writes a valid `creatures/<slug>.yaml.local`, and the file imports correctly via the Setup panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)