### PR TITLE
Quick-pick formula and Roll-on-apply for persistent damage

### DIFF
--- a/src/components/EffectModal.svelte
+++ b/src/components/EffectModal.svelte
@@ -35,13 +35,25 @@
     { id: 'effects', label: 'Effects' }
   ];
 
+  const PERSISTENT_DAMAGE_QUICK_PICKS = [
+    '1d4',
+    '1d6',
+    '1d8',
+    '1d10',
+    '1d12',
+    '2d4',
+    '2d6',
+    '2d8'
+  ] as const;
+  const DEFAULT_PERSISTENT_FORMULA = '1d6';
+
   let activeTab: EffectModalTab = initialTab;
   let conditionSearch = '';
   let valuePickerForId: string | null = null;
   let valuePickerValue = 1;
   let valuePickerSource: 'conditions' | 'afflictions' = 'conditions';
   let persistentFormulaForId: string | null = null;
-  let persistentFormula = '1d6';
+  let persistentFormula = DEFAULT_PERSISTENT_FORMULA;
   let durationEditorForId: string | null = null;
   let durationKindBuf: DurationKind = 'unlimited';
   let durationCountBuf = 1;
@@ -80,7 +92,11 @@
 
   function startPersistent(option: ConditionOption) {
     persistentFormulaForId = option.id;
-    persistentFormula = '1d6';
+    persistentFormula = DEFAULT_PERSISTENT_FORMULA;
+  }
+
+  function selectQuickPick(formula: string) {
+    persistentFormula = formula;
   }
 
   function commitPersistent(option: ConditionOption) {
@@ -347,7 +363,7 @@
         {#if persistentOptions.length === 0}
           <p class="empty">No persistent damage types defined.</p>
         {:else}
-          <p class="hint">Pick a damage type, then enter the formula (e.g. <code>1d6</code> or <code>2d4+2</code>).</p>
+          <p class="hint">Pick a damage type, then click a formula (or type a custom one).</p>
           <div class="chip-row">
             {#each persistentOptions as option (option.id)}
               <div class="chip-wrap">
@@ -361,14 +377,33 @@
                   {option.name}
                 </button>
                 {#if persistentFormulaForId === option.id}
-                  <div class="value-picker">
-                    <input
-                      type="text"
-                      bind:value={persistentFormula}
-                      aria-label={`${option.name} damage formula`}
-                    />
-                    <button type="button" class="primary" onclick={() => commitPersistent(option)}>Apply</button>
-                    <button type="button" class="ghost" onclick={() => (persistentFormulaForId = null)}>Cancel</button>
+                  <div class="formula-picker" data-formula-picker>
+                    <div class="formula-chips" role="group" aria-label="Quick formulas">
+                      {#each PERSISTENT_DAMAGE_QUICK_PICKS as formula (formula)}
+                        <button
+                          type="button"
+                          class="chip formula-chip"
+                          class:chip-active={persistentFormula.trim() === formula}
+                          data-formula={formula}
+                          onclick={() => selectQuickPick(formula)}
+                        >
+                          {formula}
+                        </button>
+                      {/each}
+                    </div>
+                    <label class="custom-formula">
+                      <span>Custom</span>
+                      <input
+                        type="text"
+                        bind:value={persistentFormula}
+                        aria-label={`${option.name} damage formula`}
+                        placeholder="e.g. 2d6+3"
+                      />
+                    </label>
+                    <div class="formula-actions">
+                      <button type="button" class="primary" onclick={() => commitPersistent(option)}>Apply</button>
+                      <button type="button" class="ghost" onclick={() => (persistentFormulaForId = null)}>Cancel</button>
+                    </div>
                   </div>
                 {/if}
               </div>
@@ -803,5 +838,52 @@
     justify-content: flex-end;
     padding: var(--space-3) var(--space-4);
     border-top: 1px solid var(--color-rule);
+  }
+
+  .formula-picker {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    background: var(--color-panel);
+    border: 1px solid var(--color-rule);
+    border-radius: 4px;
+  }
+
+  .formula-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .formula-chip {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 3px 10px;
+  }
+
+  .custom-formula {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: 11px;
+    color: var(--color-ink-mute);
+  }
+
+  .custom-formula input {
+    flex: 1;
+    padding: 2px 6px;
+    font: inherit;
+    font-family: var(--font-mono);
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 3px;
+    background: var(--color-bg);
+    color: inherit;
+  }
+
+  .formula-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 4px;
   }
 </style>

--- a/src/components/EffectModal.svelte
+++ b/src/components/EffectModal.svelte
@@ -8,6 +8,8 @@
     type ConditionOption,
     type EffectModalTab
   } from '$lib/encounter-app';
+  import { persistentEffectIdToDamageType } from '$lib/effects/damage-type-glyph';
+  import DamageTypeGlyph from './ui/DamageTypeGlyph.svelte';
   import type { Duration } from '../domain';
 
   export let combatantName: string;
@@ -93,6 +95,10 @@
   function startPersistent(option: ConditionOption) {
     persistentFormulaForId = option.id;
     persistentFormula = DEFAULT_PERSISTENT_FORMULA;
+  }
+
+  function persistentChipLabel(name: string): string {
+    return name.replace(/^Persistent\s+/i, '');
   }
 
   function selectQuickPick(formula: string) {
@@ -366,15 +372,21 @@
           <p class="hint">Pick a damage type, then click a formula (or type a custom one).</p>
           <div class="chip-row">
             {#each persistentOptions as option (option.id)}
+              {@const damageType = persistentEffectIdToDamageType(option.id)}
               <div class="chip-wrap">
                 <button
                   type="button"
-                  class="chip"
+                  class="chip persistent-chip"
                   class:chip-active={persistentFormulaForId === option.id}
                   data-option-id={option.id}
+                  aria-label={option.name}
+                  title={option.name}
                   onclick={() => startPersistent(option)}
                 >
-                  {option.name}
+                  {#if damageType}
+                    <DamageTypeGlyph type={damageType} />
+                  {/if}
+                  <span>{persistentChipLabel(option.name)}</span>
                 </button>
                 {#if persistentFormulaForId === option.id}
                   <div class="formula-picker" data-formula-picker>
@@ -787,6 +799,12 @@
     background: var(--color-ink);
     color: var(--color-bg);
     border-color: var(--color-ink);
+  }
+
+  .persistent-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
 
   .value-picker {

--- a/src/components/EffectModal.test.ts
+++ b/src/components/EffectModal.test.ts
@@ -153,6 +153,18 @@ describe('EffectModal', () => {
     expect(onApply).toHaveBeenCalledWith({ kind: 'unvalued', effectId: 'persistent-fire', note: '2d6' });
   });
 
+  test('Persistent tab: chip strips the "Persistent" prefix from its visible label but keeps the full name as accessible name', () => {
+    const { container } = render(
+      EffectModal,
+      { props: baseProps({ initialTab: 'persistent' as EffectModalTab }) }
+    );
+    const chip = container.querySelector('[data-option-id="persistent-fire"]') as HTMLButtonElement;
+    expect(chip).not.toBeNull();
+    expect(chip.textContent ?? '').not.toMatch(/Persistent/i);
+    expect(chip.textContent ?? '').toMatch(/Fire/);
+    expect(chip.getAttribute('aria-label')).toBe('Persistent Fire');
+  });
+
   test('Escape and backdrop click both call onClose', async () => {
     const onClose = vi.fn();
     const { container } = render(EffectModal, { props: baseProps({ onClose }) });

--- a/src/components/PromptResolutionPanel.svelte
+++ b/src/components/PromptResolutionPanel.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import type {
+    AppliedEffect,
     CombatantState,
     EncounterPhase,
     Prompt,
     PromptResolution,
     TurnBoundarySuggestion
   } from '../domain';
+  import { rollDiceFormula } from '$lib/dice/formula';
   import Button from './ui/Button.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
 
@@ -13,21 +15,74 @@
   export let combatantsById: Record<string, CombatantState>;
   export let phase: EncounterPhase;
   export let onResolve: (promptId: string, resolution: PromptResolution) => void;
+  export let onApplyPersistentDamage: (
+    combatantId: string,
+    amount: number,
+    damageType: string
+  ) => void = () => {};
 
   $: focused = phase === 'RESOLVING' && prompts.length > 0;
 
-  let setValueDrafts: Record<string, number> = {};
+  interface PersistentDamageBranch {
+    damageType: string;
+    formula: string | null;
+  }
 
-  $: setValueDrafts = reconcileDrafts(prompts, setValueDrafts);
+  let setValueDrafts: Record<string, number> = {};
+  let damageDrafts: Record<string, number | null> = {};
+
+  $: persistentBranches = computePersistentBranches(prompts, combatantsById);
+  $: setValueDrafts = reconcileDrafts(prompts, persistentBranches, setValueDrafts);
+  $: damageDrafts = reconcileDamageDrafts(prompts, persistentBranches, damageDrafts);
+
+  function findEffect(p: Prompt): AppliedEffect | undefined {
+    return combatantsById[p.targetId]?.appliedEffects.find(
+      (effect) => effect.instanceId === p.effectInstanceId
+    );
+  }
+
+  function computePersistentBranches(
+    list: Prompt[],
+    byId: Record<string, CombatantState>
+  ): Record<string, PersistentDamageBranch> {
+    const next: Record<string, PersistentDamageBranch> = {};
+    for (const p of list) {
+      if (p.suggestionType.type !== 'promptResolution') continue;
+      const effect = byId[p.targetId]?.appliedEffects.find(
+        (e) => e.instanceId === p.effectInstanceId
+      );
+      if (!effect || !effect.effectId.startsWith('persistent-')) continue;
+      next[p.id] = {
+        damageType: effect.effectId.slice('persistent-'.length),
+        formula: effect.note?.trim() ? effect.note.trim() : null
+      };
+    }
+    return next;
+  }
 
   function reconcileDrafts(
     list: Prompt[],
+    branches: Record<string, PersistentDamageBranch>,
     current: Record<string, number>
   ): Record<string, number> {
     const next: Record<string, number> = {};
     for (const p of list) {
+      if (branches[p.id]) continue;
       if (!supportsSetValue(p.suggestionType)) continue;
       next[p.id] = current[p.id] ?? defaultSetValue(p);
+    }
+    return next;
+  }
+
+  function reconcileDamageDrafts(
+    list: Prompt[],
+    branches: Record<string, PersistentDamageBranch>,
+    current: Record<string, number | null>
+  ): Record<string, number | null> {
+    const next: Record<string, number | null> = {};
+    for (const p of list) {
+      if (!branches[p.id]) continue;
+      next[p.id] = p.id in current ? current[p.id] : null;
     }
     return next;
   }
@@ -90,6 +145,19 @@
     if (!Number.isFinite(value)) return;
     onResolve(p.id, { type: 'setValue', value });
   }
+
+  function handleRoll(p: Prompt, formula: string) {
+    const rolled = rollDiceFormula(formula);
+    if (rolled === null) return;
+    damageDrafts = { ...damageDrafts, [p.id]: rolled };
+  }
+
+  function handleApplyDamage(p: Prompt, branch: PersistentDamageBranch) {
+    const amount = damageDrafts[p.id];
+    if (amount === null || amount === undefined || !Number.isFinite(amount) || amount <= 0) return;
+    onApplyPersistentDamage(p.targetId, amount, branch.damageType);
+    damageDrafts = { ...damageDrafts, [p.id]: null };
+  }
 </script>
 
 {#if focused}
@@ -115,45 +183,87 @@
           </div>
           <p class="prompt__description">{prompt.description}</p>
           <div class="prompt__actions">
-            {#if showAccept(prompt.suggestionType)}
-              <Button
-                size="sm"
-                variant="primary"
-                ariaLabel={acceptLabel(prompt.suggestionType)}
-                onclick={() => handleAccept(prompt)}
-              >{acceptLabel(prompt.suggestionType)}</Button>
-            {/if}
-            {#if supportsSetValue(prompt.suggestionType)}
-              <span class="set-value">
-                <label>
-                  Set to
-                  <input
-                    type="number"
-                    aria-label={`Set value for ${prompt.effectName}`}
-                    bind:value={setValueDrafts[prompt.id]}
-                  />
-                </label>
+            {#if persistentBranches[prompt.id]}
+              {@const branch = persistentBranches[prompt.id]}
+              {#if branch.formula}
                 <Button
                   size="sm"
-                  variant="secondary"
-                  ariaLabel="Set"
-                  onclick={() => handleSetValue(prompt)}
-                >Set</Button>
+                  variant="primary"
+                  ariaLabel={`Roll ${branch.formula}`}
+                  onclick={() => handleRoll(prompt, branch.formula!)}
+                >Roll {branch.formula}</Button>
+              {/if}
+              <span class="set-value">
+                <label>
+                  Damage
+                  <input
+                    type="number"
+                    min="0"
+                    aria-label={`Damage amount for ${prompt.effectName}`}
+                    bind:value={damageDrafts[prompt.id]}
+                  />
+                </label>
+                <span class="damage-type">{branch.damageType}</span>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  ariaLabel="Apply damage"
+                  onclick={() => handleApplyDamage(prompt, branch)}
+                >Apply damage</Button>
               </span>
-            {/if}
-            <Button
-              size="sm"
-              variant="secondary"
-              ariaLabel="Dismiss"
-              onclick={() => handleDismiss(prompt)}
-            >Dismiss</Button>
-            {#if showRemove(prompt.suggestionType)}
+              <Button
+                size="sm"
+                variant="secondary"
+                ariaLabel="Dismiss"
+                onclick={() => handleDismiss(prompt)}
+              >Dismiss</Button>
               <Button
                 size="sm"
                 variant="destructive"
                 ariaLabel="Remove effect"
                 onclick={() => handleRemove(prompt)}
               >Remove effect</Button>
+            {:else}
+              {#if showAccept(prompt.suggestionType)}
+                <Button
+                  size="sm"
+                  variant="primary"
+                  ariaLabel={acceptLabel(prompt.suggestionType)}
+                  onclick={() => handleAccept(prompt)}
+                >{acceptLabel(prompt.suggestionType)}</Button>
+              {/if}
+              {#if supportsSetValue(prompt.suggestionType)}
+                <span class="set-value">
+                  <label>
+                    Set to
+                    <input
+                      type="number"
+                      aria-label={`Set value for ${prompt.effectName}`}
+                      bind:value={setValueDrafts[prompt.id]}
+                    />
+                  </label>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    ariaLabel="Set"
+                    onclick={() => handleSetValue(prompt)}
+                  >Set</Button>
+                </span>
+              {/if}
+              <Button
+                size="sm"
+                variant="secondary"
+                ariaLabel="Dismiss"
+                onclick={() => handleDismiss(prompt)}
+              >Dismiss</Button>
+              {#if showRemove(prompt.suggestionType)}
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  ariaLabel="Remove effect"
+                  onclick={() => handleRemove(prompt)}
+                >Remove effect</Button>
+              {/if}
             {/if}
           </div>
         </li>
@@ -275,5 +385,11 @@
     outline: 2px solid var(--color-blue);
     outline-offset: 1px;
     border-color: var(--color-ink);
+  }
+
+  .damage-type {
+    font-size: var(--text-sm);
+    color: var(--color-ink-soft);
+    text-transform: lowercase;
   }
 </style>

--- a/src/components/PromptResolutionPanel.test.ts
+++ b/src/components/PromptResolutionPanel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, type Mock } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { combatant, prompt } from '../domain/test-support';
 import type {
+  AppliedEffect,
   CombatantState,
   EncounterPhase,
   Prompt,
@@ -10,6 +11,7 @@ import type {
 import PromptResolutionPanel from './PromptResolutionPanel.svelte';
 
 type ResolveHandler = (promptId: string, resolution: PromptResolution) => void;
+type ApplyDamageHandler = (combatantId: string, amount: number, damageType: string) => void;
 
 const goblin: CombatantState = combatant('goblin-1', { name: 'Goblin Warrior' });
 const fighter: CombatantState = combatant('fighter-1', { name: 'Fighter' });
@@ -18,22 +20,30 @@ const combatants: Record<string, CombatantState> = {
   'fighter-1': fighter
 };
 
+function withEffect(c: CombatantState, effect: AppliedEffect): CombatantState {
+  return { ...c, appliedEffects: [...c.appliedEffects, effect] };
+}
+
 function renderPanel(props: {
   prompts: Prompt[];
   phase?: EncounterPhase;
   combatantsById?: Record<string, CombatantState>;
   onResolve?: Mock<ResolveHandler>;
+  onApplyPersistentDamage?: Mock<ApplyDamageHandler>;
 }) {
   const onResolve: Mock<ResolveHandler> = props.onResolve ?? vi.fn<ResolveHandler>();
+  const onApplyPersistentDamage: Mock<ApplyDamageHandler> =
+    props.onApplyPersistentDamage ?? vi.fn<ApplyDamageHandler>();
   const utils = render(PromptResolutionPanel, {
     props: {
       prompts: props.prompts,
       combatantsById: props.combatantsById ?? combatants,
       phase: props.phase ?? 'RESOLVING',
-      onResolve: onResolve as unknown as ResolveHandler
+      onResolve: onResolve as unknown as ResolveHandler,
+      onApplyPersistentDamage: onApplyPersistentDamage as unknown as ApplyDamageHandler
     }
   });
-  return { ...utils, onResolve };
+  return { ...utils, onResolve, onApplyPersistentDamage };
 }
 
 describe('PromptResolutionPanel', () => {
@@ -300,6 +310,176 @@ describe('PromptResolutionPanel', () => {
 
     const input = screen.getByRole('spinbutton') as HTMLInputElement;
     expect(input.value).toBe('0');
+  });
+
+  describe('persistent-damage prompts', () => {
+    function persistentEffect(overrides: Partial<AppliedEffect> = {}): AppliedEffect {
+      return {
+        instanceId: 'instance-1',
+        effectId: 'persistent-fire',
+        duration: { type: 'unlimited' },
+        note: '1d6',
+        ...overrides
+      };
+    }
+
+    function persistentPrompt(overrides: Parameters<typeof prompt>[0] = {}): Prompt {
+      return prompt({
+        id: 'prompt-pd',
+        ownerId: 'goblin-1',
+        targetId: 'goblin-1',
+        effectInstanceId: 'instance-1',
+        effectName: 'Persistent Fire',
+        suggestionType: { type: 'promptResolution', description: 'Take 1d6 fire damage.' },
+        ...overrides
+      });
+    }
+
+    test('renders Roll, damage field, Apply damage, Dismiss, Remove effect (no Accept, no Set)', () => {
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect())
+        }
+      });
+
+      expect(screen.getByRole('button', { name: 'Roll 1d6' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply damage' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Remove effect' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Set' })).toBeNull();
+      expect(screen.getByText('fire')).toBeInTheDocument();
+    });
+
+    test('Roll fills the damage field with a deterministic value', async () => {
+      const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // mid roll
+      try {
+        renderPanel({
+          prompts: [persistentPrompt()],
+          combatantsById: {
+            'goblin-1': withEffect(goblin, persistentEffect({ note: '1d6' }))
+          }
+        });
+
+        const input = screen.getByRole('spinbutton', {
+          name: 'Damage amount for Persistent Fire'
+        }) as HTMLInputElement;
+        expect(input.value).toBe('');
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Roll 1d6' }));
+        expect(input.value).toBe('4');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    test('Apply damage dispatches onApplyPersistentDamage with combatantId, amount and damage type', async () => {
+      const onApplyPersistentDamage = vi.fn<ApplyDamageHandler>();
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect({ effectId: 'persistent-bleed', note: '1d8' }))
+        },
+        onApplyPersistentDamage
+      });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: '7' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Apply damage' }));
+
+      expect(onApplyPersistentDamage).toHaveBeenCalledWith('goblin-1', 7, 'bleed');
+    });
+
+    test('Apply damage with no value or zero is ignored', async () => {
+      const onApplyPersistentDamage = vi.fn<ApplyDamageHandler>();
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect())
+        },
+        onApplyPersistentDamage
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Apply damage' }));
+      expect(onApplyPersistentDamage).not.toHaveBeenCalled();
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: '0' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Apply damage' }));
+      expect(onApplyPersistentDamage).not.toHaveBeenCalled();
+    });
+
+    test('Manual entry: GM types a value without rolling and applies it', async () => {
+      const onApplyPersistentDamage = vi.fn<ApplyDamageHandler>();
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect())
+        },
+        onApplyPersistentDamage
+      });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: '5' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Apply damage' }));
+      expect(onApplyPersistentDamage).toHaveBeenCalledWith('goblin-1', 5, 'fire');
+    });
+
+    test('formula-less effect: no Roll button; manual-only', () => {
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect({ note: undefined }))
+        }
+      });
+
+      expect(screen.queryByRole('button', { name: /^Roll/ })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Apply damage' })).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    test('Apply damage does not auto-resolve the prompt; Remove effect still works', async () => {
+      const onResolve = vi.fn<ResolveHandler>();
+      const onApplyPersistentDamage = vi.fn<ApplyDamageHandler>();
+      renderPanel({
+        prompts: [persistentPrompt()],
+        combatantsById: {
+          'goblin-1': withEffect(goblin, persistentEffect())
+        },
+        onResolve,
+        onApplyPersistentDamage
+      });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: '4' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Apply damage' }));
+      expect(onApplyPersistentDamage).toHaveBeenCalled();
+      expect(onResolve).not.toHaveBeenCalled();
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Remove effect' }));
+      expect(onResolve).toHaveBeenCalledWith('prompt-pd', { type: 'remove' });
+    });
+
+    test('non-persistent promptResolution prompts still get the legacy Accept/Set controls', () => {
+      renderPanel({
+        prompts: [
+          prompt({
+            id: 'prompt-dying',
+            effectName: 'Dying',
+            suggestionType: { type: 'promptResolution', description: 'Recovery check.' },
+            currentValue: 1,
+            suggestedValue: 1
+          })
+        ],
+        combatantsById: combatants
+      });
+
+      expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Set' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^Roll/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Apply damage' })).toBeNull();
+    });
   });
 
   test('preserves typed drafts across re-renders and drops drafts for resolved prompts', async () => {

--- a/src/components/ui/DamageTypeGlyph.svelte
+++ b/src/components/ui/DamageTypeGlyph.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { damageTypeGlyph } from '$lib/effects/damage-type-glyph';
+
+  export let type: string;
+
+  $: info = damageTypeGlyph(type);
+</script>
+
+<span
+  class="damage-type-glyph"
+  class:color-red={info.color === 'red'}
+  class:color-blue={info.color === 'blue'}
+  class:color-amber={info.color === 'amber'}
+  class:color-green={info.color === 'green'}
+  class:color-ink={info.color === 'ink'}
+  aria-label={info.aria}
+  title={info.aria}
+>{info.glyph}</span>
+
+<style>
+  .damage-type-glyph {
+    display: inline-block;
+    font-size: 1em;
+    line-height: 1;
+    /* Emoji glyphs render their own colors; the .color-* classes apply
+       only to monochrome unicode glyphs (♪, ❄, ☠, ➹, ⚔, ◯). */
+  }
+
+  .color-red {
+    color: var(--color-red);
+  }
+  .color-blue {
+    color: var(--color-blue);
+  }
+  .color-amber {
+    color: var(--color-amber);
+  }
+  .color-green {
+    color: var(--color-green);
+  }
+  .color-ink {
+    color: var(--color-ink);
+  }
+</style>

--- a/src/lib/dice/formula.test.ts
+++ b/src/lib/dice/formula.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { parseDiceFormula, rollDiceFormula } from './formula';
+
+describe('parseDiceFormula', () => {
+  it('parses bare NdM', () => {
+    expect(parseDiceFormula('1d6')).toEqual({ dice: 1, dieSize: 6, bonus: 0 });
+    expect(parseDiceFormula('2d4')).toEqual({ dice: 2, dieSize: 4, bonus: 0 });
+    expect(parseDiceFormula('3d10')).toEqual({ dice: 3, dieSize: 10, bonus: 0 });
+  });
+
+  it('parses positive bonus', () => {
+    expect(parseDiceFormula('1d6+2')).toEqual({ dice: 1, dieSize: 6, bonus: 2 });
+    expect(parseDiceFormula('2d6 + 3')).toEqual({ dice: 2, dieSize: 6, bonus: 3 });
+  });
+
+  it('parses negative bonus', () => {
+    expect(parseDiceFormula('2d8-1')).toEqual({ dice: 2, dieSize: 8, bonus: -1 });
+    expect(parseDiceFormula('1d10 - 2')).toEqual({ dice: 1, dieSize: 10, bonus: -2 });
+  });
+
+  it('is case-insensitive on D', () => {
+    expect(parseDiceFormula('1D6')).toEqual({ dice: 1, dieSize: 6, bonus: 0 });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseDiceFormula('  1d6  ')).toEqual({ dice: 1, dieSize: 6, bonus: 0 });
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseDiceFormula('')).toBeNull();
+    expect(parseDiceFormula('   ')).toBeNull();
+    expect(parseDiceFormula('d6')).toBeNull();
+    expect(parseDiceFormula('1d')).toBeNull();
+    expect(parseDiceFormula('abc')).toBeNull();
+    expect(parseDiceFormula('1d6+')).toBeNull();
+    expect(parseDiceFormula('0d6')).toBeNull();
+    expect(parseDiceFormula('1d1')).toBeNull();
+  });
+});
+
+describe('rollDiceFormula', () => {
+  it('returns null for unparseable input', () => {
+    expect(rollDiceFormula('garbage')).toBeNull();
+  });
+
+  it('rolls each die using the injected RNG', () => {
+    const values = [0, 0.5, 0.999];
+    let i = 0;
+    const rng = () => values[i++];
+    expect(rollDiceFormula('3d6', rng)).toBe(1 + 4 + 6);
+  });
+
+  it('adds the bonus', () => {
+    const rng = () => 0;
+    expect(rollDiceFormula('2d6+5', rng)).toBe(1 + 1 + 5);
+  });
+
+  it('subtracts the bonus', () => {
+    const rng = () => 0.999;
+    expect(rollDiceFormula('1d6-2', rng)).toBe(6 - 2);
+  });
+
+  it('clamps a negative total to zero', () => {
+    const rng = () => 0;
+    expect(rollDiceFormula('1d4-10', rng)).toBe(0);
+  });
+});

--- a/src/lib/dice/formula.ts
+++ b/src/lib/dice/formula.ts
@@ -1,0 +1,30 @@
+export interface ParsedDiceFormula {
+  dice: number;
+  dieSize: number;
+  bonus: number;
+}
+
+const FORMULA_RE = /^(\d+)d(\d+)\s*(?:([+-])\s*(\d+))?$/i;
+
+export function parseDiceFormula(input: string): ParsedDiceFormula | null {
+  const trimmed = input.trim();
+  if (trimmed === '') return null;
+  const match = FORMULA_RE.exec(trimmed.replace(/\s+/g, ''));
+  if (!match) return null;
+  const dice = Number(match[1]);
+  const dieSize = Number(match[2]);
+  if (dice < 1 || dieSize < 2) return null;
+  const sign = match[3] === '-' ? -1 : 1;
+  const bonus = match[4] !== undefined ? sign * Number(match[4]) : 0;
+  return { dice, dieSize, bonus };
+}
+
+export function rollDiceFormula(input: string, rng: () => number = Math.random): number | null {
+  const parsed = parseDiceFormula(input);
+  if (!parsed) return null;
+  let total = parsed.bonus;
+  for (let i = 0; i < parsed.dice; i++) {
+    total += Math.floor(rng() * parsed.dieSize) + 1;
+  }
+  return Math.max(total, 0);
+}

--- a/src/lib/effects/damage-type-glyph.test.ts
+++ b/src/lib/effects/damage-type-glyph.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { damageTypeGlyph, persistentEffectIdToDamageType } from './damage-type-glyph';
+
+describe('damageTypeGlyph', () => {
+  it('returns a glyph and color for known types', () => {
+    expect(damageTypeGlyph('fire')).toEqual({ glyph: '🔥', color: 'red', aria: 'Fire' });
+    expect(damageTypeGlyph('cold')).toEqual({ glyph: '❄', color: 'blue', aria: 'Cold' });
+    expect(damageTypeGlyph('bleed')).toEqual({ glyph: '🩸', color: 'red', aria: 'Bleed' });
+  });
+
+  it('is case-insensitive', () => {
+    expect(damageTypeGlyph('Fire').glyph).toBe('🔥');
+    expect(damageTypeGlyph('ELECTRICITY').glyph).toBe('⚡');
+  });
+
+  it('falls back to a neutral glyph for unknown types', () => {
+    const fallback = damageTypeGlyph('exotic');
+    expect(fallback.glyph).toBe('◯');
+    expect(fallback.color).toBe('ink');
+    expect(fallback.aria).toBe('exotic');
+  });
+
+  it('covers every persistent damage type the effect library defines', () => {
+    const expected = [
+      'fire',
+      'cold',
+      'acid',
+      'electricity',
+      'sonic',
+      'bleed',
+      'poison',
+      'mental',
+      'bludgeoning',
+      'piercing',
+      'slashing'
+    ];
+    for (const type of expected) {
+      const info = damageTypeGlyph(type);
+      expect(info.glyph).not.toBe('◯');
+      expect(info.aria.toLowerCase()).toBe(type);
+    }
+  });
+});
+
+describe('persistentEffectIdToDamageType', () => {
+  it('strips the persistent- prefix', () => {
+    expect(persistentEffectIdToDamageType('persistent-fire')).toBe('fire');
+    expect(persistentEffectIdToDamageType('persistent-bleed')).toBe('bleed');
+  });
+
+  it('returns null when the prefix is absent', () => {
+    expect(persistentEffectIdToDamageType('frightened')).toBeNull();
+    expect(persistentEffectIdToDamageType('persistent-')).toBeNull();
+  });
+});

--- a/src/lib/effects/damage-type-glyph.ts
+++ b/src/lib/effects/damage-type-glyph.ts
@@ -1,0 +1,33 @@
+export type DamageTypeColor = 'red' | 'blue' | 'amber' | 'green' | 'ink';
+
+export interface DamageTypeGlyphInfo {
+  glyph: string;
+  color: DamageTypeColor;
+  aria: string;
+}
+
+const TABLE: Record<string, DamageTypeGlyphInfo> = {
+  fire: { glyph: '🔥', color: 'red', aria: 'Fire' },
+  cold: { glyph: '❄', color: 'blue', aria: 'Cold' },
+  acid: { glyph: '🧪', color: 'green', aria: 'Acid' },
+  electricity: { glyph: '⚡', color: 'amber', aria: 'Electricity' },
+  sonic: { glyph: '♪', color: 'blue', aria: 'Sonic' },
+  bleed: { glyph: '🩸', color: 'red', aria: 'Bleed' },
+  poison: { glyph: '☠', color: 'green', aria: 'Poison' },
+  mental: { glyph: '🧠', color: 'amber', aria: 'Mental' },
+  bludgeoning: { glyph: '🔨', color: 'ink', aria: 'Bludgeoning' },
+  piercing: { glyph: '➹', color: 'ink', aria: 'Piercing' },
+  slashing: { glyph: '⚔', color: 'ink', aria: 'Slashing' }
+};
+
+export function damageTypeGlyph(type: string): DamageTypeGlyphInfo {
+  return TABLE[type.toLowerCase()] ?? { glyph: '◯', color: 'ink', aria: type };
+}
+
+const PERSISTENT_PREFIX = 'persistent-';
+
+export function persistentEffectIdToDamageType(effectId: string): string | null {
+  if (!effectId.startsWith(PERSISTENT_PREFIX)) return null;
+  const tail = effectId.slice(PERSISTENT_PREFIX.length);
+  return tail.length > 0 ? tail : null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -795,6 +795,10 @@
     runCommand(toCommand('RESOLVE_PROMPT', { promptId, resolution }, nextCommandId()));
   }
 
+  function applyPersistentDamageFromPrompt(combatantId: string, amount: number, damageType: string) {
+    runCommand(toCommand('APPLY_DAMAGE', { combatantId, amount, damageType }, nextCommandId()));
+  }
+
   function selectCombatant(id: string) {
     selection = pickCombatant(selection, id);
   }
@@ -848,6 +852,7 @@
         combatantsById={encounter.combatants}
         phase={encounter.phase}
         onResolve={resolvePrompt}
+        onApplyPersistentDamage={applyPersistentDamageFromPrompt}
       />
       {#if unorderedCombatants.length > 0}
         <div class="not-yet-rolled" aria-label="Not yet rolled">


### PR DESCRIPTION
## Summary

- **Setting**: replace the typed-formula input on the EffectModal Persistent tab with quick-pick chips (1d4, 1d6, 1d8, 1d10, 1d12, 2d4, 2d6, 2d8) plus a custom text fallback. One click sets the formula.
- **Applying at turn start**: for persistent-damage prompts only, the PromptResolutionPanel now renders `Roll {formula}` -> editable damage field -> `Apply damage`. Apply dispatches `APPLY_DAMAGE` with the correct damage type. Manual entry without rolling is also supported.
- **Apply damage does not auto-resolve the prompt** (per PF2e RAW: damage and the DC 15 flat check are independent). The GM still clicks `Remove effect` (success) or `Dismiss` (failed) afterwards.
- New `src/lib/dice.ts` utility: pure parser + roller with injectable RNG. UI-side only; reducer remains dice-free and JSON-deterministic.
- Other prompt types (dying recovery, sustained, decrement, reminder) are unchanged.

## Test plan
- [x] `npm run check` (svelte-check + tsc on domain) passes
- [x] `npm run test:run` -- 524/524 tests pass (8 new persistent-damage panel tests + 11 new dice tests)
- [x] `npm run audit` -- 3 low-severity advisories (pre-existing), exit 0
- [x] `npm run build` -- static build succeeds
- [ ] Manual: open effect modal -> Persistent -> click *Persistent Bleed* -> click `1d8` chip -> Apply
- [ ] Manual: advance to that combatant's turn -> click `Roll 1d8` -> field fills -> click `Apply damage` -> HP drops, log shows "X took N bleed damage"
- [ ] Manual: type a number directly into the field without rolling, then `Apply damage`
- [ ] Manual: `Remove effect` removes the effect; `Dismiss` keeps it pending for next turn
- [ ] Manual: a non-persistent prompt (e.g. Frightened end-of-turn) still shows the legacy Accept / Set / Dismiss controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)