### PR TITLE
Inline initiative scores: roll, type, auto-sort

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -40,6 +40,8 @@
   export let onRequestRadial:
     | ((id: string, anchor: { x: number; y: number }) => void)
     | undefined = undefined;
+  export let initiativeScore: number | undefined = undefined;
+  export let onSetInitiative: ((id: string, value: number | null) => void) | undefined = undefined;
 
   const LONG_PRESS_MS = 400;
   const LONG_PRESS_TOLERANCE_PX = 6;
@@ -113,6 +115,44 @@
     if (isInnerInteractive(event.target, event.currentTarget)) return;
     event.preventDefault();
     onSelect(combatant.id);
+  }
+
+  let initiativeDraft: number | null = null;
+  let lastSyncedScore: number | undefined = undefined;
+  $: if (initiativeScore !== lastSyncedScore) {
+    initiativeDraft = initiativeScore ?? null;
+    lastSyncedScore = initiativeScore;
+  }
+
+  function commitInitiativeDraft() {
+    if (!onSetInitiative) return;
+    if (initiativeDraft === null) {
+      if (initiativeScore !== undefined) onSetInitiative(combatant.id, null);
+      return;
+    }
+    if (!Number.isFinite(initiativeDraft)) {
+      initiativeDraft = initiativeScore ?? null;
+      return;
+    }
+    if (initiativeDraft === initiativeScore) return;
+    onSetInitiative(combatant.id, initiativeDraft);
+  }
+
+  function handleInitiativeKey(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      (event.target as HTMLInputElement).blur();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      initiativeDraft = initiativeScore ?? null;
+      (event.target as HTMLInputElement).blur();
+    }
+  }
+
+  function rollInitiative() {
+    if (!onSetInitiative) return;
+    const die = Math.floor(Math.random() * 20) + 1;
+    onSetInitiative(combatant.id, die + combatant.baseStats.perception);
   }
 
   let pickerOpen = false;
@@ -255,6 +295,30 @@
       <Chip variant={isCurrent ? 'success' : 'default'}>
         {isCurrent ? 'Turn' : phase}
       </Chip>
+      {#if phase === 'PREPARING' && onSetInitiative}
+        <div class="card-initiative" aria-label="Initiative">
+          <SectionLabel>Init</SectionLabel>
+          <input
+            type="number"
+            class="card-initiative__input"
+            aria-label={`Initiative for ${combatant.name}`}
+            placeholder="—"
+            bind:value={initiativeDraft}
+            onblur={commitInitiativeDraft}
+            onkeydown={handleInitiativeKey}
+          />
+          <Button
+            size="sm"
+            variant="secondary"
+            ariaLabel={`Roll initiative for ${combatant.name}`}
+            onclick={rollInitiative}
+          >Roll</Button>
+          <span
+            class="card-initiative__hint"
+            aria-label={`Perception modifier ${combatant.baseStats.perception >= 0 ? '+' : ''}${combatant.baseStats.perception}`}
+          >({combatant.baseStats.perception >= 0 ? '+' : ''}{combatant.baseStats.perception} Perception)</span>
+        </div>
+      {/if}
       <div class="card-reorder" aria-label="Reorder">
         <IconButton
           ariaLabel={`Move ${combatant.name} up`}
@@ -553,6 +617,40 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+  }
+
+  .card-initiative {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 6px;
+    background: var(--color-panel);
+    border: var(--border-thin);
+    border-radius: var(--radius-card, 4px);
+  }
+
+  .card-initiative__input {
+    width: 56px;
+    padding: 2px 6px;
+    font: inherit;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    text-align: right;
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 3px;
+    background: var(--color-bg);
+    color: inherit;
+  }
+
+  .card-initiative__input:focus-visible {
+    outline: 2px solid var(--color-blue, var(--color-amber));
+    outline-offset: 1px;
+  }
+
+  .card-initiative__hint {
+    font-size: 11px;
+    color: var(--color-ink-mute);
+    white-space: nowrap;
   }
 
   .stat-grid {

--- a/src/components/CombatantCard.test.ts
+++ b/src/components/CombatantCard.test.ts
@@ -106,3 +106,81 @@ describe('CombatantCard select affordance', () => {
     expect(onSelect).toHaveBeenCalledWith('goblin-1');
   });
 });
