### PR TITLE
Redesign encounter setup left panel

### DIFF
--- a/src/components/BestiarySection.svelte
+++ b/src/components/BestiarySection.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
   import type { Creature } from '../domain';
+  import type { TemplateAdjustmentChoice } from '$lib/encounter-app';
+  import Button from './ui/Button.svelte';
   import IconButton from './ui/IconButton.svelte';
   import Input from './ui/Input.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
 
   export let creatures: Creature[];
-  export let onAddCreature: (creature: Creature) => void;
-  export let onRemoveCreature: ((id: string) => void) | undefined = undefined;
+  export let encounterCounts: Record<string, number> = {};
+  export let onAddToEncounter: (creature: Creature, adjustment: TemplateAdjustmentChoice) => void;
+  export let onRemoveOneFromEncounter: (creatureId: string) => void;
+  export let onImportYamlFiles: ((files: File[]) => void) | undefined = undefined;
+  export let onOpenManageLibrary: (() => void) | undefined = undefined;
 
   let query = '';
+  let adjustment: TemplateAdjustmentChoice = 'normal';
+  let fileInput: HTMLInputElement | undefined;
 
   $: needle = query.trim().toLowerCase();
   $: filtered = needle
@@ -17,6 +24,15 @@
         return creature.traits.some((t) => t.toLowerCase().includes(needle));
       })
     : creatures;
+
+  function handleFileChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    if (files.length > 0) {
+      onImportYamlFiles?.(files);
+    }
+    input.value = '';
+  }
 </script>
 
 <section class="bestiary" aria-labelledby="bestiary-label">
@@ -24,6 +40,23 @@
     <SectionLabel as="h3" id="bestiary-label">Bestiary</SectionLabel>
     <span class="count">{creatures.length}</span>
   </header>
