### PR TITLE
Fix Low per-PC threshold to 20 per GM Core Table 10-1

### DIFF
--- a/src/domain/encounter-xp.test.ts
+++ b/src/domain/encounter-xp.test.ts
@@ -62,7 +62,7 @@ describe('difficultyThresholds', () => {
   it('party of 5 (one PC above standard)', () => {
     expect(difficultyThresholds(5)).toEqual({
       trivial: 50,
-      low: 75,
+      low: 80,
       moderate: 100,
       severe: 150,
       extreme: 200
@@ -72,7 +72,7 @@ describe('difficultyThresholds', () => {
   it('party of 3 (one PC below standard)', () => {
     expect(difficultyThresholds(3)).toEqual({
       trivial: 30,
-      low: 45,
+      low: 40,
       moderate: 60,
       severe: 90,
       extreme: 120
@@ -82,17 +82,20 @@ describe('difficultyThresholds', () => {
   it('party of 6', () => {
     expect(difficultyThresholds(6)).toEqual({
       trivial: 60,
-      low: 90,
+      low: 100,
       moderate: 120,
       severe: 180,
       extreme: 240
     });
   });
 
-  it('party of 1', () => {
+  it('party of 1 — Low collapses to 0 because GM Core deducts 20 XP per missing PC', () => {
+    // Base Low = 60, deducted by 20*3 = 60 for the three "missing" PCs → 0.
+    // This matches the literal spec formula; party-of-1 is a degenerate edge
+    // case the rules don't really cover, so any non-zero XP qualifies as Low.
     expect(difficultyThresholds(1)).toEqual({
       trivial: 10,
-      low: 15,
+      low: 0,
       moderate: 20,
       severe: 30,
       extreme: 40
@@ -274,7 +277,7 @@ describe('computeEncounterXP', () => {
     expect(result.totalXP).toBe(240);
     expect(result.thresholds).toEqual({
       trivial: 50,
-      low: 75,
+      low: 80,
       moderate: 100,
       severe: 150,
       extreme: 200

--- a/src/domain/encounter-xp.ts
+++ b/src/domain/encounter-xp.ts
@@ -68,9 +68,11 @@ const BASE_THRESHOLDS: DifficultyThresholds = {
   extreme: 160
 };
 
+// Per-PC threshold increments from GM Core Table 10-1 ("Character Adjustment").
+// The pre-Remaster Core Rulebook had Low at +15/PC; GM Core changed it to +20/PC.
 const PER_PC_INCREMENTS: DifficultyThresholds = {
   trivial: 10,
-  low: 15,
+  low: 20,
   moderate: 20,
   severe: 30,
   extreme: 40


### PR DESCRIPTION
## Summary

`PER_PC_INCREMENTS.low` was `15`, the value from the **original** (pre-Remaster) Core Rulebook. The Remaster's GM Core Table 10-1 increased Low's Character Adjustment to **20**, matching Moderate. This PR aligns the constant and its tests with the spec.

Other bands were already correct (Trivial 10, Moderate 20, Severe 30, Extreme 40), and the canonical 4-PC budget (Low 60, Moderate 80, …) was unaffected. Only non-4-PC parties saw incorrect Low thresholds.

| Party size | Old Low | New Low |
|---|---|---|
| 3 | 45 | **40** |
| 5 | 75 | **80** |
| 6 | 90 | **100** |
| 1 | 15 | **0** (degenerate — see test note) |

For party-of-1 the literal formula yields 0; the rules don't really cover that party size, so the test now documents and enshrines the spec's literal arithmetic.

## Test plan
- [ ] `npm run check && npm run test:run && npm run audit && npm run build` pass locally (all 569 tests pass).
- [ ] No production behavior change for the common case (4 PCs, same level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)