+
+describe('CombatantCard initiative control', () => {
+  function withInitiative(overrides: Record<string, unknown> = {}) {
+    return baseProps({
+      onSetInitiative: vi.fn(),
+      ...overrides
+    });
+  }
+
+  test('PREPARING: shows initiative input, Roll button, and perception hint', () => {
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.perception = 5;
+    render(CombatantCard, { props: withInitiative({ combatant: c }) });
+
+    expect(screen.getByRole('spinbutton', { name: 'Initiative for Goblin Warrior' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll initiative for Goblin Warrior' })).toBeInTheDocument();
+    expect(screen.getByText('(+5 Perception)')).toBeInTheDocument();
+  });
+
+  test('initiative input pre-fills from initiativeScore prop', () => {
+    render(CombatantCard, { props: withInitiative({ initiativeScore: 17 }) });
+    const input = screen.getByRole('spinbutton', { name: /Initiative for/ }) as HTMLInputElement;
+    expect(input.value).toBe('17');
+  });
+
+  test('blurring the input dispatches onSetInitiative with the parsed number', async () => {
+    const onSetInitiative = vi.fn();
+    render(CombatantCard, { props: withInitiative({ onSetInitiative }) });
+    const input = screen.getByRole('spinbutton', { name: /Initiative for/ }) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '14' } });
+    await fireEvent.blur(input);
+    expect(onSetInitiative).toHaveBeenCalledWith('goblin-1', 14);
+  });
+
+  test('clearing a previously-set value dispatches onSetInitiative with null', async () => {
+    const onSetInitiative = vi.fn();
+    render(CombatantCard, { props: withInitiative({ onSetInitiative, initiativeScore: 12 }) });
+    const input = screen.getByRole('spinbutton', { name: /Initiative for/ }) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '' } });
+    await fireEvent.blur(input);
+    expect(onSetInitiative).toHaveBeenCalledWith('goblin-1', null);
+  });
+
+  test('Roll button rolls 1d20 + perception and dispatches onSetInitiative', async () => {
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.perception = 7;
+    const onSetInitiative = vi.fn();
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // floor(0.5*20)+1 = 11
+    try {
+      render(CombatantCard, { props: withInitiative({ combatant: c, onSetInitiative }) });
+      await fireEvent.click(screen.getByRole('button', { name: 'Roll initiative for Goblin Warrior' }));
+      expect(onSetInitiative).toHaveBeenCalledWith('goblin-1', 18);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('ACTIVE phase: initiative control is hidden, reorder buttons remain', () => {
+    render(CombatantCard, { props: withInitiative({ phase: 'ACTIVE' }) });
+    expect(screen.queryByRole('spinbutton', { name: /Initiative for/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Roll initiative/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Move .* up/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Move .* down/ })).toBeInTheDocument();
+  });
+
+  test('without onSetInitiative the control is hidden even in PREPARING', () => {
+    render(CombatantCard, { props: baseProps() });
+    expect(screen.queryByRole('spinbutton', { name: /Initiative for/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Roll initiative/ })).toBeNull();
+  });
+
+  test('negative perception is rendered with explicit minus sign', () => {
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.perception = -1;
+    render(CombatantCard, { props: withInitiative({ combatant: c }) });
+    expect(screen.getByText('(-1 Perception)')).toBeInTheDocument();
+  });
+});

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -56,7 +56,8 @@ describe('applyCommand lifecycle and initiative slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: -1,
-        delaying: []
+        delaying: [],
+        scores: {}
       }
     });
 
