### PR TITLE
Bestiary preview: adjusted level + XP double-count fix

### DIFF
--- a/src/components/BestiarySection.svelte
+++ b/src/components/BestiarySection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Creature } from '../domain';
+  import { adjustedLevel, type Creature } from '../domain';
   import type { TemplateAdjustmentChoice } from '$lib/encounter-app';
   import Button from './ui/Button.svelte';
   import IconButton from './ui/IconButton.svelte';
@@ -16,6 +16,9 @@
   let query = '';
   let adjustment: TemplateAdjustmentChoice = 'normal';
   let fileInput: HTMLInputElement | undefined;
+
+  $: previewLevel = (level: number) =>
+    adjustment === 'normal' ? level : adjustedLevel(level, adjustment);
 
   $: needle = query.trim().toLowerCase();
   $: filtered = needle
@@ -104,6 +107,8 @@
     <ul class="rows">
       {#each filtered as creature (creature.id)}
         {@const count = encounterCounts[creature.id] ?? 0}
+        {@const displayedLevel = previewLevel(creature.level)}
+        {@const levelDelta = displayedLevel - creature.level}
         <li class="row">
           <button
             type="button"
@@ -112,7 +117,19 @@
             title="Add to encounter"
             onclick={() => onAddToEncounter(creature, adjustment)}
           >
-            <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
+            <span class="row__level-wrap">
+              <span
+                class="row__level"
+                aria-label={adjustment === 'normal'
+                  ? `Level ${displayedLevel}`
+                  : `Level ${displayedLevel} (${adjustment}, base ${creature.level})`}
+              >{displayedLevel}</span>
+              {#if levelDelta !== 0}
+                <span class="row__level-delta" aria-hidden="true"
+                  >{levelDelta > 0 ? `+${levelDelta}` : `${levelDelta}`}</span
+                >
+              {/if}
+            </span>
             <span class="row__body">
               <span class="row__name">{creature.name}</span>
               <span class="row__traits">{creature.traits.join(' · ')}</span>
@@ -255,7 +272,7 @@
     all: unset;
     cursor: pointer;
     display: grid;
-    grid-template-columns: 32px 1fr;
+    grid-template-columns: 48px 1fr;
     gap: var(--space-3);
     align-items: center;
     padding: var(--space-2) var(--space-2);
@@ -272,6 +289,13 @@
     outline-offset: -2px;
   }
 
+  .row__level-wrap {
+    display: inline-flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 3px;
+  }
+
   .row__level {
     display: inline-flex;
     align-items: center;
@@ -280,6 +304,14 @@
     font-size: var(--text-md);
     font-weight: 600;
     color: var(--color-ink);
+  }
+
+  .row__level-delta {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-blue);
   }
 
   .row__body {

--- a/src/domain/creatures/templates.test.ts
+++ b/src/domain/creatures/templates.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { expectSerializable } from '../test-support';
 import type { Creature } from '../types';
-import { applyEliteWeak } from './templates';
+import { adjustedLevel, applyEliteWeak } from './templates';
 
 describe('applyEliteWeak', () => {
   test('applies elite numeric, strike, and spellcasting adjustments without mutating the source creature', () => {
@@ -91,6 +91,21 @@ describe('applyEliteWeak', () => {
 
     expect(applyEliteWeak(creatureTemplate({ level: 1 }), 'weak').level).toBe(-1);
     expect(applyEliteWeak(creatureTemplate({ level: 2 }), 'weak').level).toBe(1);
+  });
+});
+
+describe('adjustedLevel', () => {
+  test('elite adds +1, or +2 when starting at level <= 0', () => {
+    expect(adjustedLevel(5, 'elite')).toBe(6);
+    expect(adjustedLevel(1, 'elite')).toBe(2);
+    expect(adjustedLevel(0, 'elite')).toBe(2);
+    expect(adjustedLevel(-1, 'elite')).toBe(1);
+  });
+
+  test('weak subtracts 1, or 2 when starting at level 1', () => {
+    expect(adjustedLevel(5, 'weak')).toBe(4);
+    expect(adjustedLevel(2, 'weak')).toBe(1);
+    expect(adjustedLevel(1, 'weak')).toBe(-1);
   });
 });
 

--- a/src/domain/creatures/templates.ts
+++ b/src/domain/creatures/templates.ts
@@ -28,7 +28,7 @@ export function applyEliteWeak(creature: Creature, adjustment: CreatureTemplateA
   return adjusted;
 }
 
-function adjustedLevel(level: number, adjustment: CreatureTemplateAdjustment): number {
+export function adjustedLevel(level: number, adjustment: CreatureTemplateAdjustment): number {
   if (adjustment === 'elite') {
     return level <= 0 ? level + 2 : level + 1;
   }

--- a/src/domain/encounter-xp.test.ts
+++ b/src/domain/encounter-xp.test.ts
@@ -231,13 +231,17 @@ describe('computeEncounterXP', () => {
     expect(noEnemies.xpAward).toBe(0);
   });
 
-  it('4 PCs L5 vs one L5 elite → 60 XP, Low (elite shifts effective level +1)', () => {
+  // CombatantState.level is the *post-adjustment* level (set by applyEliteWeak
+  // inside createCombatantFromCreature). The XP calculator must NOT shift it
+  // again — doing so double-counts the adjustment.
+
+  it('4 PCs L5 vs an Elite basilisk (base L5 → stored L6) → 60 XP, Low', () => {
     const state = makeEncounter([
       pc('p1', 5),
       pc('p2', 5),
       pc('p3', 5),
       pc('p4', 5),
-      enemy('e1', 5, { templateAdjustment: 'elite' })
+      enemy('e1', 6, { templateAdjustment: 'elite' })
     ]);
     const result = computeEncounterXP(state);
     expect(result.totalXP).toBe(60);
@@ -246,7 +250,7 @@ describe('computeEncounterXP', () => {
     expect(result.contributions[0].delta).toBe(1);
   });
 
-  it('4 PCs L5 vs one L4 weak → 20 XP (weak shifts effective level -1)', () => {
+  it('4 PCs L5 vs a Weak basilisk (base L5 → stored L4) → 30 XP, Trivial', () => {
     const state = makeEncounter([
       pc('p1', 5),
       pc('p2', 5),
@@ -255,10 +259,24 @@ describe('computeEncounterXP', () => {
       enemy('e1', 4, { templateAdjustment: 'weak' })
     ]);
     const result = computeEncounterXP(state);
-    expect(result.contributions[0].effectiveLevel).toBe(3);
-    expect(result.contributions[0].delta).toBe(-2);
-    expect(result.totalXP).toBe(20);
+    expect(result.contributions[0].effectiveLevel).toBe(4);
+    expect(result.contributions[0].delta).toBe(-1);
+    expect(result.totalXP).toBe(30);
     expect(result.difficulty).toBe('Trivial');
+  });
+
+  it('4 PCs L5 vs Normal + Weak + Elite basilisks (party L5) → 130 XP', () => {
+    const state = makeEncounter([
+      pc('p1', 5),
+      pc('p2', 5),
+      pc('p3', 5),
+      pc('p4', 5),
+      enemy('e1', 5),
+      enemy('e2', 4, { templateAdjustment: 'weak' }),
+      enemy('e3', 6, { templateAdjustment: 'elite' })
+    ]);
+    const result = computeEncounterXP(state);
+    expect(result.totalXP).toBe(130);
   });
 
   it('5 PCs L4 vs L5+L5+L7 → uses party-5 thresholds', () => {

--- a/src/domain/encounter-xp.ts
+++ b/src/domain/encounter-xp.ts
@@ -112,10 +112,7 @@ export function classifyDifficulty(
 }
 
 function effectiveCreatureLevel(c: CombatantState): number | null {
-  if (c.level == null) return null;
-  if (c.templateAdjustment === 'elite') return c.level + 1;
-  if (c.templateAdjustment === 'weak') return c.level - 1;
-  return c.level;
+  return c.level ?? null;
 }
 
 export function computeEncounterXP(state: EncounterState): EncounterXPSummary {

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,7 +1,7 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
 export { createCombatantFromPartyMember } from './party/factory';
-export { applyEliteWeak } from './creatures/templates';
+export { applyEliteWeak, adjustedLevel } from './creatures/templates';
 export { effectLibrary } from './effects/library';
 export { deriveStats } from './effects/derivation';
 export {


### PR DESCRIPTION
## Summary
Two related fixes around creature adjustments (Weak / Elite):

1. **Bestiary preview shows the would-be-added level.** Toggling Weak / Elite in the encounter setup panel now updates the level next to each creature in the bestiary list to reflect what would actually be added, with a small `+1` / `-1` delta badge. Existing combatants in the encounter are unchanged — the adjustment is still captured per-creature at add time.

2. **XP calculator no longer double-counts the adjustment.** `CombatantState.level` is the *post-adjustment* level (set by `applyEliteWeak` inside `createCombatantFromCreature`), but `effectiveCreatureLevel` in `encounter-xp.ts` was adding another `+/-1` on top. Concrete repro: party L5 vs Normal + Weak + Elite basilisks was 40 + 20 + 80 = **140 XP**; correct value is 40 + 30 + 60 = **130 XP**. Two existing tests passed only because they hand-constructed combatants with the inverse convention (base level instead of stored level); both updated, plus a new regression test for the basilisk trio.

## Implementation
- `src/domain/creatures/templates.ts` — promote `adjustedLevel` to exported helper; re-exported from the domain barrel.
- `src/components/BestiarySection.svelte` — derived `previewLevel` and `{@const}` per row; widened the level grid column from 32px to 48px to fit the badge.
- `src/domain/encounter-xp.ts` — `effectiveCreatureLevel` now just returns `c.level`.
- `src/domain/encounter-xp.test.ts` — fix two tests to use post-adjustment level (production semantics); add basilisk trio regression test.
- `src/domain/creatures/templates.test.ts` — direct boundary-case unit tests for `adjustedLevel`.

## Test plan
- [x] `npm run check`
- [x] `npm run test:run` (583 tests)
- [x] `npm run audit` (only low-severity, gate is moderate+)
- [x] `npm run build`
- [x] Manual UI: toggle Normal/Weak/Elite in setup panel, confirm level number updates live with delta badge
- [x] Manual UI: party L5, add Normal + Weak + Elite basilisk → encounter shows 130 XP total
- [x] Manual UI: add a creature while Weak is selected, then switch to Elite — verify the already-added combatant's level on the right does NOT change

🤖 Generated with [Claude Code](https://claude.com/claude-code)