### PR TITLE
Make whole combatant card clickable to view stats

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -89,6 +89,32 @@
     clearLongPress();
   }
 
+  function isInnerInteractive(target: EventTarget | null, card: EventTarget | null): boolean {
+    if (!(target instanceof Element)) return false;
+    const hit = target.closest(
+      'button, a, input, select, textarea, [role="button"], [contenteditable="true"]'
+    );
+    return hit !== null && hit !== card;
+  }
+
+  function handleArticleClick(event: MouseEvent) {
+    if (!onSelect) return;
+    if (isInnerInteractive(event.target, event.currentTarget)) return;
+    if (longPressFired) {
+      longPressFired = false;
+      return;
+    }
+    onSelect(combatant.id);
+  }
+
+  function handleArticleKeyDown(event: KeyboardEvent) {
+    if (!onSelect) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    if (isInnerInteractive(event.target, event.currentTarget)) return;
+    event.preventDefault();
+    onSelect(combatant.id);
+  }
+
   let pickerOpen = false;
   let pickerEffectId = '';
   let pickerValue = 1;
@@ -181,18 +207,25 @@
       : 'Revive is unavailable in this phase';
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <article
   class:current-card={isCurrent}
   class:selected-card={isSelected}
+  class:selectable={Boolean(onSelect)}
   class:dimmed={visualState !== 'alive'}
   data-visual-state={visualState}
   data-hp-tone={hpTone}
   class="combatant-card"
+  role={onSelect ? 'button' : undefined}
+  tabindex={onSelect ? 0 : -1}
+  aria-label={onSelect ? `Select ${combatant.name}` : undefined}
   oncontextmenu={handleContextMenu}
   onpointerdown={handleArticlePointerDown}
   onpointermove={handleArticlePointerMove}
   onpointerup={handleArticlePointerEnd}
   onpointercancel={handleArticlePointerEnd}
+  onclick={handleArticleClick}
+  onkeydown={handleArticleKeyDown}
 >
   <div class="card-heading">
     <div class="card-heading__main">
@@ -438,11 +471,20 @@
   }
 
   .selected-card {
-    box-shadow: inset 3px 0 0 var(--color-blue), 0 1px 2px rgba(31, 26, 20, 0.08);
+    box-shadow: inset 0 0 0 2px var(--color-blue), 0 1px 2px rgba(31, 26, 20, 0.08);
   }
 
   .selected-card.current-card {
-    box-shadow: inset 3px 0 0 var(--color-blue), var(--shadow-soft);
+    box-shadow: inset 0 0 0 2px var(--color-blue), var(--shadow-soft);
+  }
+
+  .combatant-card.selectable {
+    cursor: pointer;
+  }
+
+  .combatant-card:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
   }
 
   .combatant-card.dimmed {

--- a/src/components/CombatantCard.test.ts
+++ b/src/components/CombatantCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { combatant } from '../domain/test-support';
 import CombatantCard from './CombatantCard.svelte';
 
@@ -78,5 +78,31 @@ describe('CombatantCard select affordance', () => {
       'aria-pressed',
       'false'
     );
+  });
+
+  test('clicking the card body calls onSelect with the combatant id', async () => {
+    const onSelect = vi.fn();
+    const { container } = render(CombatantCard, { props: baseProps({ onSelect }) });
+    const article = container.querySelector('article.combatant-card') as HTMLElement;
+    expect(article).not.toBeNull();
+    await fireEvent.click(article);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('goblin-1');
+  });
+
+  test('clicking the inner name button does not double-fire onSelect from the card handler', async () => {
+    const onSelect = vi.fn();
+    render(CombatantCard, { props: baseProps({ onSelect }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Goblin Warrior' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test('pressing Enter on the focused card calls onSelect', async () => {
+    const onSelect = vi.fn();
+    const { container } = render(CombatantCard, { props: baseProps({ onSelect }) });
+    const article = container.querySelector('article.combatant-card') as HTMLElement;
+    await fireEvent.keyDown(article, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('goblin-1');
   });
 });


### PR DESCRIPTION
## Summary

- Clicking anywhere on a combatant card body (or pressing Enter/Space on a focused card) selects that combatant and shows their stats in the details panel — the previous click target was just the small name link.
- "Selected" and "current turn" are now two layered visuals: the active-turn card keeps its ink left-border + soft shadow + Turn chip; the selected card gets a blue inset ring. Both states show simultaneously when the active combatant is also the selected one.
- Inner controls (HP edit, ↑/↓ reorder, condition chips, lifecycle buttons, condition select/input, the existing name button, right-click radial menu) all keep working without firing card-level select. Selection is gated by a `closest('button, a, input, select, textarea, [role="button"], [contenteditable="true"]')` filter that ignores the article itself.

UI-only change: no domain, route-state, or persistence changes. Selection remains ephemeral, route-level state — `Selection { id, pinned }` and the existing `pickCombatant` / `followActive` / `reconcileWithCombatants` helpers in `src/lib/selection-state.ts` already handled the harder cases (pinned selection survives turn advances; cleanup when a selected combatant is removed).

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 505/505 (3 new tests added to `CombatantCard.test.ts`)
- [x] `npm run audit` — exit 0 (3 low-severity advisories, gate is moderate-or-higher)
- [x] `npm run build` — Cloudflare Pages static build OK
- [x] Manual via Playwright (dev server):
  - [x] Click bare body of non-active card → details panel switches; clicked card gets `selected-card`, active card keeps `current-card`
  - [x] Click HP edit on a card → inline editor opens, selection unchanged
  - [x] Right-click any card → radial condition menu opens, selection unchanged
  - [x] Tab to a card, press Enter → that card becomes selected
  - [x] Active + selected on the same card → both visuals layer (ink border + soft shadow + blue inset ring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)