@@ -96,7 +97,7 @@ describe('applyCommand lifecycle and initiative slice', () => {
   test('rejects starting an encounter without at least two combatants and initiative order', () => {
     const state = encounter({
       combatants: { 'goblin-1': combatant('goblin-1') },
-      initiative: { order: ['goblin-1'], currentIndex: -1, delaying: [] }
+      initiative: { order: ['goblin-1'], currentIndex: -1, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('START_ENCOUNTER'), emptyEffects);
@@ -821,7 +822,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fallen-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -848,7 +850,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fallen-1', 'fighter-1'],
         currentIndex: 2,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
@@ -875,7 +878,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1', { isAlive: false }),
@@ -899,7 +903,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 8,
-        delaying: []
+        delaying: [],
+        scores: {}
       }
     });
 
@@ -986,7 +991,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 1,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1', {
@@ -1093,7 +1099,8 @@ describe('applyCommand turn advancement slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1185,7 +1192,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1', 'cleric-1'],
         currentIndex: 1,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1199,7 +1207,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['goblin-1', 'cleric-1'],
       currentIndex: 1,
-      delaying: ['fighter-1']
+      delaying: ['fighter-1'],
+        scores: {}
     });
     expect(result.newState.round).toBe(1);
     expect(result.newState.combatants['cleric-1'].reactionUsedThisRound).toBe(false);
@@ -1216,7 +1225,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1', 'cleric-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1230,7 +1240,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['fighter-1', 'cleric-1'],
       currentIndex: 0,
-      delaying: ['goblin-1']
+      delaying: ['goblin-1'],
+        scores: {}
     });
     expect(result.newState.round).toBe(1);
     expectEvents(result, [
@@ -1247,7 +1258,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1', 'cleric-1'],
         currentIndex: 2,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
@@ -1261,7 +1273,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['goblin-1', 'fighter-1'],
       currentIndex: 0,
-      delaying: ['cleric-1']
+      delaying: ['cleric-1'],
+        scores: {}
     });
     expect(result.newState.round).toBe(5);
     expect(result.newState.combatants['goblin-1'].reactionUsedThisRound).toBe(false);
@@ -1279,7 +1292,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fallen-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1293,7 +1307,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['fallen-1', 'fighter-1'],
       currentIndex: 1,
-      delaying: ['goblin-1']
+      delaying: ['goblin-1'],
+        scores: {}
     });
     expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
     expectEvents(result, [
@@ -1309,7 +1324,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: -1,
-        delaying: []
+        delaying: [],
+        scores: {}
       }
     });
 
@@ -1323,7 +1339,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'cleric-1'],
         currentIndex: 0,
-        delaying: ['fighter-1']
+        delaying: ['fighter-1'],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1341,7 +1358,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['goblin-1', 'fighter-1', 'cleric-1'],
       currentIndex: 1,
-      delaying: []
+      delaying: [],
+        scores: {}
     });
     expect(result.newState.round).toBe(1);
     expect(result.newState.combatants['fighter-1'].reactionUsedThisRound).toBe(false);
@@ -1358,7 +1376,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'cleric-1'],
         currentIndex: 1,