+
+  <div class="bestiary__actions">
+    {#if onImportYamlFiles}
+      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept=".yaml,.yml,application/yaml,text/yaml"
+        multiple
+        hidden
+        onchange={handleFileChange}
+      />
+    {/if}
+    {#if onOpenManageLibrary}
+      <Button variant="secondary" size="sm" onclick={onOpenManageLibrary}>Manage…</Button>
+    {/if}
+  </div>
 
   <div class="bestiary__search">
     <Input
@@ -36,6 +69,33 @@
     </Input>
   </div>
 
+  <fieldset class="adjustment" aria-label="Adjustment for added creatures">
+    <legend class="adjustment__legend">Adjustment</legend>
+    <div class="adjustment__group">
+      <button
+        type="button"
+        class="adjustment__option"
+        class:adjustment__option--active={adjustment === 'weak'}
+        aria-pressed={adjustment === 'weak'}
+        onclick={() => (adjustment = 'weak')}
+      >Weak</button>
+      <button
+        type="button"
+        class="adjustment__option"
+        class:adjustment__option--active={adjustment === 'normal'}
+        aria-pressed={adjustment === 'normal'}
+        onclick={() => (adjustment = 'normal')}
+      >Normal</button>
+      <button
+        type="button"
+        class="adjustment__option"
+        class:adjustment__option--active={adjustment === 'elite'}
+        aria-pressed={adjustment === 'elite'}
+        onclick={() => (adjustment = 'elite')}
+      >Elite</button>
+    </div>
+  </fieldset>
+
   {#if creatures.length === 0}
     <p class="empty">Import a YAML file to add creatures.</p>
   {:else if filtered.length === 0}
@@ -43,38 +103,35 @@
   {:else}
     <ul class="rows">
       {#each filtered as creature (creature.id)}
+        {@const count = encounterCounts[creature.id] ?? 0}
         <li class="row">
-          <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
-          <span class="row__body">
-            <span class="row__name">{creature.name}</span>
-            <span class="row__traits">{creature.traits.join(' · ')}</span>
-          </span>
-          {#if onRemoveCreature}
-            <span class="row__remove">
-              <IconButton
-                ariaLabel="Remove {creature.name}"
-                title="Remove from library"
-                variant="destructive"
-                size={22}
-                onclick={() => onRemoveCreature?.(creature.id)}
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-                  <path d="M2 6h8" />
-                </svg>
-              </IconButton>
-            </span>
-          {/if}
-          <IconButton
-            ariaLabel="Add {creature.name}"
+          <button
+            type="button"
+            class="row__add"
+            aria-label="Add {creature.name} to encounter"
             title="Add to encounter"
-            variant="primary"
-            size={26}
-            onclick={() => onAddCreature(creature)}
+            onclick={() => onAddToEncounter(creature, adjustment)}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-              <path d="M7 2v10M2 7h10" />
-            </svg>
-          </IconButton>
+            <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
+            <span class="row__body">
+              <span class="row__name">{creature.name}</span>
+              <span class="row__traits">{creature.traits.join(' · ')}</span>
+            </span>
+          </button>
+          {#if count > 0}
+            <span class="row__count" aria-label="{count} in encounter">×{count}</span>
+            <IconButton
+              ariaLabel="Remove one {creature.name} from encounter"
+              title="Remove one from encounter"
+              variant="default"
+              size={22}
+              onclick={() => onRemoveOneFromEncounter(creature.id)}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          {/if}
         </li>
       {/each}
     </ul>
@@ -95,10 +152,72 @@
     gap: var(--space-2);
   }
 
+  .bestiary__actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
   .count {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--color-ink-mute);
+  }
+
+  .adjustment {
+    border: var(--border-thin);
+    border-radius: var(--radius-card);
+    padding: 4px 8px 6px;
+    margin: 0;
+    display: grid;
+    gap: 4px;
+  }
+
+  .adjustment__legend {
+    padding: 0 var(--space-2);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-ink-mute);
+  }
+
+  .adjustment__group {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+  }
+
+  .adjustment__option {
+    background: transparent;
+    color: var(--color-ink-mute);
+    border: var(--border-thin);
+    border-radius: var(--radius-card);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    padding: 4px 6px;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+
+  .adjustment__option:hover {
+    color: var(--color-ink);
+    border-color: var(--color-ink);
+  }
+
+  .adjustment__option--active {
+    background: var(--color-ink);
+    color: var(--color-panel);
+    border-color: var(--color-ink);
+  }
+
+  .adjustment__option:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
   }
 
   .empty {
@@ -121,10 +240,10 @@
 
   .row {
     display: grid;
-    grid-template-columns: 32px 1fr auto auto;
-    gap: var(--space-3);
+    grid-template-columns: 1fr auto auto;
+    gap: var(--space-2);
     align-items: center;
-    padding: var(--space-2) 0;
+    padding: 0;
     border-bottom: 1px dashed var(--color-rule);
   }
 
@@ -132,16 +251,25 @@
     border-bottom: none;
   }
 
-  /* Destructive remove is de-emphasized but kept in tab order; hover/focus-within
-     reveals it so quick-add stays the dominant affordance. */
-  .row__remove {
-    opacity: 0;
-    transition: opacity 0.12s;
+  .row__add {
+    all: unset;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 32px 1fr;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) var(--space-2);
+    min-width: 0;
+    transition: background 0.08s;
   }
 
-  .row:hover .row__remove,
-  .row:focus-within .row__remove {
-    opacity: 1;
+  .row__add:hover {
+    background: var(--color-panel-2);
+  }
+
+  .row__add:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -2px;
   }
 
   .row__level {
@@ -179,5 +307,13 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .row__count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    color: var(--color-ink);
+    padding: 0 6px;
   }
 </style>

--- a/src/components/BestiarySection.test.ts
+++ b/src/components/BestiarySection.test.ts
@@ -31,20 +31,30 @@ function creature(id: string, name: string, traits: string[] = [], level = 1): C
   };
 }
 
+function defaultProps(overrides: Record<string, unknown> = {}) {
+  return {
+    creatures: [],
+    encounterCounts: {},
+    onAddToEncounter: vi.fn(),
+    onRemoveOneFromEncounter: vi.fn(),
+    ...overrides
+  };
+}
+
 describe('BestiarySection', () => {
   test('renders one row per creature with name and level', () => {
     const creatures = [
       creature('a', 'Goblin Warrior', ['goblin', 'humanoid'], 1),
       creature('b', 'Cave Wolf', ['animal'], 2)
     ];
-    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    render(BestiarySection, { props: defaultProps({ creatures }) });
     expect(screen.getByText('Goblin Warrior')).toBeInTheDocument();
     expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
   });
 
   test('renders the empty-state message when the search filters everything out', async () => {
     const creatures = [creature('a', 'Goblin Warrior', ['goblin'], 1)];
-    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    render(BestiarySection, { props: defaultProps({ creatures }) });
     const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
     await fireEvent.input(search, { target: { value: 'dragon' } });
     expect(screen.getByText('No matching creatures.')).toBeInTheDocument();
@@ -55,7 +65,7 @@ describe('BestiarySection', () => {
       creature('a', 'Goblin Warrior', ['goblin'], 1),
       creature('b', 'Cave Wolf', ['animal'], 2)
     ];
-    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    render(BestiarySection, { props: defaultProps({ creatures }) });
     const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
     await fireEvent.input(search, { target: { value: 'WOLF' } });
     expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
@@ -67,44 +77,94 @@ describe('BestiarySection', () => {
       creature('a', 'Goblin Warrior', ['goblin', 'humanoid'], 1),
       creature('b', 'Cave Wolf', ['animal'], 2)
     ];
-    render(BestiarySection, { props: { creatures, onAddCreature: vi.fn() } });
+    render(BestiarySection, { props: defaultProps({ creatures }) });
     const search = screen.getByRole('searchbox', { name: 'Search bestiary' });
     await fireEvent.input(search, { target: { value: 'animal' } });
     expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
     expect(screen.queryByText('Goblin Warrior')).not.toBeInTheDocument();
   });
 
-  test('the per-row + button calls onAddCreature with that creature', async () => {
-    const onAddCreature = vi.fn();
+  test('clicking a row calls onAddToEncounter with the creature and current adjustment', async () => {
+    const onAddToEncounter = vi.fn();
     const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
-    render(BestiarySection, { props: { creatures: [c], onAddCreature } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Add Goblin Warrior' }));
-    expect(onAddCreature).toHaveBeenCalledWith(c);
+    render(BestiarySection, { props: defaultProps({ creatures: [c], onAddToEncounter }) });
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Add Goblin Warrior to encounter' })
+    );
+    expect(onAddToEncounter).toHaveBeenCalledWith(c, 'normal');
   });
 
-  test('renders the empty-library message (not the no-match copy) when the library is empty', () => {
-    render(BestiarySection, { props: { creatures: [], onAddCreature: vi.fn() } });
+  test('row click uses the selected adjustment when Elite is active', async () => {
+    const onAddToEncounter = vi.fn();
+    const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
+    render(BestiarySection, { props: defaultProps({ creatures: [c], onAddToEncounter }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Elite' }));
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Add Goblin Warrior to encounter' })
+    );
+    expect(onAddToEncounter).toHaveBeenCalledWith(c, 'elite');
+  });
+
+  test('renders the empty-library message when the library is empty', () => {
+    render(BestiarySection, { props: defaultProps() });
     expect(
       screen.getByText('Import a YAML file to add creatures.')
     ).toBeInTheDocument();
     expect(screen.queryByText('No matching creatures.')).not.toBeInTheDocument();
   });
 
-  test('renders no remove button when onRemoveCreature is not provided', () => {
+  test('does not render any per-row remove-from-library button', () => {
     const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
-    render(BestiarySection, { props: { creatures: [c], onAddCreature: vi.fn() } });
+    render(BestiarySection, { props: defaultProps({ creatures: [c] }) });
     expect(
-      screen.queryByRole('button', { name: 'Remove Goblin Warrior' })
+      screen.queryByRole('button', { name: /Remove Goblin Warrior$/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove from library' })
     ).not.toBeInTheDocument();
   });
 
-  test('the per-row remove button calls onRemoveCreature with that creature id', async () => {
-    const onRemoveCreature = vi.fn();
+  test('shows a count badge and minus button when the creature is in the encounter', async () => {
+    const onRemoveOneFromEncounter = vi.fn();
     const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
     render(BestiarySection, {
-      props: { creatures: [c], onAddCreature: vi.fn(), onRemoveCreature }
+      props: defaultProps({
+        creatures: [c],
+        encounterCounts: { a: 3 },
+        onRemoveOneFromEncounter
+      })
     });
-    await fireEvent.click(screen.getByRole('button', { name: 'Remove Goblin Warrior' }));
-    expect(onRemoveCreature).toHaveBeenCalledWith('a');
+    expect(screen.getByText('×3')).toBeInTheDocument();
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove one Goblin Warrior from encounter' })
+    );
+    expect(onRemoveOneFromEncounter).toHaveBeenCalledWith('a');
+  });
+
+  test('does not show count badge or minus when count is zero', () => {
+    const c = creature('a', 'Goblin Warrior', ['goblin'], 1);
+    render(BestiarySection, {
+      props: defaultProps({ creatures: [c], encounterCounts: { a: 0 } })
+    });
+    expect(screen.queryByText(/×/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove one Goblin Warrior from encounter' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders Manage… button when onOpenManageLibrary is provided', async () => {
+    const onOpenManageLibrary = vi.fn();
+    render(BestiarySection, {
+      props: defaultProps({ onOpenManageLibrary })
+    });
+    const manage = screen.getByRole('button', { name: 'Manage…' });
+    await fireEvent.click(manage);
+    expect(onOpenManageLibrary).toHaveBeenCalled();
+  });
+
+  test('does not render Manage… or Import buttons when their handlers are absent', () => {
+    render(BestiarySection, { props: defaultProps() });
+    expect(screen.queryByRole('button', { name: 'Manage…' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Import YAML…' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/LibraryManageModal.svelte
+++ b/src/components/LibraryManageModal.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import type { Creature } from '../domain';
+  import Button from './ui/Button.svelte';
+  import IconButton from './ui/IconButton.svelte';
+
+  export let creatures: Creature[];
+  export let onRemove: (creatureId: string) => void;
+  export let onClose: () => void;
+
+  let pendingRemoveId: string | null = null;
+
+  function startRemove(id: string) {
+    pendingRemoveId = id;
+  }
+
+  function cancelRemove() {
+    pendingRemoveId = null;
+  }
+
+  function confirmRemove(id: string) {
+    pendingRemoveId = null;
+    onRemove(id);
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) onClose();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if (pendingRemoveId !== null) {
+        cancelRemove();
+        return;
+      }
+      onClose();
+    }
+  }
+
+  function formatTraits(creature: Creature): string {
+    return creature.traits.join(' · ');
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="backdrop" role="presentation" onclick={handleBackdropClick}>
+  <div class="modal" role="dialog" aria-labelledby="library-manage-title" aria-modal="true">
+    <header class="modal__header">
+      <h2 id="library-manage-title">Manage Library</h2>
+      <IconButton ariaLabel="Close" variant="default" onclick={onClose}>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+          <path d="M2 2l8 8M10 2l-8 8" />
+        </svg>
+      </IconButton>
+    </header>
+
+    <div class="modal__body">
+      {#if creatures.length === 0}
+        <p class="empty">Your library is empty. Import a YAML file to add creatures.</p>
+      {:else}
+        <ul class="rows">
+          {#each creatures as creature (creature.id)}
+            <li class="row">
+              <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
+              <span class="row__body">
+                <span class="row__name">{creature.name}</span>
+                {#if creature.traits.length > 0}
+                  <span class="row__traits">{formatTraits(creature)}</span>
+                {/if}
+              </span>
+              {#if pendingRemoveId === creature.id}
+                <span class="row__confirm">
+                  <span class="row__confirm-text">Delete?</span>
+                  <Button variant="ghost" size="sm" onclick={cancelRemove}>Cancel</Button>
+                  <Button variant="destructive" size="sm" onclick={() => confirmRemove(creature.id)}>
+                    Delete
+                  </Button>
+                </span>
+              {:else}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onclick={() => startRemove(creature.id)}
+                  ariaLabel="Remove {creature.name} from library"
+                >
+                  Remove
+                </Button>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    <footer class="modal__footer">
+      <Button variant="primary" onclick={onClose}>Done</Button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgb(0 0 0 / 35%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: var(--space-4);
+  }
+
+  .modal {
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card);
+    width: min(560px, 100%);
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgb(29 37 40 / 25%);
+  }
+
+  .modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    border-bottom: var(--border-thin);
+  }
+
+  .modal__header h2 {
+    margin: 0;
+    font-family: var(--font-serif);
+    font-size: var(--text-lg);
+    font-weight: 600;
+  }
+
+  .modal__body {
+    padding: var(--space-3) var(--space-4);
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-3) var(--space-4);
+    border-top: var(--border-thin);
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px dashed var(--color-rule);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .row__level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  .row__body {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .row__name {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__traits {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .row__confirm-text {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-red);
+  }
+</style>

--- a/src/components/LibraryManageModal.test.ts
+++ b/src/components/LibraryManageModal.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Creature } from '../domain';
+import LibraryManageModal from './LibraryManageModal.svelte';
+
+function creature(id: string, name: string, traits: string[] = [], level = 1): Creature {
+  return {
+    id,
+    name,
+    level,
+    traits,
+    size: 'medium',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 5,
+    reflex: 5,
+    will: 5,
+    perception: 5,
+    hp: 20,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    skills: {},
+    source: 'test',
+    tags: []
+  };
+}
+
+describe('LibraryManageModal', () => {
+  test('lists every creature passed in', () => {
+    render(LibraryManageModal, {
+      props: {
+        creatures: [
+          creature('a', 'Goblin Warrior', ['goblin'], 1),
+          creature('b', 'Cave Wolf', ['animal'], 2)
+        ],
+        onRemove: vi.fn(),
+        onClose: vi.fn()
+      }
+    });
+    expect(screen.getByText('Goblin Warrior')).toBeInTheDocument();
+    expect(screen.getByText('Cave Wolf')).toBeInTheDocument();
+  });
+
+  test('shows the empty-library message when no creatures are passed', () => {
+    render(LibraryManageModal, {
+      props: { creatures: [], onRemove: vi.fn(), onClose: vi.fn() }
+    });
+    expect(
+      screen.getByText('Your library is empty. Import a YAML file to add creatures.')
+    ).toBeInTheDocument();
+  });
+
+  test('Remove button does not immediately call onRemove — requires inline confirm', async () => {
+    const onRemove = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [creature('a', 'Goblin Warrior', ['goblin'], 1)],
+        onRemove,
+        onClose: vi.fn()
+      }
+    });
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Goblin Warrior from library' })
+    );
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(screen.getByText('Delete?')).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onRemove).toHaveBeenCalledWith('a');
+  });
+
+  test('Cancel during inline confirm aborts the removal', async () => {
+    const onRemove = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [creature('a', 'Goblin Warrior', ['goblin'], 1)],
+        onRemove,
+        onClose: vi.fn()
+      }
+    });
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Goblin Warrior from library' })
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(screen.queryByText('Delete?')).not.toBeInTheDocument();
+  });
+
+  test('Escape closes the modal when no inline confirm is open', async () => {
+    const onClose = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [creature('a', 'Goblin Warrior', ['goblin'], 1)],
+        onRemove: vi.fn(),
+        onClose
+      }
+    });
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('Escape cancels an open inline confirm before closing the modal', async () => {
+    const onClose = vi.fn();
+    const onRemove = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [creature('a', 'Goblin Warrior', ['goblin'], 1)],
+        onRemove,
+        onClose
+      }
+    });
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Goblin Warrior from library' })
+    );
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByText('Delete?')).not.toBeInTheDocument();
+  });
+
+  test('Done button calls onClose', async () => {
+    const onClose = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [creature('a', 'Goblin Warrior', ['goblin'], 1)],
+        onRemove: vi.fn(),
+        onClose
+      }
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -6,6 +6,7 @@
     TemplateAdjustmentChoice
   } from '$lib/encounter-app';
   import BestiarySection from './BestiarySection.svelte';
+  import LibraryManageModal from './LibraryManageModal.svelte';
   import PartySection from './PartySection.svelte';
   import SetupPanel from './SetupPanel.svelte';
 
@@ -13,12 +14,9 @@
   export let creatures: Creature[];
   export let partyMembers: PartyMember[];
   export let conditionOptions: ConditionOption[];
-  export let onAddCreatures: (input: {
-    creature: Creature;
-    adjustment: TemplateAdjustmentChoice;
-    quantity: number;
-    namePrefix: string;
-  }) => void;
+  export let encounterCounts: Record<string, number>;
+  export let onAddOneFromBestiary: (creature: Creature, adjustment: TemplateAdjustmentChoice) => void;
+  export let onRemoveOneFromBestiaryCount: (creatureId: string) => void;
   export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
   export let onImportYamlFiles: (files: File[]) => void;
   export let onRemoveCreature: (id: string) => void;
@@ -29,8 +27,14 @@
   export let onStart: () => void;
   export let onReset: () => void;
 
-  function quickAdd(creature: Creature) {
-    onAddCreatures({ creature, adjustment: 'normal', quantity: 1, namePrefix: '' });
+  let manageOpen = false;
+
+  function openManage() {
+    manageOpen = true;
+  }
+
+  function closeManage() {
+    manageOpen = false;
   }
 </script>
 
@@ -38,6 +42,14 @@
   <header class="library__header">
     <h2 id="library-title">Library</h2>
   </header>
+  <BestiarySection
+    {creatures}
+    {encounterCounts}
+    onAddToEncounter={onAddOneFromBestiary}
+    onRemoveOneFromEncounter={onRemoveOneFromBestiaryCount}
+    {onImportYamlFiles}
+    onOpenManageLibrary={openManage}
+  />
   <PartySection
     {partyMembers}
     {conditionOptions}
@@ -46,19 +58,14 @@
     {onSavePartyMember}
     {onImportPartyMemberYamlFiles}
   />
-  <BestiarySection {creatures} onAddCreature={quickAdd} {onRemoveCreature} />
   <div class="library__configure">
-    <SetupPanel
-      {canStart}
-      {creatures}
-      {onAddCreatures}
-      {onAddManual}
-      {onImportYamlFiles}
-      {onStart}
-      {onReset}
-    />
+    <SetupPanel {canStart} {onAddManual} {onStart} {onReset} />
   </div>
 </aside>
+
+{#if manageOpen}
+  <LibraryManageModal {creatures} onRemove={onRemoveCreature} onClose={closeManage} />
+{/if}
 
 <style>
   .library {
@@ -86,13 +93,6 @@
     line-height: var(--leading-tight);
   }
 
-  /*
-   * SetupPanel still owns the configure-before-add form (template / quantity /
-   * name prefix), the manual-combatant form, the YAML import flow, and the
-   * Start / Reset buttons. A future slice can split those further (per-row
-   * configure UI in the bestiary) and strip SetupPanel's redundant creature
-   * dropdown; for now the dropdown coexists with the bestiary list above.
-   */
   .library__configure {
     border-top: var(--border-thin);
     padding: var(--space-3) var(--space-4);

--- a/src/components/PartySection.svelte
+++ b/src/components/PartySection.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { PartyMember } from '../domain';
   import type { ConditionOption } from '$lib/encounter-app';
   import IconButton from './ui/IconButton.svelte';
-  import Input from './ui/Input.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
   import Button from './ui/Button.svelte';
   import PartyMemberEditModal from './PartyMemberEditModal.svelte';
@@ -14,23 +14,34 @@
   export let onSavePartyMember: (partyMember: PartyMember) => void;
   export let onImportPartyMemberYamlFiles: (files: File[]) => void;
 
-  let query = '';
+  const COLLAPSE_KEY = 'pf2e:partyCollapsed';
+
   let editingMember: PartyMember | null = null;
   let isCreatingNew = false;
   let fileInput: HTMLInputElement | undefined;
-
-  $: needle = query.trim().toLowerCase();
-  $: filtered = needle
-    ? partyMembers.filter((pm) => {
-        if (pm.name.toLowerCase().includes(needle)) return true;
-        if (pm.playerName?.toLowerCase().includes(needle)) return true;
-        if (pm.class?.toLowerCase().includes(needle)) return true;
-        return pm.tags.some((t) => t.toLowerCase().includes(needle));
-      })
-    : partyMembers;
+  let collapsed = false;
 
   $: existingIds = partyMembers.map((pm) => pm.id);
   $: modalOpen = isCreatingNew || editingMember !== null;
+
+  onMount(() => {
+    try {
+      const stored = localStorage.getItem(COLLAPSE_KEY);
+      collapsed = stored === '1';
+    } catch {
+      // localStorage unavailable (private mode, blocked) — fall back to default open.
+    }
+  });
+
+  function handleToggle(event: Event) {
+    const open = (event.currentTarget as HTMLDetailsElement).open;
+    collapsed = !open;
+    try {
+      localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0');
+    } catch {
+      // Persistence is best-effort; the section still works without it.
+    }
+  }
 
   function openNew() {
     editingMember = null;
@@ -67,91 +78,80 @@
   }
 </script>
 
-<section class="party" aria-labelledby="party-label">
-  <header class="party__header">
-    <SectionLabel as="h3" id="party-label">Party</SectionLabel>
-    <span class="count">{partyMembers.length}</span>
-  </header>
+<details class="party" open={!collapsed} ontoggle={handleToggle}>
+  <summary class="party__summary">
+    <span class="party__heading">
+      <span class="party__chevron" aria-hidden="true">▾</span>
+      <SectionLabel as="span">Party</SectionLabel>
+      <span class="count">{partyMembers.length}</span>
+    </span>
+  </summary>
 
-  <div class="party__actions">
-    <Button variant="secondary" size="sm" onclick={openNew}>New</Button>
-    <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
-    <input
-      bind:this={fileInput}
-      type="file"
-      accept=".yaml,.yml,application/yaml,text/yaml"
-      multiple
-      hidden
-      onchange={handleFileChange}
-    />
-  </div>
-
-  {#if partyMembers.length > 0}
-    <div class="party__search">
-      <Input
-        ariaLabel="Search party"
-        type="search"
-        placeholder="Search…"
-        bind:value={query}
-      >
-        <span slot="leading" aria-hidden="true">⌕</span>
-      </Input>
+  <div class="party__body">
+    <div class="party__actions">
+      <Button variant="secondary" size="sm" onclick={openNew}>New</Button>
+      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept=".yaml,.yml,application/yaml,text/yaml"
+        multiple
+        hidden
+        onchange={handleFileChange}
+      />
     </div>
-  {/if}
 
-  {#if partyMembers.length === 0}
-    <p class="empty">Click <strong>New</strong> or <strong>Import YAML</strong> to add party members.</p>
-  {:else if filtered.length === 0}
-    <p class="empty">No matching party members.</p>
-  {:else}
-    <ul class="rows">
-      {#each filtered as pm (pm.id)}
-        <li class="row">
-          <span class="row__level" aria-label="Level {pm.level}">{pm.level}</span>
-          <span class="row__body">
-            <span class="row__name">{pm.name}</span>
-            <span class="row__sub">{memberSubtext(pm)}</span>
-          </span>
-          <span class="row__remove">
-            <IconButton
-              ariaLabel="Remove {pm.name} from library"
-              title="Remove from library"
-              variant="destructive"
-              size={22}
-              onclick={() => onRemovePartyMember(pm.id)}
+    {#if partyMembers.length === 0}
+      <p class="empty">Click <strong>New</strong> or <strong>Import YAML</strong> to add party members.</p>
+    {:else}
+      <ul class="rows">
+        {#each partyMembers as pm (pm.id)}
+          <li class="row">
+            <button
+              type="button"
+              class="row__add"
+              aria-label="Add {pm.name} to encounter"
+              title="Add to encounter"
+              onclick={() => onAddPartyMemberToEncounter(pm)}
             >
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-                <path d="M2 6h8" />
-              </svg>
-            </IconButton>
-          </span>
-          <IconButton
-            ariaLabel="Edit {pm.name}"
-            title="Edit"
-            variant="default"
-            size={22}
-            onclick={() => openEdit(pm)}
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M2 10l1-3 5-5 2 2-5 5-3 1z" />
-            </svg>
-          </IconButton>
-          <IconButton
-            ariaLabel="Add {pm.name} to encounter"
-            title="Add to encounter"
-            variant="primary"
-            size={26}
-            onclick={() => onAddPartyMemberToEncounter(pm)}
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
-              <path d="M7 2v10M2 7h10" />
-            </svg>
-          </IconButton>
-        </li>
-      {/each}
-    </ul>
-  {/if}
-</section>
+              <span class="row__level" aria-label="Level {pm.level}">{pm.level}</span>
+              <span class="row__body">
+                <span class="row__name">{pm.name}</span>
+                <span class="row__sub">{memberSubtext(pm)}</span>
+              </span>
+            </button>
+            <span class="row__actions">
+              <IconButton
+                ariaLabel="Edit {pm.name}"
+                title="Edit"
+                variant="default"
+                size={22}
+                onclick={() => openEdit(pm)}
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M2 10l1-3 5-5 2 2-5 5-3 1z" />
+                </svg>
+              </IconButton>
+              <span class="row__remove">
+                <IconButton
+                  ariaLabel="Remove {pm.name} from library"
+                  title="Remove from library"
+                  variant="destructive"
+                  size={22}
+                  onclick={() => onRemovePartyMember(pm.id)}
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                    <path d="M2 6h8" />
+                  </svg>
+                </IconButton>
+              </span>
+            </span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</details>
 
 {#if modalOpen}
   <PartyMemberEditModal
@@ -165,23 +165,48 @@
 
 <style>
   .party {
-    display: grid;
-    gap: var(--space-2);
-    padding: var(--space-3) var(--space-4);
+    display: block;
+    padding: 0;
     border-bottom: var(--border-thin);
   }
 
-  .party__header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
+  .party__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: var(--space-3) var(--space-4);
+    user-select: none;
+  }
+
+  .party__summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .party__heading {
+    display: inline-flex;
+    align-items: center;
     gap: var(--space-2);
+  }
+
+  .party__chevron {
+    display: inline-block;
+    color: var(--color-ink-mute);
+    transition: transform 0.12s;
+  }
+
+  .party:not([open]) .party__chevron {
+    transform: rotate(-90deg);
   }
 
   .count {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--color-ink-mute);
+  }
+
+  .party__body {
+    display: grid;
+    gap: var(--space-2);
+    padding: 0 var(--space-4) var(--space-3);
   }
 
   .party__actions {
@@ -215,15 +240,43 @@
 
   .row {
     display: grid;
-    grid-template-columns: 32px 1fr auto auto auto;
-    gap: var(--space-3);
+    grid-template-columns: 1fr auto;
+    gap: var(--space-2);
     align-items: center;
-    padding: var(--space-2) 0;
+    padding: 0;
     border-bottom: 1px dashed var(--color-rule);
   }
 
   .row:last-child {
     border-bottom: none;
+  }
+
+  .row__add {
+    all: unset;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 32px 1fr;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) var(--space-2);
+    min-width: 0;
+    transition: background 0.08s;
+  }
+
+  .row__add:hover {
+    background: var(--color-panel-2);
+  }
+
+  .row__add:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -2px;
+  }
+
+  .row__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding-right: var(--space-2);
   }
 
   .row__remove {

--- a/src/components/SetupPanel.svelte
+++ b/src/components/SetupPanel.svelte
@@ -1,34 +1,10 @@
 <script lang="ts">
-  import type { Creature } from '../domain';
-  import {
-    makeCreatureCombatant,
-    type ManualCombatantInput,
-    type TemplateAdjustmentChoice
-  } from '$lib/encounter-app';
-  import { templateLabel } from '$lib/template-label';
+  import { type ManualCombatantInput } from '$lib/encounter-app';
 
   export let canStart: boolean;
-  export let creatures: Creature[];
-  export let onAddCreatures: (input: {
-    creature: Creature;
-    adjustment: TemplateAdjustmentChoice;
-    quantity: number;
-    namePrefix: string;
-  }) => void;
   export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
-  export let onImportYamlFiles: (files: File[]) => void;
   export let onStart: () => void;
   export let onReset: () => void;
-
-  let selectedCreatureId = creatures[0]?.id ?? '';
-  let selectedAdjustment: TemplateAdjustmentChoice = 'normal';
-  let creatureQuantity = 1;
-  let creatureNamePrefix = '';
-  let fileInput: HTMLInputElement | undefined;
-
-  $: if (!creatures.some((c) => c.id === selectedCreatureId) && creatures.length > 0) {
-    selectedCreatureId = creatures[0].id;
-  }
 
   let manualName = 'Goblin Warrior';
   let manualHp = 18;
@@ -39,31 +15,8 @@
   let manualPerception = 7;
   let manualSpeed = 25;
 
-  $: selectedCreature = creatures.find((c) => c.id === selectedCreatureId) ?? creatures[0];
-  $: previewCombatant = selectedCreature
-    ? makeCreatureCombatant({
-        creature: selectedCreature,
-        combatantId: 'preview',
-        adjustment: selectedAdjustment
-      })
-    : undefined;
-
-  function formatTraits(creature: Creature) {
-    return [creature.rarity, creature.size, ...creature.traits].join(' · ');
-  }
-
   function numberOrDefault(value: number, fallback: number) {
     return Number.isFinite(value) ? Math.trunc(value) : fallback;
-  }
-
-  function submitCreatures() {
-    if (!selectedCreature) return;
-    onAddCreatures({
-      creature: selectedCreature,
-      adjustment: selectedAdjustment,
-      quantity: Math.max(1, numberOrDefault(creatureQuantity, 1)),
-      namePrefix: creatureNamePrefix
-    });
   }
 
   function submitManual() {
@@ -78,108 +31,12 @@
       speed: numberOrDefault(manualSpeed, 25)
     });
   }
-
-  function reset() {
-    selectedAdjustment = 'normal';
-    creatureQuantity = 1;
-    creatureNamePrefix = '';
-    onReset();
-  }
-
-  function handleFileChange(event: Event) {
-    const input = event.currentTarget as HTMLInputElement;
-    const files = input.files ? Array.from(input.files) : [];
-    if (files.length > 0) {
-      onImportYamlFiles(files);
-    }
-    // <input type="file"> only fires 'change' on a new selection; reset so
-    // the same file can be re-imported after fixing it.
-    input.value = '';
-  }
 </script>
 
 <aside class="panel setup-panel" aria-labelledby="setup-title">
   <div class="panel-heading">
-    <h2 id="setup-title">Encounter Setup</h2>
-    <span>{creatures.length} creature{creatures.length === 1 ? '' : 's'}</span>
+    <h2 id="setup-title">Encounter Controls</h2>
   </div>
-
-  <div class="import-row">
-    <button type="button" class="secondary" onclick={() => fileInput?.click()}>
-      Import YAML…
-    </button>
-    <input
-      bind:this={fileInput}
-      type="file"
-      accept=".yaml,.yml,application/yaml,text/yaml"
-      multiple
-      hidden
-      onchange={handleFileChange}
-    />
-    <span class="import-hint">Personal monster YAMLs (kept on your machine).</span>
-  </div>
-
-  <form class="creature-form" onsubmit={(event) => { event.preventDefault(); submitCreatures(); }}>
-    <label>
-      Creature
-      <select bind:value={selectedCreatureId}>
-        {#each creatures as creature (creature.id)}
-          <option value={creature.id}>{creature.name}</option>
-        {/each}
-      </select>
-    </label>
-
-    {#if selectedCreature && previewCombatant}
-      <section class="creature-preview" aria-label="Selected creature preview">
-        <div class="preview-heading">
-          <div>
-            <strong>{selectedCreature.name}</strong>
-            <span>Level {selectedCreature.level} · {formatTraits(selectedCreature)}</span>
-          </div>
-          <span class:adjusted={selectedAdjustment !== 'normal'}>{templateLabel(selectedAdjustment)}</span>
-        </div>
-        <dl class="preview-stats">
-          <div><dt>HP</dt><dd>{previewCombatant.baseStats.hp}</dd></div>
-          <div><dt>AC</dt><dd>{previewCombatant.baseStats.ac}</dd></div>
-          <div><dt>Fort</dt><dd>+{previewCombatant.baseStats.fortitude}</dd></div>
-          <div><dt>Ref</dt><dd>+{previewCombatant.baseStats.reflex}</dd></div>
-          <div><dt>Will</dt><dd>+{previewCombatant.baseStats.will}</dd></div>
-          <div><dt>Per</dt><dd>+{previewCombatant.baseStats.perception}</dd></div>
-        </dl>
-        <p class="preview-line">
-          {selectedCreature.attacks.length} attack{selectedCreature.attacks.length === 1 ? '' : 's'}
-          {selectedCreature.spellcasting ? ` · ${selectedCreature.spellcasting.length} spell block${selectedCreature.spellcasting.length === 1 ? '' : 's'}` : ''}
-        </p>
-      </section>
-    {/if}
-
-    <fieldset class="template-picker">
-      <legend>Template</legend>
-      <div class="segmented">
-        <button type="button" class:active={selectedAdjustment === 'normal'} aria-pressed={selectedAdjustment === 'normal'} onclick={() => (selectedAdjustment = 'normal')}>Normal</button>
-        <button type="button" class:active={selectedAdjustment === 'weak'} aria-pressed={selectedAdjustment === 'weak'} onclick={() => (selectedAdjustment = 'weak')}>Weak</button>
-        <button type="button" class:active={selectedAdjustment === 'elite'} aria-pressed={selectedAdjustment === 'elite'} onclick={() => (selectedAdjustment = 'elite')}>Elite</button>
-      </div>
-    </fieldset>
-
-    {#if selectedAdjustment !== 'normal'}
-      <p class="template-warning">
-        {templateLabel(selectedAdjustment)} adjusts structured stats, attacks, spell DCs, and HP. DCs or damage written only inside ability text are not adjusted automatically.
-      </p>
-    {/if}
-
-    <div class="add-grid">
-      <label>
-        Quantity
-        <input type="number" min="1" max="12" bind:value={creatureQuantity} />
-      </label>
-      <label>
-        Name prefix
-        <input bind:value={creatureNamePrefix} autocomplete="off" placeholder={selectedCreature?.name ?? 'Combatant'} />
-      </label>
-    </div>
-    <button type="submit">Add Creature</button>
-  </form>
 
   <details class="custom-combatant">
     <summary>Custom Combatant</summary>
@@ -200,7 +57,7 @@
 
   <div class="control-row">
     <button type="button" disabled={!canStart} onclick={onStart}>Start Encounter</button>
-    <button type="button" class="secondary" onclick={reset}>Reset Local</button>
+    <button type="button" class="secondary" onclick={onReset}>Reset Local</button>
   </div>
 </aside>
 
@@ -227,12 +84,6 @@
     line-height: 1.2;
   }
 
-  .panel-heading > span {
-    color: #627171;
-    font-size: 13px;
-  }
-
-  .creature-form,
   .manual-form {
     display: grid;
     gap: 10px;
@@ -246,8 +97,7 @@
     font-weight: 700;
   }
 
-  input,
-  select {
+  input {
     min-width: 0;
     border: 1px solid #b8c3be;
     border-radius: 6px;
@@ -286,143 +136,9 @@
     gap: 8px;
   }
 
-  .add-grid {
-    display: grid;
-    grid-template-columns: 96px minmax(0, 1fr);
-    gap: 8px;
-  }
-
-  .creature-preview {
-    display: grid;
-    gap: 10px;
-    border: 1px solid #d8ddd9;
-    border-radius: 7px;
-    background: #ffffff;
-    padding: 12px;
-  }
-
-  .preview-heading {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-  }
-
-  .preview-heading strong,
-  .preview-heading span {
-    display: block;
-  }
-
-  .preview-heading span,
-  .preview-line,
-  .custom-combatant summary {
-    color: #627171;
-    font-size: 13px;
-  }
-
-  .preview-heading > span {
-    border-radius: 999px;
-    background: #eef1ee;
-    color: #334143;
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1;
-    padding: 5px 7px;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-
-  .preview-heading > span.adjusted {
-    background: #f4e6d7;
-    color: #7c3d1f;
-  }
-
-  .preview-stats {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 6px;
-    margin: 0;
-  }
-
-  .preview-stats div {
-    border-radius: 6px;
-    background: #eef1ee;
-    padding: 8px;
-  }
-
-  .preview-stats dt,
-  .preview-stats dd,
-  .preview-line {
-    margin: 0;
-  }
-
-  .preview-stats dt {
-    color: #627171;
-    font-size: 11px;
-    font-weight: 800;
-    text-transform: uppercase;
-  }
-
-  .preview-stats dd {
-    color: #1d2528;
-    font-size: 18px;
-    font-weight: 800;
-  }
-
-  .template-picker {
-    display: grid;
-    gap: 6px;
-    border: 0;
-    margin: 0;
-    padding: 0;
-  }
-
-  .template-picker legend {
-    color: #526061;
-    font-size: 12px;
-    font-weight: 700;
-    padding: 0;
-  }
-
-  .segmented {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    border: 1px solid #b8c3be;
-    border-radius: 7px;
-    overflow: hidden;
-  }
-
-  .segmented button {
-    min-height: 36px;
-    border: 0;
-    border-radius: 0;
-    background: #ffffff;
-    color: #334143;
-  }
-
-  .segmented button + button {
-    border-left: 1px solid #d8ddd9;
-  }
-
-  .segmented button.active {
-    background: #28494c;
-    color: #ffffff;
-  }
-
-  .template-warning {
-    border-left: 4px solid #b6652e;
-    border-radius: 6px;
-    background: #fff7ee;
-    color: #5f3c23;
-    font-size: 13px;
-    line-height: 1.4;
-    margin: 0;
-    padding: 10px;
-  }
-
   .custom-combatant {
     border-top: 1px solid #d8ddd9;
-    margin-top: 14px;
+    margin-top: 4px;
     padding-top: 12px;
   }
 
@@ -430,6 +146,8 @@
     cursor: pointer;
     font-weight: 800;
     margin-bottom: 10px;
+    color: #627171;
+    font-size: 13px;
   }
 
   .control-row {
@@ -438,19 +156,6 @@
     justify-content: space-between;
     gap: 10px;
     margin-top: 12px;
-  }
-
-  .import-row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 14px;
-  }
-
-  .import-hint {
-    color: #627171;
-    font-size: 12px;
-    line-height: 1.3;
   }
 
   @media (max-width: 760px) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,6 +90,8 @@
 
   $: availableCreatures = storedCreatures;
 
+  $: encounterCounts = computeEncounterCounts(encounter.combatants);
+
   $: xpSummary = computeEncounterXP(encounter);
 
   $: orderedCombatants = encounter.initiative.order
@@ -242,25 +244,48 @@
     runCommand(toCommand('SET_INITIATIVE_ORDER', { order: nextOrder }, nextCommandId()));
   }
 
-  function handleAddCreatures(input: {
-    creature: Creature;
-    adjustment: TemplateAdjustmentChoice;
-    quantity: number;
-    namePrefix: string;
-  }) {
-    const prefix = input.namePrefix.trim();
-    for (let index = 1; index <= input.quantity; index += 1) {
-      const name = prefix
-        ? input.quantity > 1 ? `${prefix} ${index}` : prefix
-        : input.quantity > 1 ? `${input.creature.name} ${index}` : input.creature.name;
-      const combatant = makeCreatureCombatant({
-        creature: input.creature,
-        combatantId: `${input.creature.id}-${combatantCounter++}`,
-        name,
-        adjustment: input.adjustment
-      });
-      addCombatant(combatant);
+  function computeEncounterCounts(
+    combatants: Record<string, CombatantState>
+  ): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const combatant of Object.values(combatants)) {
+      if (combatant.sourceType !== 'creature') continue;
+      counts[combatant.sourceId] = (counts[combatant.sourceId] ?? 0) + 1;
     }
+    return counts;
+  }
+
+  function handleAddOneFromBestiary(creature: Creature, adjustment: TemplateAdjustmentChoice) {
+    const existing = encounterCounts[creature.id] ?? 0;
+    const name = existing > 0 ? `${creature.name} ${existing + 1}` : creature.name;
+    const combatant = makeCreatureCombatant({
+      creature,
+      combatantId: `${creature.id}-${combatantCounter++}`,
+      name,
+      adjustment
+    });
+    addCombatant(combatant);
+  }
+
+  function handleRemoveOneFromBestiaryCount(creatureId: string) {
+    let target: CombatantState | undefined;
+    for (const id of [...encounter.initiative.order].reverse()) {
+      const c = encounter.combatants[id];
+      if (c && c.sourceType === 'creature' && c.sourceId === creatureId) {
+        target = c;
+        break;
+      }
+    }
+    if (!target) {
+      for (const c of Object.values(encounter.combatants)) {
+        if (c.sourceType === 'creature' && c.sourceId === creatureId) {
+          target = c;
+          break;
+        }
+      }
+    }
+    if (!target) return;
+    runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
   }
 
   async function handleImportYamlFiles(files: File[]) {
@@ -701,7 +726,9 @@
         creatures={availableCreatures}
         partyMembers={storedPartyMembers}
         {conditionOptions}
-        onAddCreatures={handleAddCreatures}
+        {encounterCounts}
+        onAddOneFromBestiary={handleAddOneFromBestiary}
+        onRemoveOneFromBestiaryCount={handleRemoveOneFromBestiaryCount}
         onAddManual={handleAddManual}
         onImportYamlFiles={handleImportYamlFiles}
         onRemoveCreature={handleRemoveCreature}


### PR DESCRIPTION
## Summary

- **Bestiary**: whole-row click adds +1 to the encounter; each row shows a live `×N` count badge with an inline minus button when N>0. Global Weak / Normal / Elite toggle replaces the per-add picker in `SetupPanel`. Drops the dropdown / quantity / name-prefix flow entirely.
- **Library safety**: per-row destructive remove is gone. A new `LibraryManageModal` (opened from a `Manage…` button in the bestiary header) is the only place to delete library entries, gated by a two-step inline confirm.
- **Party**: section is now collapsible (native `<details>`), expanded by default, persisted in localStorage. Search box removed; row click adds to the encounter.
- **SetupPanel**: stripped down to Custom Combatant + Start / Reset; renamed to "Encounter Controls".
- **Import YAML**: relocated from SetupPanel to the bestiary header.

No new domain commands — all flows still dispatch existing `ADD_COMBATANT` / `REMOVE_COMBATANT`.

## Test plan
- [ ] `npm run check && npm run test:run && npm run audit && npm run build` pass locally (43 files, 580 tests).
- [ ] Click a bestiary row 3× → row shows `×3`; click the inline `−` → row shows `×2`.
- [ ] Toggle Elite → click a bestiary row → combatant card shows the Elite badge and the boosted stat block.
- [ ] Open Manage Library → click Remove on a creature → inline `Delete?` confirm appears → click Delete → creature is gone from both the modal and the bestiary list.
- [ ] Cancel during inline confirm aborts; ESC during inline confirm cancels the confirm without closing the modal; ESC outside the confirm closes the modal.
- [ ] Collapse the Party section, refresh the page → still collapsed. Expand, refresh → still expanded.
- [ ] Custom Combatant form, Start Encounter, Reset Local still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)