### PR TITLE
Fix radial condition picker + EffectModal (#92)

### DIFF
--- a/src/components/EffectModal.svelte
+++ b/src/components/EffectModal.svelte
@@ -1,0 +1,807 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import {
+    resolveApplyChoice,
+    type ApplyConditionChoice,
+    type AppliedEffectView,
+    type ConditionGroup,
+    type ConditionOption,
+    type EffectModalTab
+  } from '$lib/encounter-app';
+  import type { Duration } from '../domain';
+
+  export let combatantName: string;
+  export let combatantHpLabel: string;
+  export let initialTab: EffectModalTab = 'applied';
+  export let appliedEffects: AppliedEffectView[];
+  export let conditionGroups: ConditionGroup[];
+  export let persistentOptions: ConditionOption[];
+  export let afflictionOptions: ConditionOption[];
+  export let effectOptions: ConditionOption[];
+  export let otherCombatants: Array<{ id: string; name: string }> = [];
+  export let onApply: (choice: ApplyConditionChoice) => void;
+  export let onModifyValue: (instanceId: string, delta: number) => void;
+  export let onSetDuration: (instanceId: string, newDuration: Duration) => void;
+  export let onRemove: (instanceId: string) => void;
+  export let onClose: () => void;
+
+  type DurationKind = Duration['type'];
+
+  const TABS: ReadonlyArray<{ id: EffectModalTab; label: string }> = [
+    { id: 'applied', label: 'Applied' },
+    { id: 'conditions', label: 'Conditions' },
+    { id: 'persistent', label: 'Persistent' },
+    { id: 'afflictions', label: 'Afflictions' },
+    { id: 'effects', label: 'Effects' }
+  ];
+
+  let activeTab: EffectModalTab = initialTab;
+  let conditionSearch = '';
+  let valuePickerForId: string | null = null;
+  let valuePickerValue = 1;
+  let valuePickerSource: 'conditions' | 'afflictions' = 'conditions';
+  let persistentFormulaForId: string | null = null;
+  let persistentFormula = '1d6';
+  let durationEditorForId: string | null = null;
+  let durationKindBuf: DurationKind = 'unlimited';
+  let durationCountBuf = 1;
+  let durationCombatantBuf = '';
+  let durationDescriptionBuf = '';
+  let cardEl: HTMLDivElement | null = null;
+  let returnFocusTo: HTMLElement | null = null;
+
+  $: filteredConditionGroups = filterGroups(conditionGroups, conditionSearch);
+
+  function filterGroups(groups: ConditionGroup[], search: string): ConditionGroup[] {
+    const trimmed = search.trim().toLowerCase();
+    if (!trimmed) return groups;
+    return groups
+      .map((group) => ({
+        label: group.label,
+        options: group.options.filter((option) => option.name.toLowerCase().includes(trimmed))
+      }))
+      .filter((group) => group.options.length > 0);
+  }
+
+  function applyFromList(option: ConditionOption, source: 'conditions' | 'afflictions' | 'effects') {
+    if (option.value.kind === 'unvalued') {
+      onApply(resolveApplyChoice(option, 1));
+      return;
+    }
+    valuePickerSource = source === 'effects' ? 'conditions' : source;
+    valuePickerForId = option.id;
+    valuePickerValue = option.value.defaultValue ?? 1;
+  }
+
+  function commitValuePicker(option: ConditionOption) {
+    onApply(resolveApplyChoice(option, valuePickerValue));
+    valuePickerForId = null;
+  }
+
+  function startPersistent(option: ConditionOption) {
+    persistentFormulaForId = option.id;
+    persistentFormula = '1d6';
+  }
+
+  function commitPersistent(option: ConditionOption) {
+    onApply(resolveApplyChoice(option, 1, persistentFormula.trim() || undefined));
+    persistentFormulaForId = null;
+  }
+
+  function startDurationEdit(view: AppliedEffectView) {
+    durationEditorForId = view.instanceId;
+    durationKindBuf = view.duration.type;
+    durationCountBuf = view.duration.type === 'rounds' ? view.duration.count : 1;
+    durationCombatantBuf =
+      view.duration.type === 'untilTurnEnd' || view.duration.type === 'untilTurnStart'
+        ? view.duration.combatantId
+        : (otherCombatants[0]?.id ?? '');
+    durationDescriptionBuf = view.duration.type === 'conditional' ? view.duration.description : '';
+  }
+
+  function commitDuration(view: AppliedEffectView) {
+    let next: Duration | null = null;
+    switch (durationKindBuf) {
+      case 'unlimited':
+        next = { type: 'unlimited' };
+        break;
+      case 'rounds': {
+        const count = Math.max(1, Math.trunc(durationCountBuf));
+        next = { type: 'rounds', count };
+        break;
+      }
+      case 'untilTurnEnd':
+      case 'untilTurnStart': {
+        const combatantId = durationCombatantBuf;
+        if (!combatantId) return;
+        next = { type: durationKindBuf, combatantId };
+        break;
+      }
+      case 'conditional':
+        next = { type: 'conditional', description: durationDescriptionBuf.trim() || 'conditional' };
+        break;
+    }
+    if (next) onSetDuration(view.instanceId, next);
+    durationEditorForId = null;
+  }
+
+  function handleKey(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  }
+
+  function handleBackdrop() {
+    onClose();
+  }
+
+  onMount(() => {
+    returnFocusTo = (document.activeElement as HTMLElement) ?? null;
+    void tick().then(() => cardEl?.focus());
+    return () => {
+      returnFocusTo?.focus?.();
+    };
+  });
+</script>
+
+<div class="modal-host">
+  <button
+    type="button"
+    class="modal-backdrop"
+    aria-label="Close effect modal"
+    onclick={handleBackdrop}
+    tabindex="-1"
+  ></button>
+  <div
+    bind:this={cardEl}
+    class="modal-card"
+    role="dialog"
+    aria-modal="true"
+    aria-label={`Manage effects on ${combatantName}`}
+    tabindex="-1"
+    onkeydown={handleKey}
+  >
+    <header class="modal-header">
+      <div>
+        <h2>{combatantName}</h2>
+        <p class="hp">{combatantHpLabel}</p>
+      </div>
+      <button type="button" class="close" aria-label="Close" onclick={onClose}>×</button>
+    </header>
+
+    <div class="tabs" role="tablist">
+      {#each TABS as tab (tab.id)}
+        <button
+          type="button"
+          class="tab"
+          class:tab-active={activeTab === tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          data-tab={tab.id}
+          onclick={() => {
+            activeTab = tab.id;
+            valuePickerForId = null;
+            persistentFormulaForId = null;
+            durationEditorForId = null;
+          }}
+        >
+          {tab.label}
+        </button>
+      {/each}
+    </div>
+
+    <div class="body">
+      {#if activeTab === 'applied'}
+        {#if appliedEffects.length === 0}
+          <p class="empty">No effects applied to this combatant yet.</p>
+        {:else}
+          <ul class="applied-list">
+            {#each appliedEffects as effect (effect.instanceId)}
+              <li class="applied-row">
+                <div class="applied-main">
+                  <span class="applied-name">{effect.name}</span>
+                  {#if effect.value.kind === 'valued'}
+                    <span class="value-controls" aria-label="Value controls">
+                      <button
+                        type="button"
+                        class="step"
+                        aria-label={`Decrease ${effect.name}`}
+                        disabled={effect.value.current <= 1}
+                        onclick={() => onModifyValue(effect.instanceId, -1)}
+                      >−</button>
+                      <span class="value" aria-label={`${effect.name} value`}>{effect.value.current}</span>
+                      <button
+                        type="button"
+                        class="step"
+                        aria-label={`Increase ${effect.name}`}
+                        disabled={
+                          effect.value.maxValue !== undefined &&
+                          effect.value.current >= effect.value.maxValue
+                        }
+                        onclick={() => onModifyValue(effect.instanceId, 1)}
+                      >+</button>
+                    </span>
+                  {/if}
+                  {#if effect.source.kind === 'implied'}
+                    <span class="implied">from {effect.source.parentName}</span>
+                  {/if}
+                </div>
+                <div class="applied-meta">
+                  <span class="duration-label">{effect.durationLabel}</span>
+                  {#if effect.source.kind === 'direct'}
+                    <button
+                      type="button"
+                      class="meta-edit"
+                      aria-label={`Edit duration for ${effect.name}`}
+                      onclick={() => startDurationEdit(effect)}
+                    >edit</button>
+                  {/if}
+                  {#if effect.note}
+                    <span class="note">{effect.note}</span>
+                  {/if}
+                  {#if effect.source.kind === 'direct'}
+                    <button
+                      type="button"
+                      class="remove"
+                      aria-label={`Remove ${effect.name}`}
+                      onclick={() => onRemove(effect.instanceId)}
+                    >×</button>
+                  {/if}
+                </div>
+                {#if durationEditorForId === effect.instanceId}
+                  <div class="duration-editor">
+                    <label>
+                      Type
+                      <select bind:value={durationKindBuf}>
+                        <option value="unlimited">Unlimited</option>
+                        <option value="rounds">Rounds</option>
+                        <option value="untilTurnEnd">Until end of turn</option>
+                        <option value="untilTurnStart">Until start of turn</option>
+                        <option value="conditional">Conditional</option>
+                      </select>
+                    </label>
+                    {#if durationKindBuf === 'rounds'}
+                      <label>
+                        Count
+                        <input
+                          type="number"
+                          min="1"
+                          bind:value={durationCountBuf}
+                          aria-label="Round count"
+                        />
+                      </label>
+                    {:else if durationKindBuf === 'untilTurnEnd' || durationKindBuf === 'untilTurnStart'}
+                      <label>
+                        Combatant
+                        <select bind:value={durationCombatantBuf} aria-label="Combatant whose turn anchors the duration">
+                          {#each otherCombatants as c (c.id)}
+                            <option value={c.id}>{c.name}</option>
+                          {/each}
+                        </select>
+                      </label>
+                    {:else if durationKindBuf === 'conditional'}
+                      <label class="full">
+                        Description
+                        <input type="text" bind:value={durationDescriptionBuf} aria-label="Conditional description" />
+                      </label>
+                    {/if}
+                    <div class="duration-actions">
+                      <button type="button" class="ghost" onclick={() => (durationEditorForId = null)}>Cancel</button>
+                      <button type="button" class="primary" onclick={() => commitDuration(effect)}>Save</button>
+                    </div>
+                  </div>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      {:else if activeTab === 'conditions'}
+        <div class="search-row">
+          <input
+            type="search"
+            class="search"
+            placeholder="Type to filter conditions…"
+            aria-label="Filter conditions"
+            bind:value={conditionSearch}
+          />
+        </div>
+        {#if filteredConditionGroups.length === 0}
+          <p class="empty">No conditions match your search.</p>
+        {:else}
+          {#each filteredConditionGroups as group (group.label)}
+            <section class="group">
+              <h3 class="group-label">{group.label}</h3>
+              <div class="chip-row">
+                {#each group.options as option (option.id)}
+                  <div class="chip-wrap">
+                    <button
+                      type="button"
+                      class="chip"
+                      class:chip-active={valuePickerForId === option.id && valuePickerSource === 'conditions'}
+                      data-option-id={option.id}
+                      onclick={() => applyFromList(option, 'conditions')}
+                    >
+                      {option.name}
+                    </button>
+                    {#if valuePickerForId === option.id && valuePickerSource === 'conditions' && option.value.kind === 'valued'}
+                      <div class="value-picker">
+                        <input
+                          type="number"
+                          min="1"
+                          max={option.value.maxValue ?? undefined}
+                          bind:value={valuePickerValue}
+                          aria-label={`Value for ${option.name}`}
+                        />
+                        <button type="button" class="primary" onclick={() => commitValuePicker(option)}>Apply</button>
+                        <button type="button" class="ghost" onclick={() => (valuePickerForId = null)}>Cancel</button>
+                      </div>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            </section>
+          {/each}
+        {/if}
+      {:else if activeTab === 'persistent'}
+        {#if persistentOptions.length === 0}
+          <p class="empty">No persistent damage types defined.</p>
+        {:else}
+          <p class="hint">Pick a damage type, then enter the formula (e.g. <code>1d6</code> or <code>2d4+2</code>).</p>
+          <div class="chip-row">
+            {#each persistentOptions as option (option.id)}
+              <div class="chip-wrap">
+                <button
+                  type="button"
+                  class="chip"
+                  class:chip-active={persistentFormulaForId === option.id}
+                  data-option-id={option.id}
+                  onclick={() => startPersistent(option)}
+                >
+                  {option.name}
+                </button>
+                {#if persistentFormulaForId === option.id}
+                  <div class="value-picker">
+                    <input
+                      type="text"
+                      bind:value={persistentFormula}
+                      aria-label={`${option.name} damage formula`}
+                    />
+                    <button type="button" class="primary" onclick={() => commitPersistent(option)}>Apply</button>
+                    <button type="button" class="ghost" onclick={() => (persistentFormulaForId = null)}>Cancel</button>
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {:else if activeTab === 'afflictions'}
+        {#if afflictionOptions.length === 0}
+          <p class="empty">No afflictions defined yet.</p>
+        {:else}
+          <div class="chip-row">
+            {#each afflictionOptions as option (option.id)}
+              <div class="chip-wrap">
+                <button
+                  type="button"
+                  class="chip"
+                  class:chip-active={valuePickerForId === option.id && valuePickerSource === 'afflictions'}
+                  data-option-id={option.id}
+                  onclick={() => applyFromList(option, 'afflictions')}
+                >
+                  {option.name}
+                </button>
+                {#if valuePickerForId === option.id && valuePickerSource === 'afflictions' && option.value.kind === 'valued'}
+                  <div class="value-picker">
+                    <input
+                      type="number"
+                      min="1"
+                      max={option.value.maxValue ?? undefined}
+                      bind:value={valuePickerValue}
+                      aria-label={`Stage for ${option.name}`}
+                    />
+                    <button type="button" class="primary" onclick={() => commitValuePicker(option)}>Apply</button>
+                    <button type="button" class="ghost" onclick={() => (valuePickerForId = null)}>Cancel</button>
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {:else if activeTab === 'effects'}
+        {#if effectOptions.length === 0}
+          <p class="empty">No spell effects defined yet.</p>
+        {:else}
+          <div class="chip-row">
+            {#each effectOptions as option (option.id)}
+              <button
+                type="button"
+                class="chip"
+                data-option-id={option.id}
+                onclick={() => applyFromList(option, 'effects')}
+              >
+                {option.name}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      {/if}
+    </div>
+
+    <footer class="actions">
+      <button type="button" class="primary" onclick={onClose}>Done</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .modal-host {
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(31, 26, 20, 0.42);
+    border: 0;
+    padding: 0;
+    cursor: default;
+    pointer-events: auto;
+  }
+
+  .modal-card {
+    position: relative;
+    pointer-events: auto;
+    width: min(720px, 92vw);
+    max-height: min(82vh, 720px);
+    background: var(--color-bg);
+    color: var(--color-ink);
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 6px;
+    box-shadow: 0 12px 32px rgba(31, 26, 20, 0.28);
+    display: flex;
+    flex-direction: column;
+    outline: none;
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-rule);
+  }
+
+  .modal-header h2 {
+    margin: 0;
+    font-family: var(--font-serif);
+    font-size: 18px;
+    font-weight: 700;
+  }
+
+  .hp {
+    margin: 2px 0 0;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-ink-mute);
+  }
+
+  .close {
+    background: transparent;
+    border: 0;
+    color: var(--color-ink-soft);
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .tabs {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3) 0;
+    border-bottom: 1px solid var(--color-rule);
+  }
+
+  .tab {
+    background: transparent;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    padding: var(--space-2) var(--space-3);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+    cursor: pointer;
+  }
+
+  .tab-active {
+    color: var(--color-ink);
+    border-bottom-color: var(--color-amber);
+  }
+
+  .body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .empty {
+    color: var(--color-ink-mute);
+    font-size: 13px;
+  }
+
+  .hint {
+    color: var(--color-ink-mute);
+    font-size: 12px;
+    margin: 0 0 var(--space-2);
+  }
+
+  .applied-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .applied-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-rule);
+    border-radius: 4px;
+    background: var(--color-panel);
+  }
+
+  .applied-main {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .applied-name {
+    font-weight: 600;
+  }
+
+  .value-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .step {
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--color-rule-strong);
+    background: var(--color-bg);
+    border-radius: 4px;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .step:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .value {
+    min-width: 1.5em;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+
+  .implied {
+    color: var(--color-ink-mute);
+    font-size: 11px;
+    font-style: italic;
+  }
+
+  .applied-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: 12px;
+    color: var(--color-ink-soft);
+  }
+
+  .duration-label {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .meta-edit {
+    background: transparent;
+    border: 0;
+    color: var(--color-amber);
+    cursor: pointer;
+    font: inherit;
+    font-size: 11px;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 3px;
+  }
+
+  .note {
+    color: var(--color-ink-mute);
+    font-style: italic;
+  }
+
+  .remove {
+    background: transparent;
+    border: 0;
+    color: var(--color-red);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .duration-editor {
+    flex-basis: 100%;
+    margin-top: var(--space-2);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: flex-end;
+    background: var(--color-bg);
+    border: 1px dashed var(--color-rule);
+    border-radius: 4px;
+    padding: var(--space-2);
+  }
+
+  .duration-editor label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 11px;
+    color: var(--color-ink-mute);
+  }
+
+  .duration-editor label.full {
+    flex-basis: 100%;
+  }
+
+  .duration-editor input,
+  .duration-editor select {
+    font: inherit;
+    padding: 4px 6px;
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 3px;
+    background: var(--color-bg);
+    color: inherit;
+  }
+
+  .duration-actions {
+    margin-left: auto;
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .search-row {
+    margin-bottom: var(--space-3);
+  }
+
+  .search {
+    width: 100%;
+    padding: 6px 8px;
+    font: inherit;
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 4px;
+    background: var(--color-bg);
+    color: inherit;
+  }
+
+  .group {
+    margin-bottom: var(--space-3);
+  }
+
+  .group-label {
+    font-family: var(--font-sans);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+    margin: 0 0 var(--space-2);
+  }
+
+  .chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .chip-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .chip {
+    background: var(--color-bg);
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 999px;
+    padding: 4px 12px;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    color: var(--color-ink);
+  }
+
+  .chip:hover,
+  .chip:focus-visible {
+    background: var(--color-panel);
+  }
+
+  .chip-active {
+    background: var(--color-ink);
+    color: var(--color-bg);
+    border-color: var(--color-ink);
+  }
+
+  .value-picker {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 6px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-rule);
+    border-radius: 4px;
+  }
+
+  .value-picker input {
+    width: 5ch;
+    padding: 2px 4px;
+    font: inherit;
+    text-align: right;
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 3px;
+    background: var(--color-bg);
+    color: inherit;
+  }
+
+  .primary {
+    background: var(--color-ink);
+    color: var(--color-bg);
+    border: 0;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .ghost {
+    background: transparent;
+    color: var(--color-ink-mute);
+    border: 0;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-3) var(--space-4);
+    border-top: 1px solid var(--color-rule);
+  }
+</style>

--- a/src/components/EffectModal.test.ts
+++ b/src/components/EffectModal.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import EffectModal from './EffectModal.svelte';
+import type {
+  AppliedEffectView,
+  ConditionGroup,
+  ConditionOption,
+  EffectModalTab
+} from '$lib/encounter-app';
+
+function makeApplied(overrides: Partial<AppliedEffectView> = {}): AppliedEffectView {
+  return {
+    instanceId: 'inst-1',
+    effectId: 'frightened',
+    name: 'Frightened',
+    value: { kind: 'valued', current: 2, maxValue: 4 },
+    duration: { type: 'unlimited' },
+    durationLabel: 'unlimited',
+    source: { kind: 'direct' },
+    ...overrides
+  };
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  const conditionGroups: ConditionGroup[] = [
+    {
+      label: 'Common',
+      options: [
+        { id: 'off-guard', name: 'Off-Guard', value: { kind: 'unvalued' } },
+        { id: 'frightened', name: 'Frightened', value: { kind: 'valued', defaultValue: 1, maxValue: 4 } }
+      ]
+    }
+  ];
+  const persistentOptions: ConditionOption[] = [
+    { id: 'persistent-fire', name: 'Persistent Fire', value: { kind: 'unvalued' } }
+  ];
+  const afflictionOptions: ConditionOption[] = [
+    { id: 'ghoul-fever', name: 'Ghoul Fever', value: { kind: 'valued', defaultValue: 1, maxValue: 4 } }
+  ];
+  const effectOptions: ConditionOption[] = [
+    { id: 'bless', name: 'Bless', value: { kind: 'unvalued' } }
+  ];
+
+  return {
+    combatantName: 'Goblin Warrior',
+    combatantHpLabel: '18/18 HP',
+    initialTab: 'applied' as EffectModalTab,
+    appliedEffects: [makeApplied()],
+    conditionGroups,
+    persistentOptions,
+    afflictionOptions,
+    effectOptions,
+    otherCombatants: [
+      { id: 'pc-1', name: 'Aric' },
+      { id: 'pc-2', name: 'Bryn' }
+    ],
+    onApply: vi.fn(),
+    onSetValue: vi.fn(),
+    onModifyValue: vi.fn(),
+    onSetDuration: vi.fn(),
+    onRemove: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('EffectModal', () => {
+  test('renders header with combatant info and tab labels', () => {
+    render(EffectModal, { props: baseProps() });
+    expect(screen.getByText('Goblin Warrior')).toBeInTheDocument();
+    expect(screen.getByText('18/18 HP')).toBeInTheDocument();
+    for (const label of ['Applied', 'Conditions', 'Persistent', 'Afflictions', 'Effects']) {
+      expect(screen.getByRole('tab', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  test('Applied tab: + and - call onModifyValue with delta', async () => {
+    const onModifyValue = vi.fn();
+    render(EffectModal, { props: baseProps({ onModifyValue }) });
+
+    const inc = screen.getByRole('button', { name: 'Increase Frightened' });
+    const dec = screen.getByRole('button', { name: 'Decrease Frightened' });
+    await fireEvent.click(inc);
+    await fireEvent.click(dec);
+    expect(onModifyValue).toHaveBeenNthCalledWith(1, 'inst-1', 1);
+    expect(onModifyValue).toHaveBeenNthCalledWith(2, 'inst-1', -1);
+  });
+
+  test('Applied tab: × button calls onRemove with the instance id', async () => {
+    const onRemove = vi.fn();
+    render(EffectModal, { props: baseProps({ onRemove }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove Frightened' }));
+    expect(onRemove).toHaveBeenCalledWith('inst-1');
+  });
+
+  test('Conditions tab: search filters chips', async () => {
+    const { container } = render(
+      EffectModal,
+      { props: baseProps({ initialTab: 'conditions' as EffectModalTab }) }
+    );
+    expect(container.querySelector('[data-option-id="off-guard"]')).not.toBeNull();
+    expect(container.querySelector('[data-option-id="frightened"]')).not.toBeNull();
+
+    const search = screen.getByLabelText('Filter conditions') as HTMLInputElement;
+    await fireEvent.input(search, { target: { value: 'fright' } });
+
+    expect(container.querySelector('[data-option-id="off-guard"]')).toBeNull();
+    expect(container.querySelector('[data-option-id="frightened"]')).not.toBeNull();
+  });
+
+  test('Conditions tab: clicking unvalued condition calls onApply immediately', async () => {
+    const onApply = vi.fn();
+    const { container } = render(
+      EffectModal,
+      { props: baseProps({ onApply, initialTab: 'conditions' as EffectModalTab }) }
+    );
+    const chip = container.querySelector('[data-option-id="off-guard"]') as HTMLButtonElement;
+    await fireEvent.click(chip);
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledWith({ kind: 'unvalued', effectId: 'off-guard', note: undefined });
+  });
+
+  test('Conditions tab: clicking valued condition opens the value picker; commit dispatches onApply', async () => {
+    const onApply = vi.fn();
+    const { container } = render(
+      EffectModal,
+      { props: baseProps({ onApply, initialTab: 'conditions' as EffectModalTab }) }
+    );
+    const chip = container.querySelector('[data-option-id="frightened"]') as HTMLButtonElement;
+    await fireEvent.click(chip);
+
+    const numberInput = screen.getByLabelText('Value for Frightened') as HTMLInputElement;
+    expect(numberInput).toBeInTheDocument();
+    await fireEvent.input(numberInput, { target: { value: '3' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledWith({ kind: 'valued', effectId: 'frightened', value: 3, note: undefined });
+  });
+
+  test('Persistent tab: clicking a damage type opens formula popover; Apply dispatches with note', async () => {
+    const onApply = vi.fn();
+    const { container } = render(
+      EffectModal,
+      { props: baseProps({ onApply, initialTab: 'persistent' as EffectModalTab }) }
+    );
+    await fireEvent.click(container.querySelector('[data-option-id="persistent-fire"]') as HTMLButtonElement);
+    const formula = screen.getByLabelText('Persistent Fire damage formula') as HTMLInputElement;
+    await fireEvent.input(formula, { target: { value: '2d6' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledWith({ kind: 'unvalued', effectId: 'persistent-fire', note: '2d6' });
+  });
+
+  test('Escape and backdrop click both call onClose', async () => {
+    const onClose = vi.fn();
+    const { container } = render(EffectModal, { props: baseProps({ onClose }) });
+    await fireEvent.keyDown(container.querySelector('.modal-card')!, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Close effect modal' }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/RadialConditionMenu.svelte
+++ b/src/components/RadialConditionMenu.svelte
@@ -5,7 +5,7 @@
     type ApplyConditionChoice,
     type ConditionOption,
     type ConditionWedgeCounts,
-    type RemovableEffectOption
+    type EffectModalTab
   } from '$lib/encounter-app';
 
   export let combatantId: string;
@@ -13,12 +13,11 @@
   export let combatantHpLabel: string;
   export let combatantSubtitle: string | undefined = undefined;
   export let anchor: { x: number; y: number };
-  export let conditionOptions: ConditionOption[];
   export let recentOptions: ConditionOption[];
-  export let removableEffects: RemovableEffectOption[];
+  export let appliedCount: number;
   export let wedgeCounts: ConditionWedgeCounts;
   export let onApply: (choice: ApplyConditionChoice) => void;
-  export let onRemove: (instanceId: string) => void;
+  export let onOpenModal: (tab: EffectModalTab) => void;
   export let onClose: () => void;
 
   // Geometry — ported verbatim from design/radial-menu.jsx.
@@ -36,29 +35,35 @@
   const HALF = RADIAL_DIAMETER / 2;
   const PADDING = 8;
 
-  type WedgeId = 'recent' | 'conditions' | 'persistent' | 'remove' | 'buffs' | 'afflict';
-  type ActiveWedgeId = 'recent' | 'conditions' | 'remove';
+  type WedgeId =
+    | 'recent'
+    | 'conditions'
+    | 'persistent'
+    | 'manage'
+    | 'effects'
+    | 'afflict';
+  // Only Recent fans out as a sub-arc; the others open the modal.
+  type SubArcWedgeId = 'recent';
   interface WedgeDef {
     id: WedgeId;
     icon: string;
     label: string;
-    active: boolean;
-    danger: boolean;
+    modalTab: EffectModalTab | null;
   }
 
   const WEDGES: readonly WedgeDef[] = [
-    { id: 'recent', icon: '↺', label: 'Recent', active: true, danger: false },
-    { id: 'conditions', icon: '✦', label: 'Conditions', active: true, danger: false },
-    { id: 'persistent', icon: '✷', label: 'Persistent', active: false, danger: false },
-    { id: 'remove', icon: '✕', label: 'Remove', active: true, danger: true },
-    { id: 'buffs', icon: '✚', label: 'Buffs', active: false, danger: false },
-    { id: 'afflict', icon: '☣', label: 'Afflictions', active: false, danger: false }
+    { id: 'recent', icon: '↺', label: 'Recent', modalTab: null },
+    { id: 'conditions', icon: '✦', label: 'Conditions', modalTab: 'conditions' },
+    { id: 'persistent', icon: '✷', label: 'Persistent', modalTab: 'persistent' },
+    { id: 'manage', icon: '⚙', label: 'Manage', modalTab: 'applied' },
+    { id: 'effects', icon: '✚', label: 'Effects', modalTab: 'effects' },
+    { id: 'afflict', icon: '☣', label: 'Afflictions', modalTab: 'afflictions' }
   ];
 
   type Phase =
     | { kind: 'hub' }
-    | { kind: 'subarc'; wedge: ActiveWedgeId }
-    | { kind: 'scrub'; wedge: ActiveWedgeId; option: ConditionOption; value: number };
+    | { kind: 'subarc'; wedge: SubArcWedgeId }
+    | { kind: 'scrub'; wedge: SubArcWedgeId; option: ConditionOption; value: number };
 
   let phase: Phase = { kind: 'hub' };
   let hoveredWedgeId: WedgeId | null = null;
@@ -122,22 +127,14 @@
     return WEDGES[i]?.id ?? null;
   }
 
-  $: subItems = currentSubItems(phase, recentOptions, conditionOptions, removableEffects);
+  $: subItems = currentSubItems(phase, recentOptions);
 
   function currentSubItems(
     p: Phase,
-    recent: ConditionOption[],
-    conditions: ConditionOption[],
-    removable: RemovableEffectOption[]
-  ): readonly { id: string; name: string; valueLabel?: string }[] {
+    recent: ConditionOption[]
+  ): readonly { id: string; name: string }[] {
     if (p.kind === 'hub') return [];
-    const wedge = p.wedge;
-    if (wedge === 'recent') return recent.map((o) => ({ id: o.id, name: o.name }));
-    if (wedge === 'conditions') return conditions.map((o) => ({ id: o.id, name: o.name }));
-    return removable.map((o) => ({
-      id: o.instanceId,
-      name: o.valueLabel ? `${o.name} ${o.valueLabel}` : o.name
-    }));
+    return recent.map((o) => ({ id: o.id, name: o.name }));
   }
 
   $: subSpan = computeSubSpan(subItems.length);
@@ -147,7 +144,7 @@
     return Math.min(240, Math.max(110, 9 * (count - 1)));
   }
 
-  function subItemAngle(index: number, count: number, wedge: ActiveWedgeId): number {
+  function subItemAngle(index: number, count: number, wedge: SubArcWedgeId): number {
     const wedgeIdx = wedgeIndexFor(wedge);
     const mid = wedgeAngles(wedgeIdx).mid;
     if (count === 1) return mid;
@@ -160,25 +157,22 @@
     onApply(resolveApplyChoice(option, rawValue));
   }
 
-  function selectActiveWedge(wedgeId: WedgeId) {
+  function selectWedge(wedgeId: WedgeId) {
     const wedge = WEDGES.find((w) => w.id === wedgeId);
-    if (!wedge || !wedge.active) return;
-    phase = { kind: 'subarc', wedge: wedgeId as ActiveWedgeId };
+    if (!wedge) return;
+    if (wedge.modalTab) {
+      onOpenModal(wedge.modalTab);
+      onClose();
+      return;
+    }
+    // Recent wedge: fan out the sub-arc.
+    phase = { kind: 'subarc', wedge: 'recent' };
     hoveredItemIndex = null;
   }
 
   function handleSubItemActivate(index: number) {
     if (phase.kind !== 'subarc') return;
-    const wedge = phase.wedge;
-
-    if (wedge === 'remove') {
-      const target = removableEffects[index];
-      if (target) onRemove(target.instanceId);
-      return;
-    }
-
-    const list = wedge === 'recent' ? recentOptions : conditionOptions;
-    const option = list[index];
+    const option = recentOptions[index];
     if (!option) return;
 
     if (option.value.kind === 'unvalued') {
@@ -186,11 +180,11 @@
       return;
     }
 
-    phase = { kind: 'scrub', wedge, option, value: 1 };
+    phase = { kind: 'scrub', wedge: phase.wedge, option, value: 1 };
   }
 
   function handleHubKey(event: KeyboardEvent) {
-    const activeIds = WEDGES.filter((w) => w.active).map((w) => w.id);
+    const ids = WEDGES.map((w) => w.id);
     if (event.key === 'Escape') {
       event.preventDefault();
       onClose();
@@ -199,24 +193,20 @@
     if (event.key === 'Enter' || event.key === ' ') {
       if (hoveredWedgeId) {
         event.preventDefault();
-        selectActiveWedge(hoveredWedgeId);
+        selectWedge(hoveredWedgeId);
       }
       return;
     }
     if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
       event.preventDefault();
-      const current = hoveredWedgeId && activeIds.includes(hoveredWedgeId)
-        ? activeIds.indexOf(hoveredWedgeId)
-        : -1;
-      hoveredWedgeId = activeIds[(current + 1) % activeIds.length];
+      const current = hoveredWedgeId ? ids.indexOf(hoveredWedgeId) : -1;
+      hoveredWedgeId = ids[(current + 1) % ids.length];
       return;
     }
     if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
       event.preventDefault();
-      const current = hoveredWedgeId && activeIds.includes(hoveredWedgeId)
-        ? activeIds.indexOf(hoveredWedgeId)
-        : 0;
-      hoveredWedgeId = activeIds[(current - 1 + activeIds.length) % activeIds.length];
+      const current = hoveredWedgeId ? ids.indexOf(hoveredWedgeId) : 0;
+      hoveredWedgeId = ids[(current - 1 + ids.length) % ids.length];
       return;
     }
   }
@@ -302,8 +292,7 @@
       let bestDiff = Infinity;
       for (let i = 0; i < count; i++) {
         const target = subItemAngle(i, count, phase.wedge);
-        let diff = Math.abs(((ang - target + 540) % 360) - 180);
-        diff = 180 - diff;
+        const diff = Math.abs(((ang - target + 540) % 360) - 180);
         if (diff < bestDiff) {
           bestDiff = diff;
           bestIdx = i;
@@ -317,10 +306,9 @@
     const scrubPhase = phase;
     if (scrubPhase.kind !== 'scrub') return;
     if (scrubPhase.option.value.kind !== 'valued') return;
-    const list = scrubPhase.wedge === 'recent' ? recentOptions : conditionOptions;
-    const idx = list.findIndex((o) => o.id === scrubPhase.option.id);
+    const idx = recentOptions.findIndex((o) => o.id === scrubPhase.option.id);
     if (idx === -1) return;
-    const baseAngle = subItemAngle(idx, list.length, scrubPhase.wedge);
+    const baseAngle = subItemAngle(idx, recentOptions.length, scrubPhase.wedge);
     let delta = ang - baseAngle;
     delta = ((delta + 540) % 360) - 180;
     const max = scrubPhase.option.value.maxValue ?? 99;
@@ -344,21 +332,13 @@
     if (r < INNER_R + 4 || r > RING_R) return;
     const id = wedgeIdAtAngle(angleOf(x, y));
     if (!id) return;
-    selectActiveWedge(id);
+    selectWedge(id);
   }
 
   function handleSubarcPointerDown(event: PointerEvent, index: number) {
     event.stopPropagation();
     if (phase.kind !== 'subarc') return;
-    const wedge = phase.wedge;
-
-    if (wedge === 'remove') {
-      handleSubItemActivate(index);
-      return;
-    }
-
-    const list = wedge === 'recent' ? recentOptions : conditionOptions;
-    const option = list[index];
+    const option = recentOptions[index];
     if (!option) return;
 
     if (option.value.kind === 'unvalued') {
@@ -367,7 +347,7 @@
     }
 
     // Enter scrub mode and capture pointer for the drag gesture.
-    phase = { kind: 'scrub', wedge, option, value: 1 };
+    phase = { kind: 'scrub', wedge: phase.wedge, option, value: 1 };
     if (svgEl && event.pointerId !== undefined) {
       try {
         svgEl.setPointerCapture(event.pointerId);
@@ -403,8 +383,8 @@
     if (id === 'recent') return recentOptions.length;
     if (id === 'conditions') return wedgeCounts.conditions;
     if (id === 'persistent') return wedgeCounts.persistent;
-    if (id === 'remove') return removableEffects.length;
-    if (id === 'buffs') return wedgeCounts.buffs;
+    if (id === 'manage') return appliedCount;
+    if (id === 'effects') return wedgeCounts.spells;
     return wedgeCounts.afflictions;
   }
 
@@ -423,7 +403,7 @@
           option: phase.option,
           value: phase.value,
           maxValue: phase.option.value.maxValue ?? 4,
-          list: phase.wedge === 'recent' ? recentOptions : conditionOptions,
+          list: recentOptions,
           wedge: phase.wedge
         }
       : null;
@@ -469,19 +449,15 @@
       {@const labelPos = polar(angles.mid, LABEL_R)}
       {@const isActiveWedge = (phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge === w.id}
       {@const isDimmed = (phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge !== w.id}
-      {@const isHover = phase.kind === 'hub' && hoveredWedgeId === w.id && w.active}
+      {@const isHover = phase.kind === 'hub' && hoveredWedgeId === w.id}
       <g
-        class="wedge"
-        class:wedge-active={w.active}
-        class:wedge-disabled={!w.active}
-        class:wedge-danger={w.danger}
+        class="wedge wedge-active"
         class:wedge-hover={isHover}
         class:wedge-selected={isActiveWedge}
         class:wedge-dim={isDimmed}
         role="menuitem"
         tabindex="-1"
-        aria-label={`${w.label}${w.active ? '' : ' (coming soon)'} ${wedgeCount(w.id)}`}
-        aria-disabled={!w.active}
+        aria-label={`${w.label} ${wedgeCount(w.id)}`}
       >
         <path
           class="wedge-fill"
@@ -621,16 +597,6 @@
 
   .wedge-active {
     cursor: pointer;
-  }
-
-  .wedge-disabled {
-    cursor: not-allowed;
-    opacity: 0.42;
-  }
-
-  .wedge-danger .wedge-icon,
-  .wedge-danger .wedge-label {
-    fill: var(--color-red);
   }
 
   .wedge-hover .wedge-fill,

--- a/src/components/RadialConditionMenu.test.ts
+++ b/src/components/RadialConditionMenu.test.ts
@@ -1,27 +1,24 @@
 import { describe, expect, test, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import RadialConditionMenu from './RadialConditionMenu.svelte';
-import type { ConditionOption, RemovableEffectOption } from '$lib/encounter-app';
+import type { ConditionOption } from '$lib/encounter-app';
 
 function baseProps(overrides: Record<string, unknown> = {}) {
-  const conditionOptions: ConditionOption[] = [
+  const recentOptions: ConditionOption[] = [
     { id: 'frightened', name: 'Frightened', value: { kind: 'valued', defaultValue: 1, maxValue: 4 } },
     { id: 'off-guard', name: 'Off-Guard', value: { kind: 'unvalued' } },
     { id: 'stunned', name: 'Stunned', value: { kind: 'valued', defaultValue: 1, maxValue: 10 } }
   ];
-  const recentOptions: ConditionOption[] = [conditionOptions[0]];
-  const removableEffects: RemovableEffectOption[] = [];
   return {
     combatantId: 'goblin-1',
     combatantName: 'Goblin Warrior',
     combatantHpLabel: '18/18 HP',
     anchor: { x: 200, y: 200 },
-    conditionOptions,
     recentOptions,
-    removableEffects,
-    wedgeCounts: { conditions: 28, persistent: 11, buffs: 0, afflictions: 0 },
+    appliedCount: 0,
+    wedgeCounts: { conditions: 28, persistent: 11, spells: 10, afflictions: 4 },
     onApply: vi.fn(),
-    onRemove: vi.fn(),
+    onOpenModal: vi.fn(),
     onClose: vi.fn(),
     ...overrides
   };
@@ -30,21 +27,18 @@ function baseProps(overrides: Record<string, unknown> = {}) {
 describe('RadialConditionMenu', () => {
   test('renders all six wedge labels', () => {
     render(RadialConditionMenu, { props: baseProps() });
-    for (const label of ['Recent', 'Conditions', 'Persistent', 'Remove', 'Buffs', 'Afflictions']) {
+    for (const label of ['Recent', 'Conditions', 'Persistent', 'Manage', 'Effects', 'Afflictions']) {
       expect(screen.getByText(label.toUpperCase())).toBeInTheDocument();
     }
   });
 
-  test('marks placeholder wedges as aria-disabled', () => {
+  test('all wedges are active (no aria-disabled)', () => {
     const { container } = render(RadialConditionMenu, { props: baseProps() });
     const wedges = container.querySelectorAll('g.wedge[role="menuitem"]');
-    const disabled = Array.from(wedges).filter(
-      (g) => g.getAttribute('aria-disabled') === 'true'
-    );
-    const labels = disabled.map((g) => g.getAttribute('aria-label') ?? '');
-    expect(labels.some((label) => label.startsWith('Persistent'))).toBe(true);
-    expect(labels.some((label) => label.startsWith('Buffs'))).toBe(true);
-    expect(labels.some((label) => label.startsWith('Afflictions'))).toBe(true);
+    expect(wedges.length).toBe(6);
+    for (const wedge of Array.from(wedges)) {
+      expect(wedge.getAttribute('aria-disabled')).toBeNull();
+    }
   });
 
   test('Escape from the hub calls onClose', async () => {
@@ -63,20 +57,108 @@ describe('RadialConditionMenu', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  test('applying an unvalued condition via keyboard nav fires onApply with kind unvalued', async () => {
-    const onApply = vi.fn();
-    const { container } = render(RadialConditionMenu, { props: baseProps({ onApply }) });
+  test('keyboard-activating each non-Recent wedge calls onOpenModal with the right tab', async () => {
+    const expected: Array<[string, string]> = [
+      ['Conditions', 'conditions'],
+      ['Persistent', 'persistent'],
+      ['Manage', 'applied'],
+      ['Effects', 'effects'],
+      ['Afflictions', 'afflictions']
+    ];
+
+    for (const [label, tab] of expected) {
+      const onOpenModal = vi.fn();
+      const onClose = vi.fn();
+      const { container, unmount } = render(RadialConditionMenu, {
+        props: baseProps({ onOpenModal, onClose })
+      });
+      const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+      // Hub starts un-hovered. ArrowRight focuses wedge 0 (Recent), then walks to the target.
+      // WEDGES order: Recent (0), Conditions (1), Persistent (2), Manage (3), Effects (4), Afflictions (5).
+      const target =
+        label === 'Conditions'
+          ? 2
+          : label === 'Persistent'
+            ? 3
+            : label === 'Manage'
+              ? 4
+              : label === 'Effects'
+                ? 5
+                : 6; // Afflictions
+      for (let i = 0; i < target; i++) {
+        await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+      }
+      await fireEvent.keyDown(svg, { key: 'Enter' });
+
+      expect(onOpenModal).toHaveBeenCalledTimes(1);
+      expect(onOpenModal).toHaveBeenCalledWith(tab);
+      expect(onClose).toHaveBeenCalledTimes(1);
+      unmount();
+    }
+  });
+
+  test('hovering item K in the Recent sub-arc highlights item K, not its mirror (regression #92)', async () => {
+    // Build a 5-item Recent list so the sub-arc has clear angular spread.
+    const recentOptions: ConditionOption[] = [
+      { id: 'r0', name: 'R0', value: { kind: 'unvalued' } },
+      { id: 'r1', name: 'R1', value: { kind: 'unvalued' } },
+      { id: 'r2', name: 'R2', value: { kind: 'unvalued' } },
+      { id: 'r3', name: 'R3', value: { kind: 'unvalued' } },
+      { id: 'r4', name: 'R4', value: { kind: 'unvalued' } }
+    ];
+    const { container } = render(RadialConditionMenu, { props: baseProps({ recentOptions }) });
     const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
 
-    await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    // Open the Recent sub-arc via keyboard: hub → ArrowRight to wedge 0 (Recent) → Enter.
     await fireEvent.keyDown(svg, { key: 'ArrowRight' });
     await fireEvent.keyDown(svg, { key: 'Enter' });
 
-    await fireEvent.keyDown(svg, { key: 'ArrowDown' });
-    await fireEvent.keyDown(svg, { key: 'ArrowDown' });
-    await fireEvent.keyDown(svg, { key: 'Enter' });
+    // Geometry constants must match the component.
+    const CX = 220;
+    const CY = 220;
+    const SUB_LABEL_R = 165;
+    const SLICE = 60;
+    const RECENT_MID_DEG = 0; // wedge 0 sits at 12 o'clock.
+    const count = recentOptions.length;
+    const span = Math.min(240, Math.max(110, 9 * (count - 1)));
+    const step = span / (count - 1);
 
-    expect(onApply).toHaveBeenCalledTimes(1);
-    expect(onApply).toHaveBeenCalledWith({ kind: 'unvalued', effectId: 'off-guard' });
+    // Stub getScreenCTM so clientToSvg is a no-op identity transform.
+    const identity = {
+      inverse: () => identity,
+      multiply: () => identity,
+      a: 1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: 0,
+      f: 0
+    } as unknown as DOMMatrix;
+    (svg as unknown as { getScreenCTM: () => DOMMatrix }).getScreenCTM = () => identity;
+    (svg as unknown as { createSVGPoint: () => DOMPoint }).createSVGPoint = () => {
+      const pt = { x: 0, y: 0 } as DOMPoint;
+      (pt as unknown as { matrixTransform: (m: DOMMatrix) => DOMPoint }).matrixTransform = () => pt;
+      return pt;
+    };
+
+    function pointFor(index: number) {
+      const angDeg = RECENT_MID_DEG - span / 2 + index * step;
+      const rad = ((angDeg - 90) * Math.PI) / 180;
+      return {
+        clientX: CX + Math.cos(rad) * SUB_LABEL_R,
+        clientY: CY + Math.sin(rad) * SUB_LABEL_R
+      };
+    }
+
+    // Hover item 0 (leftmost): expect bubble around the R0 label, NOT around R4.
+    const targetIdx = 0;
+    await fireEvent.pointerMove(svg, pointFor(targetIdx));
+
+    const bubble = container.querySelector('g.subitem-hover');
+    expect(bubble).not.toBeNull();
+    expect(bubble?.getAttribute('aria-label')).toBe(`R${targetIdx}`);
+    // Sanity: also verify that the rightmost item is NOT the highlighted one.
+    expect(bubble?.getAttribute('aria-label')).not.toBe(`R${count - 1 - targetIdx}`);
   });
 });

--- a/src/domain/effects/library.ts
+++ b/src/domain/effects/library.ts
@@ -33,6 +33,14 @@ function persistentDamage(type: string, name: string): EffectDefinition {
   };
 }
 
+function affliction(definition: Omit<EffectDefinition, 'category'>): EffectDefinition {
+  return { category: 'affliction', ...definition };
+}
+
+function spellEffect(definition: Omit<EffectDefinition, 'category'>): EffectDefinition {
+  return { category: 'spell', ...definition };
+}
+
 export const effectLibrary: EffectLibrary = {
   frightened: condition({
     id: 'frightened',
@@ -342,5 +350,114 @@ export const effectLibrary: EffectLibrary = {
   'persistent-mental': persistentDamage('mental', 'Mental'),
   'persistent-bludgeoning': persistentDamage('bludgeoning', 'Bludgeoning'),
   'persistent-piercing': persistentDamage('piercing', 'Piercing'),
-  'persistent-slashing': persistentDamage('slashing', 'Slashing')
+  'persistent-slashing': persistentDamage('slashing', 'Slashing'),
+
+  'ghoul-fever': affliction({
+    id: 'ghoul-fever',
+    name: 'Ghoul Fever',
+    hasValue: true,
+    maxValue: 4,
+    modifiers: [],
+    description:
+      'Disease (DC 17 Fortitude). Stage 1: carrier (1 day). Stage 2: 3d8 negative damage and enfeebled 2 (1 day). Stage 3: 3d8 negative damage and enfeebled 2 (1 day). Stage 4: as stage 3, and the creature dies if reduced to 0 HP, rising as a ghoul on the next midnight.'
+  }),
+  'goblin-pox': affliction({
+    id: 'goblin-pox',
+    name: 'Goblin Pox',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    description:
+      'Disease (DC 17 Fortitude). Stage 1: sickened 1 (1 round). Stage 2: sickened 2 and slowed 1 (1 round). Stage 3: sickened 2 (1 day). Goblins and goblin dogs are immune.'
+  }),
+  'drow-sleep-poison': affliction({
+    id: 'drow-sleep-poison',
+    name: 'Drow Sleep Poison',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    description:
+      'Poison (DC 18 Fortitude). Stage 1: enfeebled 1 (1 round). Stage 2: fall unconscious (1 minute, with normal Perception checks to wake).'
+  }),
+  'spider-venom': affliction({
+    id: 'spider-venom',
+    name: 'Spider Venom',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    description:
+      'Poison (DC 22 Fortitude). Stage 1: 1d4 poison damage and enfeebled 1 (1 round). Stage 2: 1d4 poison damage and enfeebled 2 (1 round). Stage 3: 2d4 poison damage and enfeebled 2 (1 round).'
+  }),
+
+  bless: spellEffect({
+    id: 'bless',
+    name: 'Bless',
+    hasValue: false,
+    modifiers: [],
+    description: 'Allies in a 5-foot emanation gain a +1 status bonus to attack rolls. Sustained; emanation grows by 10 ft each turn (max 30 ft).'
+  }),
+  bane: spellEffect({
+    id: 'bane',
+    name: 'Bane',
+    hasValue: false,
+    modifiers: [],
+    description: 'Enemies in a 5-foot emanation that fail Will save take a -1 status penalty to attack rolls. Sustained; emanation grows.'
+  }),
+  haste: spellEffect({
+    id: 'haste',
+    name: 'Haste',
+    hasValue: false,
+    modifiers: [],
+    description: 'Target gains an extra Strike or Stride action each turn. 1 minute.'
+  }),
+  slow: spellEffect({
+    id: 'slow',
+    name: 'Slow (spell)',
+    hasValue: false,
+    modifiers: [],
+    description: 'Target loses an action each turn (1 round on success, 1 minute on failure, plus slowed 2 on critical failure).'
+  }),
+  heroism: spellEffect({
+    id: 'heroism',
+    name: 'Heroism',
+    hasValue: true,
+    maxValue: 3,
+    modifiers: [],
+    description: 'Target gains a status bonus to attack rolls, Perception, saves, and skill checks (+1 at rank 3, +2 at rank 6, +3 at rank 9). 10 minutes.'
+  }),
+  'inspire-courage': spellEffect({
+    id: 'inspire-courage',
+    name: 'Inspire Courage',
+    hasValue: false,
+    modifiers: [],
+    description: 'Allies in a 60-foot emanation gain a +1 status bonus to attack rolls, damage rolls, and saves vs fear. Composition cantrip; 1 round.'
+  }),
+  'inspire-defense': spellEffect({
+    id: 'inspire-defense',
+    name: 'Inspire Defense',
+    hasValue: false,
+    modifiers: [],
+    description: 'Allies in a 60-foot emanation gain a +1 status bonus to AC and saves, plus resistance equal to half the bardic level to physical damage. Composition cantrip; 1 round.'
+  }),
+  'mage-armor': spellEffect({
+    id: 'mage-armor',
+    name: 'Mage Armor',
+    hasValue: false,
+    modifiers: [],
+    description: 'Target gains a +1 item bonus to AC and a maximum Dex cap of +5. 24 hours.'
+  }),
+  shield: spellEffect({
+    id: 'shield',
+    name: 'Shield (spell)',
+    hasValue: false,
+    modifiers: [],
+    description: 'Conjures a shield (Hardness scales with rank). Can be Raised or used to Shield Block; broken shield cannot be cast again for 10 minutes.'
+  }),
+  soothe: spellEffect({
+    id: 'soothe',
+    name: 'Soothe',
+    hasValue: false,
+    modifiers: [],
+    description: 'Target regains HP and gains +2 status bonus to saves vs mental effects. 1 minute.'
+  })
 };

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -5,11 +5,15 @@ import {
   combatantVisualState,
   dispatchEncounterCommand,
   formatDuration,
+  groupConditionsByCategory,
+  listAfflictionOptions,
   listConditionDefinitions,
   listConditionOptions,
   listConditionWedgeCounts,
+  listPersistentDamageOptions,
   listRecentConditionOptions,
   listRemovableEffects,
+  listSpellEffectOptions,
   makeCombatant,
   makeCreatureCombatant,
   newEncounterState,
@@ -679,11 +683,12 @@ describe('listConditionWedgeCounts', () => {
     const expectedConditions = Object.values(effectLibrary).filter((d) => d.category === 'condition').length;
     const expectedPersistent = Object.values(effectLibrary).filter((d) => d.category === 'persistent-damage').length;
     const expectedAfflictions = Object.values(effectLibrary).filter((d) => d.category === 'affliction').length;
+    const expectedSpells = Object.values(effectLibrary).filter((d) => d.category === 'spell').length;
 
     expect(counts.conditions).toBe(expectedConditions);
     expect(counts.persistent).toBe(expectedPersistent);
     expect(counts.afflictions).toBe(expectedAfflictions);
-    expect(counts.buffs).toBe(0);
+    expect(counts.spells).toBe(expectedSpells);
   });
 });
 
@@ -878,3 +883,101 @@ function creatureTemplate(overrides: Partial<Creature> = {}): Creature {
     ...overrides
   };
 }
+
+describe('listPersistentDamageOptions', () => {
+  test('returns persistent-damage entries from the library, sorted by name, all unvalued', () => {
+    const options = listPersistentDamageOptions();
+    const expected = Object.values(effectLibrary).filter((d) => d.category === 'persistent-damage').length;
+    expect(options.length).toBe(expected);
+    for (const option of options) expect(option.value.kind).toBe('unvalued');
+
+    const sortedNames = [...options].map((o) => o.name).sort((a, b) => a.localeCompare(b));
+    expect(options.map((o) => o.name)).toEqual(sortedNames);
+  });
+});
+
+describe('listAfflictionOptions', () => {
+  test('returns affliction entries from the library', () => {
+    const options = listAfflictionOptions();
+    const expected = Object.values(effectLibrary).filter((d) => d.category === 'affliction').length;
+    expect(options.length).toBe(expected);
+    expect(options.length).toBeGreaterThan(0);
+  });
+});
+
+describe('listSpellEffectOptions', () => {
+  test('returns spell entries from the library', () => {
+    const options = listSpellEffectOptions();
+    const expected = Object.values(effectLibrary).filter((d) => d.category === 'spell').length;
+    expect(options.length).toBe(expected);
+    expect(options.length).toBeGreaterThan(0);
+  });
+});
+
+describe('groupConditionsByCategory', () => {
+  test('returns groups in declared order with every condition assigned exactly once', () => {
+    const groups = groupConditionsByCategory();
+    const declaredOrder = ['Common', 'Diminishment', 'Detection', 'Disabling', 'Mental', 'Other'];
+    const observedOrder = groups.map((g) => g.label);
+    for (let i = 1; i < observedOrder.length; i++) {
+      const a = declaredOrder.indexOf(observedOrder[i - 1]);
+      const b = declaredOrder.indexOf(observedOrder[i]);
+      expect(a).toBeLessThan(b);
+    }
+
+    const conditionDefinitions = listConditionDefinitions();
+    const groupedIds = new Set<string>();
+    for (const group of groups) {
+      expect(group.options.length).toBeGreaterThan(0);
+      for (const option of group.options) {
+        expect(groupedIds.has(option.id)).toBe(false);
+        groupedIds.add(option.id);
+      }
+    }
+    expect(groupedIds.size).toBe(conditionDefinitions.length);
+  });
+});
+
+describe('resolveApplyChoice with note', () => {
+  test('forwards note when provided for both unvalued and valued conditions', () => {
+    const unvalued: ConditionOption = {
+      id: 'persistent-fire',
+      name: 'Persistent Fire',
+      value: { kind: 'unvalued' }
+    };
+    const valued: ConditionOption = {
+      id: 'frightened',
+      name: 'Frightened',
+      value: { kind: 'valued', defaultValue: 1, maxValue: 4 }
+    };
+    expect(resolveApplyChoice(unvalued, 1, '2d6')).toEqual({
+      kind: 'unvalued',
+      effectId: 'persistent-fire',
+      note: '2d6'
+    });
+    expect(resolveApplyChoice(valued, 3, 'from Demoralize')).toEqual({
+      kind: 'valued',
+      effectId: 'frightened',
+      value: 3,
+      note: 'from Demoralize'
+    });
+  });
+
+  test('omits note when blank or not provided', () => {
+    const unvalued: ConditionOption = {
+      id: 'off-guard',
+      name: 'Off-Guard',
+      value: { kind: 'unvalued' }
+    };
+    expect(resolveApplyChoice(unvalued, 1)).toEqual({
+      kind: 'unvalued',
+      effectId: 'off-guard',
+      note: undefined
+    });
+    expect(resolveApplyChoice(unvalued, 1, '   ')).toEqual({
+      kind: 'unvalued',
+      effectId: 'off-guard',
+      note: undefined
+    });
+  });
+});

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -198,13 +198,22 @@ export interface AppliedEffectView {
   effectId: string;
   name: string;
   value: AppliedEffectValue;
+  duration: Duration;
   durationLabel: string;
+  note?: string;
   source: AppliedEffectSource;
 }
 
 export type ApplyConditionChoice =
-  | { kind: 'valued'; effectId: string; value: number }
-  | { kind: 'unvalued'; effectId: string };
+  | { kind: 'valued'; effectId: string; value: number; note?: string }
+  | { kind: 'unvalued'; effectId: string; note?: string };
+
+export type EffectModalTab =
+  | 'applied'
+  | 'conditions'
+  | 'persistent'
+  | 'afflictions'
+  | 'effects';
 
 export function listConditionDefinitions(): EffectDefinition[] {
   return Object.values(effectLibrary)
@@ -230,14 +239,20 @@ export function clampValue(value: number, maxValue: number | undefined): number 
   return maxValue !== undefined ? Math.min(lowerBounded, maxValue) : lowerBounded;
 }
 
-export function resolveApplyChoice(option: ConditionOption, rawValue: number): ApplyConditionChoice {
+export function resolveApplyChoice(
+  option: ConditionOption,
+  rawValue: number,
+  note?: string
+): ApplyConditionChoice {
+  const trimmedNote = note?.trim() ? note : undefined;
   if (option.value.kind === 'unvalued') {
-    return { kind: 'unvalued', effectId: option.id };
+    return { kind: 'unvalued', effectId: option.id, note: trimmedNote };
   }
   return {
     kind: 'valued',
     effectId: option.id,
-    value: clampValue(rawValue, option.value.maxValue)
+    value: clampValue(rawValue, option.value.maxValue),
+    note: trimmedNote
   };
 }
 
@@ -287,7 +302,9 @@ function toAppliedEffectView(
     effectId: effect.effectId,
     name: definition?.name ?? effect.effectId,
     value,
+    duration: effect.duration,
     durationLabel: formatDuration(effect.duration, state),
+    note: effect.note,
     source
   };
 }
@@ -321,14 +338,14 @@ function combatantName(state: EncounterState, combatantId: string): string {
 export interface ConditionWedgeCounts {
   conditions: number;
   persistent: number;
-  buffs: number;
+  spells: number;
   afflictions: number;
 }
 
 export type ConditionWedgeCategory = keyof ConditionWedgeCounts;
 
 export function listConditionWedgeCounts(): ConditionWedgeCounts {
-  const counts: ConditionWedgeCounts = { conditions: 0, persistent: 0, buffs: 0, afflictions: 0 };
+  const counts: ConditionWedgeCounts = { conditions: 0, persistent: 0, spells: 0, afflictions: 0 };
   for (const definition of Object.values(effectLibrary)) {
     switch (definition.category) {
       case 'condition':
@@ -340,7 +357,9 @@ export function listConditionWedgeCounts(): ConditionWedgeCounts {
       case 'affliction':
         counts.afflictions++;
         break;
-      // 'spell' and 'custom' are not exposed as wedges; 'buff' has no library data yet.
+      case 'spell':
+        counts.spells++;
+        break;
     }
   }
   return counts;
@@ -361,6 +380,106 @@ export function listRecentConditionOptions(state: EncounterState): ConditionOpti
     });
   }
   return options;
+}
+
+function definitionToOption(definition: EffectDefinition): ConditionOption {
+  return {
+    id: definition.id,
+    name: definition.name,
+    value: definition.hasValue
+      ? { kind: 'valued', defaultValue: 1, maxValue: definition.maxValue }
+      : { kind: 'unvalued' },
+    description: definition.description
+  };
+}
+
+function listOptionsByCategory(category: EffectDefinition['category']): ConditionOption[] {
+  return Object.values(effectLibrary)
+    .filter((definition) => definition.category === category)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(definitionToOption);
+}
+
+export function listPersistentDamageOptions(): ConditionOption[] {
+  return listOptionsByCategory('persistent-damage');
+}
+
+export function listAfflictionOptions(): ConditionOption[] {
+  return listOptionsByCategory('affliction');
+}
+
+export function listSpellEffectOptions(): ConditionOption[] {
+  return listOptionsByCategory('spell');
+}
+
+export interface ConditionGroup {
+  label: string;
+  options: ConditionOption[];
+}
+
+const CONDITION_GROUP_ORDER = [
+  'Common',
+  'Diminishment',
+  'Detection',
+  'Disabling',
+  'Mental',
+  'Other'
+] as const;
+
+type ConditionGroupLabel = (typeof CONDITION_GROUP_ORDER)[number];
+
+// Maps condition id → group label. Anything not listed falls into 'Other'.
+const CONDITION_GROUPS: Record<string, ConditionGroupLabel> = {
+  'off-guard': 'Common',
+  frightened: 'Common',
+  sickened: 'Common',
+  stunned: 'Common',
+  slowed: 'Common',
+  prone: 'Common',
+  dying: 'Common',
+  wounded: 'Common',
+
+  clumsy: 'Diminishment',
+  enfeebled: 'Diminishment',
+  drained: 'Diminishment',
+  stupefied: 'Diminishment',
+  doomed: 'Diminishment',
+
+  concealed: 'Detection',
+  hidden: 'Detection',
+  invisible: 'Detection',
+  observed: 'Detection',
+  undetected: 'Detection',
+  unnoticed: 'Detection',
+
+  paralyzed: 'Disabling',
+  petrified: 'Disabling',
+  unconscious: 'Disabling',
+  restrained: 'Disabling',
+  grabbed: 'Disabling',
+  immobilized: 'Disabling',
+  encumbered: 'Disabling',
+  quickened: 'Disabling',
+
+  confused: 'Mental',
+  controlled: 'Mental',
+  fascinated: 'Mental',
+  fleeing: 'Mental',
+  fatigued: 'Mental'
+};
+
+export function groupConditionsByCategory(): ConditionGroup[] {
+  const buckets = new Map<ConditionGroupLabel, ConditionOption[]>();
+  for (const label of CONDITION_GROUP_ORDER) buckets.set(label, []);
+
+  for (const definition of listConditionDefinitions()) {
+    const label: ConditionGroupLabel = CONDITION_GROUPS[definition.id] ?? 'Other';
+    buckets.get(label)!.push(definitionToOption(definition));
+  }
+
+  return CONDITION_GROUP_ORDER
+    .map((label) => ({ label, options: buckets.get(label) ?? [] }))
+    .filter((group) => group.options.length > 0);
 }
 
 export interface RemovableEffectOption {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Command, CombatantState, Creature, LogEntry, PartyMember, PromptResolution } from '../domain';
+  import type { Command, CombatantState, Creature, Duration, LogEntry, PartyMember, PromptResolution } from '../domain';
   import TopBar from '../components/TopBar.svelte';
   import CombatLogDrawer from '../components/CombatLogDrawer.svelte';
   import CombatantCard from '../components/CombatantCard.svelte';
@@ -8,14 +8,19 @@
   import LibraryPane from '../components/LibraryPane.svelte';
   import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
   import RadialConditionMenu from '../components/RadialConditionMenu.svelte';
+  import EffectModal from '../components/EffectModal.svelte';
   import {
     combatantCardActions,
     currentCombatant,
     dispatchEncounterCommand,
+    groupConditionsByCategory,
+    listAfflictionOptions,
     listConditionOptions,
     listConditionWedgeCounts,
+    listPersistentDamageOptions,
     listRecentConditionOptions,
     listRemovableEffects,
+    listSpellEffectOptions,
     makeCombatant,
     makeCreatureCombatant,
     makePartyMemberCombatant,
@@ -23,6 +28,7 @@
     toCommand,
     viewAppliedEffects,
     type ApplyConditionChoice,
+    type EffectModalTab,
     type FeedbackEntry,
     type ManualCombatantInput,
     type TemplateAdjustmentChoice
@@ -59,11 +65,17 @@
   import { importCreatureYaml, importPartyMemberYaml } from '$lib/yaml';
 
   const conditionOptions = listConditionOptions();
+  const conditionGroups = groupConditionsByCategory();
+  const persistentOptions = listPersistentDamageOptions();
+  const afflictionOptions = listAfflictionOptions();
+  const spellOptions = listSpellEffectOptions();
   const wedgeCounts = listConditionWedgeCounts();
 
   let radialOpen = false;
   let radialAnchor = { x: 0, y: 0 };
   let radialCombatantId: string | null = null;
+
+  let effectModal: { combatantId: string; tab: EffectModalTab } | null = null;
 
   let encounter = newEncounterState();
   let feedback: FeedbackEntry[] = [];
@@ -91,6 +103,13 @@
   $: radialRecentOptions = radialCombatant ? listRecentConditionOptions(encounter) : [];
   $: radialRemovable = radialCombatant ? listRemovableEffects(radialCombatant, encounter) : [];
   $: if (radialOpen && !radialCombatant) closeRadial();
+
+  $: effectModalCombatant = effectModal ? encounter.combatants[effectModal.combatantId] : undefined;
+  $: effectModalApplied = effectModalCombatant ? viewAppliedEffects(effectModalCombatant, encounter) : [];
+  $: otherCombatantsForDuration = effectModalCombatant
+    ? Object.values(encounter.combatants).map((c) => ({ id: c.id, name: c.name }))
+    : [];
+  $: if (effectModal && !effectModalCombatant) closeEffectModal();
 
   function appendFeedback(
     id: string,
@@ -530,8 +549,23 @@
           effectId: choice.effectId,
           targetId: combatantId,
           value: choice.kind === 'valued' ? choice.value : undefined,
-          duration: { type: 'unlimited' }
+          duration: { type: 'unlimited' },
+          note: choice.note
         },
+        nextCommandId()
+      )
+    );
+  }
+
+  function setConditionDuration(
+    combatantId: string,
+    instanceId: string,
+    newDuration: Duration
+  ) {
+    runCommand(
+      toCommand(
+        'SET_EFFECT_DURATION',
+        { targetId: combatantId, instanceId, newDuration },
         nextCommandId()
       )
     );
@@ -552,15 +586,43 @@
     radialCombatantId = null;
   }
 
+  function openEffectModal(combatantId: string, tab: EffectModalTab) {
+    effectModal = { combatantId, tab };
+  }
+
+  function closeEffectModal() {
+    effectModal = null;
+  }
+
+  function radialOpenModal(tab: EffectModalTab) {
+    const id = radialCombatantId;
+    closeRadial();
+    if (id) openEffectModal(id, tab);
+  }
+
+  function modalApply(choice: ApplyConditionChoice) {
+    if (!effectModal) return;
+    applyCondition(effectModal.combatantId, choice);
+  }
+
+  function modalRemove(instanceId: string) {
+    if (!effectModal) return;
+    removeCondition(effectModal.combatantId, instanceId);
+  }
+
+  function modalModifyValue(instanceId: string, delta: number) {
+    if (!effectModal) return;
+    modifyConditionValue(effectModal.combatantId, instanceId, delta);
+  }
+
+  function modalSetDuration(instanceId: string, newDuration: Duration) {
+    if (!effectModal) return;
+    setConditionDuration(effectModal.combatantId, instanceId, newDuration);
+  }
+
   function radialApply(choice: ApplyConditionChoice) {
     if (!radialCombatantId) return;
     applyCondition(radialCombatantId, choice);
-    closeRadial();
-  }
-
-  function radialRemove(instanceId: string) {
-    if (!radialCombatantId) return;
-    removeCondition(radialCombatantId, instanceId);
     closeRadial();
   }
 
@@ -689,13 +751,31 @@
     combatantName={radialCombatant.name}
     combatantHpLabel={`${radialCombatant.currentHp}/${radialCombatant.baseStats.hp} HP`}
     anchor={radialAnchor}
-    {conditionOptions}
     recentOptions={radialRecentOptions}
-    removableEffects={radialRemovable}
+    appliedCount={radialRemovable.length}
     {wedgeCounts}
     onApply={radialApply}
-    onRemove={radialRemove}
+    onOpenModal={radialOpenModal}
     onClose={closeRadial}
+  />
+{/if}
+
+{#if effectModal && effectModalCombatant}
+  <EffectModal
+    combatantName={effectModalCombatant.name}
+    combatantHpLabel={`${effectModalCombatant.currentHp}/${effectModalCombatant.baseStats.hp} HP`}
+    initialTab={effectModal.tab}
+    appliedEffects={effectModalApplied}
+    {conditionGroups}
+    {persistentOptions}
+    {afflictionOptions}
+    effectOptions={spellOptions}
+    otherCombatants={otherCombatantsForDuration}
+    onApply={modalApply}
+    onModifyValue={modalModifyValue}
+    onSetDuration={modalSetDuration}
+    onRemove={modalRemove}
+    onClose={closeEffectModal}
   />
 {/if}
 


### PR DESCRIPTION
## Summary
- **Bug fix:** the radial sub-arc highlight inverted angular distance (`diff = 180 - diff;`) and picked the item *farthest* from the cursor, mirroring the highlight across the wedge midpoint. Removed the inversion so the bubble follows the cursor.
- **Redesign:** the radial becomes a 6-wedge context menu — Recent stays as a 1-gesture sub-arc fan-out; the other five wedges (Conditions, Persistent, Manage, Effects, Afflictions) close the radial and open a new `EffectModal` at the right tab.
- **EffectModal:** search-filtered grouped conditions, persistent-damage with damage-formula popover, afflictions and spell effects, plus an Applied tab that lets the GM step values, edit durations, and remove effects on the combatant.
- **Library populate:** 4 common afflictions + 10 common spell effects; persistent damage was already seeded.
- All wiring uses existing reducer commands (`APPLY_EFFECT`, `REMOVE_EFFECT`, `MODIFY_EFFECT_VALUE`, `SET_EFFECT_DURATION`); no domain changes beyond an optional `note` on `ApplyConditionChoice`. Note-editing on applied effects is deferred (no `SET_EFFECT_NOTE` command exists yet).

Closes #92.

## Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:run` — 502 passed (41 files), including:
  - 180° highlight regression test in `RadialConditionMenu.test.ts`
  - per-wedge `onOpenModal` tab-routing test
  - `EffectModal.test.ts` covering each tab + escape/backdrop close
  - `encounter-app.test.ts` coverage for `list*Options`, `groupConditionsByCategory`, and `resolveApplyChoice` with a note
- [x] `npm run audit` — passes (3 low-severity transitive cookie advisories, below moderate threshold)
- [x] `npm run build` — static Cloudflare Pages bundle builds cleanly
- [ ] Manual smoke: right-click a combatant; verify Recent sub-arc highlight follows the cursor; click each non-Recent wedge → modal opens at the right tab; Applied +/-/× work; Conditions search filters; Persistent fire 1d6 applies; Esc + backdrop both close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)