-        delaying: ['fighter-1', 'ranger-1']
+        delaying: ['fighter-1', 'ranger-1'],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1377,7 +1396,8 @@ describe('applyCommand delay and resume slice', () => {
     expect(result.newState.initiative).toEqual({
       order: ['goblin-1', 'cleric-1', 'fighter-1'],
       currentIndex: 2,
-      delaying: ['ranger-1']
+      delaying: ['ranger-1'],
+        scores: {}
     });
     expectEvents(result, [
       { type: 'turn-ended', combatantId: 'cleric-1' },
@@ -1392,7 +1412,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       }
     });
 
@@ -1410,7 +1431,8 @@ describe('applyCommand delay and resume slice', () => {
       initiative: {
         order: ['goblin-1', 'cleric-1'],
         currentIndex: 0,
-        delaying: ['fighter-1']
+        delaying: ['fighter-1'],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1501,7 +1523,8 @@ describe('applyCommand combat state slice', () => {
       initiative: {
         order: ['goblin-1', 'fallen-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -1529,7 +1552,8 @@ describe('applyCommand combat state slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 1,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
@@ -1557,7 +1581,8 @@ describe('applyCommand combat state slice', () => {
       initiative: {
         order: ['goblin-1', 'fighter-1'],
         currentIndex: 0,
-        delaying: []
+        delaying: [],
+        scores: {}
       },
       combatants: {
         'goblin-1': combatant('goblin-1'),
@@ -2161,7 +2186,8 @@ describe('applyCommand effect slice', () => {
         initiative: {
           order: ['goblin-1', 'fighter-1'],
           currentIndex: 1,
-          delaying: []
+          delaying: [],
+        scores: {}
         },
         combatants: {
           'goblin-1': combatant('goblin-1', { reactionUsedThisRound: true }),
@@ -2328,7 +2354,7 @@ describe('REMOVE_COMBATANT', () => {
         'goblin-1': combatant('goblin-1'),
         'fighter-1': combatant('fighter-1')
       },
-      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: -1, delaying: [] }
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: -1, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
@@ -2347,7 +2373,7 @@ describe('REMOVE_COMBATANT', () => {
         'fighter-1': combatant('fighter-1', { name: 'Fighter' }),
         'wizard-1': combatant('wizard-1', { name: 'Wizard' })
       },
-      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 2, delaying: [] }
+      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 2, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
@@ -2363,7 +2389,7 @@ describe('REMOVE_COMBATANT', () => {
         'fighter-1': combatant('fighter-1'),
         'wizard-1': combatant('wizard-1')
       },
-      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 0, delaying: [] }
+      initiative: { order: ['goblin-1', 'fighter-1', 'wizard-1'], currentIndex: 0, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'wizard-1' }), emptyEffects);
@@ -2378,7 +2404,7 @@ describe('REMOVE_COMBATANT', () => {
         'goblin-1': combatant('goblin-1'),
         'fighter-1': combatant('fighter-1')
       },
-      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 1, delaying: [] }
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 1, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'fighter-1' }), emptyEffects);
@@ -2394,7 +2420,7 @@ describe('REMOVE_COMBATANT', () => {
         'fighter-1': combatant('fighter-1'),
         'wizard-1': combatant('wizard-1')
       },
-      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 0, delaying: ['wizard-1'] }
+      initiative: { order: ['goblin-1', 'fighter-1'], currentIndex: 0, delaying: ['wizard-1'], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'wizard-1' }), emptyEffects);
@@ -2409,7 +2435,7 @@ describe('REMOVE_COMBATANT', () => {
       combatants: {
         'goblin-1': combatant('goblin-1', { name: 'Goblin Warrior' })
       },
-      initiative: { order: ['goblin-1'], currentIndex: -1, delaying: [] }
+      initiative: { order: ['goblin-1'], currentIndex: -1, delaying: [], scores: {} }
     });
 
     const result = applyCommand(state, command('REMOVE_COMBATANT', { combatantId: 'goblin-1' }), emptyEffects);
@@ -2537,5 +2563,177 @@ describe('recent effects tracking', () => {
     expect(effectIds).toContain('confused');
     expect(effectIds).toContain('off-guard');
     expect(result.newState.recentEffectIds).toEqual(['confused']);
+  });
+});
+
+describe('SET_INITIATIVE_SCORES', () => {
+  function threeCombatantPrep() {
+    return encounter({
+      combatants: {
+        'goblin-1': combatant('goblin-1', { name: 'Goblin' }),
+        'fighter-1': combatant('fighter-1', { name: 'Fighter' }),
+        'wizard-1': combatant('wizard-1', { name: 'Wizard' })
+      },
+      initiative: {
+        order: ['goblin-1', 'fighter-1', 'wizard-1'],
+        currentIndex: -1,
+        delaying: [],
+        scores: {}
+      }
+    });
+  }
+
+  test('setting a single score re-sorts the order so highest is first', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', { scores: { 'wizard-1': 22 } }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative.scores).toEqual({ 'wizard-1': 22 });
+    expect(result.newState.initiative.order).toEqual(['wizard-1', 'goblin-1', 'fighter-1']);
+  });
+
+  test('multi-entry payload sorts every scored combatant correctly', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', {
+        scores: { 'goblin-1': 10, 'fighter-1': 18, 'wizard-1': 14 }
+      }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative.order).toEqual(['fighter-1', 'wizard-1', 'goblin-1']);
+  });
+
+  test('unscored combatants land after all scored ones in their existing relative order', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', { scores: { 'wizard-1': 5 } }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative.order).toEqual(['wizard-1', 'goblin-1', 'fighter-1']);
+  });
+
+  test('ties preserve existing relative order (stable sort)', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', {
+        scores: { 'goblin-1': 12, 'fighter-1': 12, 'wizard-1': 12 }
+      }),
+      emptyEffects
+    );
+
+    expect(result.newState.initiative.order).toEqual(['goblin-1', 'fighter-1', 'wizard-1']);
+  });
+
+  test('null clears a score and the combatant moves to the unscored tail', () => {
+    const seeded = applyCommand(
+      threeCombatantPrep(),
+      command('SET_INITIATIVE_SCORES', {
+        scores: { 'goblin-1': 10, 'fighter-1': 18, 'wizard-1': 14 }
+      }),
+      emptyEffects
+    ).newState;
+
+    const cleared = applyCommand(
+      seeded,
+      command('SET_INITIATIVE_SCORES', { scores: { 'fighter-1': null } }),
+      emptyEffects
+    );
+
+    expect(cleared.newState.initiative.scores).toEqual({ 'goblin-1': 10, 'wizard-1': 14 });
+    expect(cleared.newState.initiative.order).toEqual(['wizard-1', 'goblin-1', 'fighter-1']);
+  });
+
+  test('emits initiative-scores-changed event with the patch and the new order', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', { scores: { 'wizard-1': 22 } }),
+      emptyEffects
+    );
+
+    expectEvents(result, [
+      {
+        type: 'initiative-scores-changed',
+        scores: { 'wizard-1': 22 },
+        order: ['wizard-1', 'goblin-1', 'fighter-1']
+      }
+    ]);
+  });
+
+  test('rejects unknown combatant ids', () => {
+    const state = threeCombatantPrep();
+    expectRejected(
+      applyCommand(
+        state,
+        command('SET_INITIATIVE_SCORES', { scores: { 'ghost-1': 10 } }),
+        emptyEffects
+      ),
+      'SET_INITIATIVE_SCORES',
+      'Combatant ghost-1 not found'
+    );
+  });
+
+  test('rejects non-finite scores', () => {
+    const state = threeCombatantPrep();
+    expectRejected(
+      applyCommand(
+        state,
+        command('SET_INITIATIVE_SCORES', { scores: { 'goblin-1': Number.NaN } }),
+        emptyEffects
+      ),
+      'SET_INITIATIVE_SCORES',
+      'Initiative score must be a finite number or null'
+    );
+  });
+
+  test('rejects in ACTIVE phase (PREPARING-only command)', () => {
+    expectRejected(
+      applyCommand(
+        activeEncounter(),
+        command('SET_INITIATIVE_SCORES', { scores: { 'goblin-1': 10 } }),
+        emptyEffects
+      ),
+      'SET_INITIATIVE_SCORES',
+      'SET_INITIATIVE_SCORES is not legal during ACTIVE'
+    );
+  });
+
+  test('preserves existing scores when patch only mentions some combatants', () => {
+    const seeded = applyCommand(
+      threeCombatantPrep(),
+      command('SET_INITIATIVE_SCORES', { scores: { 'goblin-1': 10, 'fighter-1': 18 } }),
+      emptyEffects
+    ).newState;
+
+    const update = applyCommand(
+      seeded,
+      command('SET_INITIATIVE_SCORES', { scores: { 'wizard-1': 14 } }),
+      emptyEffects
+    );
+
+    expect(update.newState.initiative.scores).toEqual({
+      'goblin-1': 10,
+      'fighter-1': 18,
+      'wizard-1': 14
+    });
+    expect(update.newState.initiative.order).toEqual(['fighter-1', 'wizard-1', 'goblin-1']);
+  });
+
+  test('keeps the new state JSON-serializable', () => {
+    const state = threeCombatantPrep();
+    const result = applyCommand(
+      state,
+      command('SET_INITIATIVE_SCORES', { scores: { 'goblin-1': 10 } }),
+      emptyEffects
+    );
+    expectSerializable(result.newState);
   });
 });

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -25,6 +25,7 @@ const allowedPhases: Record<CommandType, EncounterPhase[]> = {
   REMOVE_COMBATANT: ['PREPARING', 'ACTIVE'],
   RENAME_COMBATANT: ['PREPARING', 'ACTIVE', 'RESOLVING'],
   SET_INITIATIVE_ORDER: ['PREPARING', 'ACTIVE'],
+  SET_INITIATIVE_SCORES: ['PREPARING'],
   REORDER_COMBATANT: ['PREPARING', 'ACTIVE'],
   END_TURN: ['ACTIVE'],
   DELAY: ['ACTIVE'],
@@ -69,6 +70,8 @@ export function applyCommand(state: EncounterState, command: Command, effectLibr
       return removeCombatant(state, command.payload.combatantId);
     case 'SET_INITIATIVE_ORDER':
       return setInitiativeOrder(state, command.payload.order);
+    case 'SET_INITIATIVE_SCORES':
+      return setInitiativeScores(state, command.payload.scores);
     case 'START_ENCOUNTER':
       return startEncounter(state, effectLibrary);
     case 'END_TURN':
@@ -232,6 +235,57 @@ function setInitiativeOrder(state: EncounterState, order: CombatantId[]): Comman
       }
     },
     events: [{ type: 'initiative-set', order: [...order] }]
+  };
+}
+
+function setInitiativeScores(
+  state: EncounterState,
+  patch: Record<CombatantId, number | null>
+): CommandResult {
+  for (const combatantId of Object.keys(patch)) {
+    if (!state.combatants[combatantId]) {
+      return reject(state, 'SET_INITIATIVE_SCORES', `Combatant ${combatantId} not found`);
+    }
+  }
+
+  for (const value of Object.values(patch)) {
+    if (value !== null && !Number.isFinite(value)) {
+      return reject(state, 'SET_INITIATIVE_SCORES', 'Initiative score must be a finite number or null');
+    }
+  }
+
+  const nextScores: Record<CombatantId, number> = { ...state.initiative.scores };
+  for (const [combatantId, value] of Object.entries(patch)) {
+    if (value === null) delete nextScores[combatantId];
+    else nextScores[combatantId] = value;
+  }
+
+  const indexed = state.initiative.order.map((id, index) => ({ id, index }));
+  indexed.sort((a, b) => {
+    const sa = nextScores[a.id];
+    const sb = nextScores[b.id];
+    const aHas = sa !== undefined;
+    const bHas = sb !== undefined;
+    if (aHas && bHas) {
+      if (sa !== sb) return sb - sa;
+      return a.index - b.index;
+    }
+    if (aHas) return -1;
+    if (bHas) return 1;
+    return a.index - b.index;
+  });
+  const nextOrder = indexed.map((entry) => entry.id);
+
+  return {
+    newState: {
+      ...state,
+      initiative: {
+        ...state.initiative,
+        order: nextOrder,
+        scores: nextScores
+      }
+    },
+    events: [{ type: 'initiative-scores-changed', scores: { ...patch }, order: [...nextOrder] }]
   };
 }
 
@@ -761,7 +815,7 @@ function resetEncounter(state: EncounterState): CommandResult {
       ...state,
       phase: 'PREPARING',
       round: 0,
-      initiative: { order: [], currentIndex: -1, delaying: [] },
+      initiative: { order: [], currentIndex: -1, delaying: [], scores: {} },
       combatants: resetCombatants,
       pendingPrompts: [],
       combatLog: [],

--- a/src/domain/test-support.ts
+++ b/src/domain/test-support.ts
@@ -89,7 +89,8 @@ export function encounter(overrides: Partial<EncounterState> = {}): EncounterSta
     initiative: {
       order: [],
       currentIndex: -1,
-      delaying: []
+      delaying: [],
+      scores: {}
     },
     combatants: {},
     pendingPrompts: [],
@@ -107,7 +108,8 @@ export function preparingEncounter(overrides: Partial<EncounterState> = {}): Enc
     initiative: {
       order: Object.keys(combatants),
       currentIndex: -1,
-      delaying: []
+      delaying: [],
+      scores: {}
     },
     ...overrides
   });
@@ -120,7 +122,8 @@ export function activeEncounter(overrides: Partial<EncounterState> = {}): Encoun
     initiative: {
       order: ['goblin-1', 'fighter-1'],
       currentIndex: 0,
-      delaying: []
+      delaying: [],
+      scores: {}
     },
     ...overrides
   });
@@ -150,7 +153,8 @@ export function completedEncounter(overrides: Partial<EncounterState> = {}): Enc
     initiative: {
       order: ['goblin-1', 'fighter-1'],
       currentIndex: 1,
-      delaying: []
+      delaying: [],
+      scores: {}
     },
     ...overrides
   });

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -6,6 +6,7 @@ export interface InitiativeState {
   order: CombatantId[];
   currentIndex: number;
   delaying: CombatantId[];
+  scores: Record<CombatantId, number>;
 }
 
 export interface CreatureBaseStats {
@@ -294,6 +295,7 @@ export type Command =
   | BaseCommand<'REMOVE_COMBATANT', { combatantId: CombatantId }>
   | BaseCommand<'RENAME_COMBATANT', { combatantId: CombatantId; newName: string }>
   | BaseCommand<'SET_INITIATIVE_ORDER', { order: CombatantId[] }>
+  | BaseCommand<'SET_INITIATIVE_SCORES', { scores: Record<CombatantId, number | null> }>
   | BaseCommand<'REORDER_COMBATANT', { combatantId: CombatantId; newIndex: number }>
   | BaseCommand<'END_TURN', Record<string, never>>
   | BaseCommand<'DELAY', Record<string, never>>
@@ -332,6 +334,7 @@ export type CommandType =
   | 'REMOVE_COMBATANT'
   | 'RENAME_COMBATANT'
   | 'SET_INITIATIVE_ORDER'
+  | 'SET_INITIATIVE_SCORES'
   | 'REORDER_COMBATANT'
   | 'END_TURN'
   | 'DELAY'
@@ -374,6 +377,7 @@ export type DomainEvent =
   | { type: 'combatant-renamed'; combatantId: CombatantId; oldName: string; newName: string }
   | { type: 'initiative-set'; order: CombatantId[] }
   | { type: 'initiative-changed'; combatantId: CombatantId; newIndex: number }
+  | { type: 'initiative-scores-changed'; scores: Record<CombatantId, number | null>; order: CombatantId[] }
   | { type: 'combatant-delayed'; combatantId: CombatantId }
   | { type: 'combatant-resumed-from-delay'; combatantId: CombatantId; insertIndex: number }
   | { type: 'turn-started'; combatantId: CombatantId; round: number }

--- a/src/lib/combat-log/format.ts
+++ b/src/lib/combat-log/format.ts
@@ -52,6 +52,13 @@ export function formatEvent(event: DomainEvent, options: FormatOptions): LogEntr
         `${nameOf(state, event.combatantId)} moved to position ${event.newIndex + 1} in the order.`,
         'info'
       );
+    case 'initiative-scores-changed': {
+      const parts = Object.entries(event.scores).map(([cid, score]) =>
+        score === null ? `${nameOf(state, cid)} cleared` : `${nameOf(state, cid)}: ${score}`
+      );
+      if (parts.length === 0) return null;
+      return entry(id, `Initiative — ${parts.join(', ')}.`, 'info');
+    }
     case 'combatant-delayed':
       return entry(id, `${nameOf(state, event.combatantId)} is delaying.`, 'info');
     case 'combatant-resumed-from-delay':

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -65,7 +65,8 @@ export function newEncounterState(): EncounterState {
     initiative: {
       order: [],
       currentIndex: -1,
-      delaying: []
+      delaying: [],
+      scores: {}
     },
     combatants: {},
     pendingPrompts: [],

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -511,6 +511,25 @@
     runCommand(toCommand('START_ENCOUNTER', undefined, nextCommandId()));
   }
 
+  function setInitiativeScore(combatantId: string, value: number | null) {
+    runCommand(
+      toCommand('SET_INITIATIVE_SCORES', { scores: { [combatantId]: value } }, nextCommandId())
+    );
+  }
+
+  function rollAllInitiative() {
+    const patch: Record<string, number> = {};
+    for (const id of encounter.initiative.order) {
+      if (encounter.initiative.scores[id] !== undefined) continue;
+      const c = encounter.combatants[id];
+      if (!c) continue;
+      const die = Math.floor(Math.random() * 20) + 1;
+      patch[id] = die + c.baseStats.perception;
+    }
+    if (Object.keys(patch).length === 0) return;
+    runCommand(toCommand('SET_INITIATIVE_SCORES', { scores: patch }, nextCommandId()));
+  }
+
   function applyHpEdit(combatantId: string, field: HpEditField, parsed: CommittableEdit) {
     const combatant = encounter.combatants[combatantId];
     if (!combatant) return;
@@ -706,6 +725,14 @@
           </ul>
         </div>
       {/if}
+      {#if encounter.phase === 'PREPARING' && orderedCombatants.length > 0}
+        <div class="initiative-bar" aria-label="Initiative actions">
+          <button type="button" class="initiative-bar__roll" onclick={rollAllInitiative}>
+            Roll all initiative
+          </button>
+          <span class="initiative-bar__hint">Rolls only blanks. Click a combatant's Roll button to re-roll one.</span>
+        </div>
+      {/if}
       <div class="cards">
         {#each orderedCombatants as combatant, index (combatant.id)}
           <CombatantCard
@@ -728,6 +755,8 @@
             onMove={moveCombatant}
             onSelect={selectCombatant}
             onRequestRadial={openRadial}
+            initiativeScore={encounter.initiative.scores[combatant.id]}
+            onSetInitiative={setInitiativeScore}
             isFirst={index === 0}
             isLast={index === orderedCombatants.length - 1}
           />
@@ -818,6 +847,39 @@
   .cards {
     display: grid;
     gap: 10px;
+  }
+
+  .initiative-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: var(--color-panel, #fbfcfa);
+    border: 1px solid var(--color-rule, #cfd6d1);
+    border-radius: 8px;
+  }
+
+  .initiative-bar__roll {
+    background: var(--color-ink, #263235);
+    color: var(--color-bg, #fff);
+    border: 0;
+    border-radius: 4px;
+    padding: 6px 14px;
+    font: inherit;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+  }
+
+  .initiative-bar__roll:focus-visible {
+    outline: 2px solid var(--color-blue, var(--color-amber, #b88a2c));
+    outline-offset: 2px;
+  }
+
+  .initiative-bar__hint {
+    color: var(--color-ink-mute, #627171);
+    font-size: 12px;
   }
 
   .not-yet-rolled {


### PR DESCRIPTION
## Summary

- **Per-combatant initiative input** on each `CombatantCard` during PREPARING: a numeric field, a `Roll` button (1d20 + Perception), and an `(+N Perception)` hint. The existing up/down reorder buttons stay for tie-breaking.
- **\"Roll all initiative\"** bar above the roster in PREPARING. Rolls only the blanks — combatants who have a manual or already-rolled value are left alone.
- **Auto-sort**: setting an initiative score (manual or via Roll) re-sorts the order automatically, descending. Ties preserve existing relative order so the GM can break them with the up/down buttons. Combatants without a score sort to the tail.
- **New domain command** \`SET_INITIATIVE_SCORES\` (PREPARING-only) with sparse \`{ scores: Record<id, number | null> }\` payload — \`null\` clears a score. \`InitiativeState\` gains a \`scores\` map; existing \`SET_INITIATIVE_ORDER\` / \`REORDER_COMBATANT\` flow is unchanged.
- **New combat-log entry** for the \`initiative-scores-changed\` event.

## Test plan
- [x] \`npm run check\` (svelte-check + tsc on domain) passes
- [x] \`npm run test:run\` — 524/524 tests (11 new reducer + 8 new component cases)
- [x] \`npm run audit\` — no new vulnerabilities
- [x] \`npm run build\` — static build succeeds
- [ ] Manual: PREPARING with three combatants → type \`15\` into one card → blur → card jumps to top
- [ ] Manual: click \`Roll\` on another card → rolled value appears, card resorts
- [ ] Manual: two cards with the same score → up/down reorders within the tie
- [ ] Manual: click \`Roll all initiative\` with one card already set → only the unset cards get rolled
- [ ] Manual: click \`Start Encounter\` → ACTIVE phase shows up/down buttons but no initiative input

🤖 Generated with [Claude Code](https://claude.com/claude-code)