### PR TITLE
Combatant details: MAP, click-to-roll, sticky panel, spellcasting

### DIFF
--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -12,8 +12,17 @@
 
   export let combatant: CombatantState | undefined;
   export let onSetNote: (combatantId: string, note: string | null) => void;
-  export let onRollAttack: (combatantId: string, attack: Attack, variant: MapVariant) => void = () => {};
-  export let onRollDamage: (combatantId: string, attack: Attack) => void = () => {};
+  export let onRollAttack: (
+    combatantId: string,
+    attack: Attack,
+    variant: MapVariant,
+    origin: { x: number; y: number }
+  ) => void = () => {};
+  export let onRollDamage: (
+    combatantId: string,
+    attack: Attack,
+    origin: { x: number; y: number }
+  ) => void = () => {};
   export let onUseSpellSlot: (combatantId: string, blockId: string, rank: number) => void = () => {};
   export let onRestoreSpellSlot: (combatantId: string, blockId: string, rank: number) => void = () => {};
   export let onUseFocusPoint: (combatantId: string, blockId: string) => void = () => {};
@@ -123,8 +132,8 @@
             <li>
               <AttackRow
                 attack={attack as Attack}
-                onRollAttack={(a, v) => onRollAttack(combatant.id, a, v)}
-                onRollDamage={(a) => onRollDamage(combatant.id, a)}
+                onRollAttack={(a, v, origin) => onRollAttack(combatant.id, a, v, origin)}
+                onRollDamage={(a, origin) => onRollDamage(combatant.id, a, origin)}
               />
             </li>
           {/each}

--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -1,37 +1,25 @@
 <script lang="ts">
-  import type { Ability, ActionCost, Attack, CombatantState, DamageComponent } from '../domain';
+  import type { Ability, Attack, CombatantState } from '../domain';
   import { templateLabel } from '$lib/template-label';
+  import { formatModifier } from '$lib/abilities/format-damage';
+  import type { MapVariant } from '$lib/dice/map';
   import Chip from './ui/Chip.svelte';
   import NotesEditor from './NotesEditor.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import AbilityCard from './details/AbilityCard.svelte';
+  import AttackRow from './details/AttackRow.svelte';
+  import SpellcastingBlockView from './details/SpellcastingBlockView.svelte';
 
   export let combatant: CombatantState | undefined;
   export let onSetNote: (combatantId: string, note: string | null) => void;
-
-  function formatDamage(damage: DamageComponent[]): string {
-    return damage
-      .map((d) => {
-        const dice = d.dice && d.dieSize ? `${d.dice}d${d.dieSize}` : '';
-        const bonus = d.bonus ? (d.bonus > 0 ? `+${d.bonus}` : `${d.bonus}`) : '';
-        const persistent = d.persistent ? ' persistent' : '';
-        const head = `${dice}${bonus}` || (d.bonus === 0 ? '0' : '');
-        const tail = `${d.type}${persistent}`;
-        return head ? `${head} ${tail}` : tail;
-      })
-      .join(' + ');
-  }
-
-  function formatActionCost(cost: ActionCost | undefined): string {
-    if (cost === undefined) return '';
-    if (cost === 'free') return 'Free action';
-    if (cost === 'reaction') return 'Reaction';
-    if (cost === 1) return '1 action';
-    return `${cost} actions`;
-  }
-
-  function formatModifier(value: number): string {
-    return value >= 0 ? `+${value}` : `${value}`;
-  }
+  export let onRollAttack: (combatantId: string, attack: Attack, variant: MapVariant) => void = () => {};
+  export let onRollDamage: (combatantId: string, attack: Attack) => void = () => {};
+  export let onUseSpellSlot: (combatantId: string, blockId: string, rank: number) => void = () => {};
+  export let onRestoreSpellSlot: (combatantId: string, blockId: string, rank: number) => void = () => {};
+  export let onUseFocusPoint: (combatantId: string, blockId: string) => void = () => {};
+  export let onRestoreFocusPoint: (combatantId: string, blockId: string) => void = () => {};
+  export let onUseInnateSpell: (combatantId: string, blockId: string, spellSlug: string) => void = () => {};
+  export let onRestoreInnateSpell: (combatantId: string, blockId: string, spellSlug: string) => void = () => {};
 
   function templateChipVariant(adjustment: 'elite' | 'weak' | undefined) {
     if (adjustment === 'elite') return 'warning';
@@ -105,55 +93,74 @@
       </dl>
     </section>
 
+    {#if combatant.passiveAbilities.length > 0}
+      <section class="details__section" aria-label="Passive Abilities">
+        <SectionLabel as="h3">Passive Abilities</SectionLabel>
+        <ul class="entry-list">
+          {#each combatant.passiveAbilities as ability, i (i)}
+            <li><AbilityCard ability={ability as Ability} /></li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    {#if combatant.reactiveAbilities.length > 0}
+      <section class="details__section" aria-label="Reactive Abilities">
+        <SectionLabel as="h3">Reactive Abilities</SectionLabel>
+        <ul class="entry-list">
+          {#each combatant.reactiveAbilities as ability, i (i)}
+            <li><AbilityCard ability={ability as Ability} /></li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
     {#if combatant.attacks.length > 0}
       <section class="details__section" aria-label="Attacks">
         <SectionLabel as="h3">Attacks</SectionLabel>
         <ul class="entry-list">
-          {#each combatant.attacks as attack, attackIndex (attackIndex)}
-            {@const a = attack as Attack}
+          {#each combatant.attacks as attack, i (i)}
             <li>
-              <div class="entry-head">
-                <span class="entry-name">{a.name}</span>
-                <span class="muted">({a.type})</span>
-                <span class="entry-modifier">{formatModifier(a.modifier)}</span>
-              </div>
-              {#if a.damage.length > 0}
-                <div class="entry-meta entry-meta--mono">{formatDamage(a.damage)}</div>
-              {/if}
+              <AttackRow
+                attack={attack as Attack}
+                onRollAttack={(a, v) => onRollAttack(combatant.id, a, v)}
+                onRollDamage={(a) => onRollDamage(combatant.id, a)}
+              />
             </li>
           {/each}
         </ul>
       </section>
     {/if}
 
-    {#each [
-      { title: 'Passive Abilities', list: combatant.passiveAbilities },
-      { title: 'Reactive Abilities', list: combatant.reactiveAbilities },
-      { title: 'Active Abilities', list: combatant.activeAbilities }
-    ] as group (group.title)}
-      {#if group.list.length > 0}
-        <section class="details__section" aria-label={group.title}>
-          <SectionLabel as="h3">{group.title}</SectionLabel>
-          <ul class="entry-list">
-            {#each group.list as ability, abilityIndex (abilityIndex)}
-              {@const ab = ability as Ability}
-              <li>
-                <div class="entry-head">
-                  <span class="entry-name">{ab.name}</span>
-                  {#if ab.actions !== undefined}
-                    <span class="entry-cost">{formatActionCost(ab.actions)}</span>
-                  {/if}
-                </div>
-                {#if ab.frequency}<div class="entry-meta"><strong>Frequency:</strong> {ab.frequency}</div>{/if}
-                {#if ab.trigger}<div class="entry-meta"><strong>Trigger:</strong> {ab.trigger}</div>{/if}
-                {#if ab.requirements}<div class="entry-meta"><strong>Requirements:</strong> {ab.requirements}</div>{/if}
-                <p class="entry-desc">{ab.description}</p>
-              </li>
-            {/each}
-          </ul>
-        </section>
-      {/if}
-    {/each}
+    {#if combatant.activeAbilities.length > 0}
+      <section class="details__section" aria-label="Active Abilities">
+        <SectionLabel as="h3">Active Abilities</SectionLabel>
+        <ul class="entry-list">
+          {#each combatant.activeAbilities as ability, i (i)}
+            <li><AbilityCard ability={ability as Ability} /></li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    {#if combatant.spellcasting && combatant.spellcasting.length > 0}
+      <section class="details__section" aria-label="Spellcasting">
+        <SectionLabel as="h3">Spellcasting</SectionLabel>
+        <div class="spellcasting-stack">
+          {#each combatant.spellcasting as block (block.blockId)}
+            <SpellcastingBlockView
+              {block}
+              onUseSlot={(blockId, rank) => onUseSpellSlot(combatant.id, blockId, rank)}
+              onRestoreSlot={(blockId, rank) => onRestoreSpellSlot(combatant.id, blockId, rank)}
+              onUseFocus={(blockId) => onUseFocusPoint(combatant.id, blockId)}
+              onRestoreFocus={(blockId) => onRestoreFocusPoint(combatant.id, blockId)}
+              onUseInnate={(blockId, slug) => onUseInnateSpell(combatant.id, blockId, slug)}
+              onRestoreInnate={(blockId, slug) => onRestoreInnateSpell(combatant.id, blockId, slug)}
+            />
+          {/each}
+        </div>
+      </section>
+    {/if}
 
     <section class="details__section" aria-label="Notes">
       <SectionLabel as="h3">GM Notes</SectionLabel>
@@ -294,50 +301,8 @@
     padding-top: 0;
   }
 
-  .entry-head {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-2);
-    flex-wrap: wrap;
-  }
-
-  .entry-name {
-    color: var(--color-ink);
-    font-size: var(--text-base);
-    font-weight: 600;
-  }
-
-  .entry-modifier {
-    margin-left: auto;
-    color: var(--color-red);
-    font-family: var(--font-mono);
-    font-size: var(--text-base);
-    font-weight: 700;
-    border-bottom: 2px solid var(--color-red);
-    padding: 0 4px;
-  }
-
-  .entry-meta {
-    margin-top: 2px;
-    color: var(--color-ink-soft);
-    font-size: var(--text-base);
-  }
-
-  .entry-meta--mono {
-    font-family: var(--font-mono);
-  }
-
-  .entry-cost {
-    color: var(--color-ink-mute);
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-wide);
-  }
-
-  .entry-desc {
-    margin: var(--space-1) 0 0;
-    color: var(--color-ink);
-    font-size: var(--text-base);
-    line-height: var(--leading-relaxed);
+  .spellcasting-stack {
+    display: grid;
+    gap: var(--space-3);
   }
 </style>

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -115,7 +115,7 @@ describe('CombatantDetailsPanel', () => {
     expect(screen.getByRole('button', { name: 'Roll Claw 3rd attack (+7)' })).toBeInTheDocument();
   });
 
-  test('clicking attack button forwards onRollAttack with the combatant id and variant', async () => {
+  test('clicking attack button forwards onRollAttack with combatant id, variant, and click origin', async () => {
     const onRollAttack = vi.fn();
     renderPanel(
       combatant('spinesnapper', {
@@ -131,9 +131,10 @@ describe('CombatantDetailsPanel', () => {
     expect(onRollAttack.mock.calls[0][0]).toBe('spinesnapper');
     expect(onRollAttack.mock.calls[0][1].name).toBe('Maul');
     expect(onRollAttack.mock.calls[0][2]).toMatchObject({ step: 1, modifier: 10 });
+    expect(onRollAttack.mock.calls[0][3]).toEqual(expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }));
   });
 
-  test('clicking damage button forwards onRollDamage with the attack', () => {
+  test('clicking damage button forwards onRollDamage with the attack and click origin', () => {
     const onRollDamage = vi.fn();
     renderPanel(
       combatant('spinesnapper', {
@@ -154,6 +155,7 @@ describe('CombatantDetailsPanel', () => {
     expect(onRollDamage).toHaveBeenCalledTimes(1);
     expect(onRollDamage.mock.calls[0][0]).toBe('spinesnapper');
     expect(onRollDamage.mock.calls[0][1].name).toBe('Maul');
+    expect(onRollDamage.mock.calls[0][2]).toEqual(expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }));
   });
 
   test('omits each ability sub-section when its array is empty', () => {

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -4,8 +4,14 @@ import { combatant } from '../domain/test-support';
 import type { CombatantState } from '../domain';
 import CombatantDetailsPanel from './CombatantDetailsPanel.svelte';
 
-function renderPanel(c: CombatantState | undefined, onSetNote = vi.fn()) {
-  return render(CombatantDetailsPanel, { props: { combatant: c, onSetNote } });
+function renderPanel(c: CombatantState | undefined, props: Record<string, unknown> = {}) {
+  return render(CombatantDetailsPanel, {
+    props: {
+      combatant: c,
+      onSetNote: vi.fn(),
+      ...props
+    }
+  });
 }
 
 describe('CombatantDetailsPanel', () => {
@@ -68,7 +74,7 @@ describe('CombatantDetailsPanel', () => {
     expect(screen.queryByLabelText('Attacks')).not.toBeInTheDocument();
   });
 
-  test('renders attacks with name, type, modifier, and damage', () => {
+  test('renders attacks with name, type, and three MAP buttons', () => {
     renderPanel(
       combatant('goblin-1', {
         attacks: [
@@ -84,31 +90,70 @@ describe('CombatantDetailsPanel', () => {
     );
     const attacks = screen.getByLabelText('Attacks');
     expect(attacks).toHaveTextContent('Longsword');
-    expect(attacks).toHaveTextContent('(melee)');
-    expect(attacks).toHaveTextContent('+12');
-    expect(attacks).toHaveTextContent('1d8+3 slashing');
+    expect(attacks).toHaveTextContent('melee');
+    expect(screen.getByRole('button', { name: 'Roll Longsword 1st attack (+12)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Longsword 2nd attack (+7)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Longsword 3rd attack (+2)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Longsword damage (1d8+3 slashing)' })).toBeInTheDocument();
   });
 
-  test('renders multi-component damage with persistent suffix and bonus-only piece', () => {
+  test('agile attack uses -4/-8 MAP', () => {
     renderPanel(
-      combatant('flame-drake-1', {
+      combatant('goblin-1', {
         attacks: [
           {
-            name: 'Bite',
+            name: 'Claw',
             type: 'melee',
-            modifier: 14,
-            traits: ['fire'],
-            damage: [
-              { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
-              { dice: 1, dieSize: 6, type: 'fire', persistent: true },
-              { bonus: 2, type: 'precision' }
-            ]
+            modifier: 15,
+            traits: ['agile'],
+            damage: [{ dice: 2, dieSize: 4, bonus: 8, type: 'slashing' }]
           }
         ]
       })
     );
-    const damageLine = screen.getByText(/2d8\+4 piercing/);
-    expect(damageLine).toHaveTextContent('2d8+4 piercing + 1d6 fire persistent + +2 precision');
+    expect(screen.getByRole('button', { name: 'Roll Claw 2nd attack (+11)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Claw 3rd attack (+7)' })).toBeInTheDocument();
+  });
+
+  test('clicking attack button forwards onRollAttack with the combatant id and variant', async () => {
+    const onRollAttack = vi.fn();
+    renderPanel(
+      combatant('spinesnapper', {
+        attacks: [
+          { name: 'Maul', type: 'melee', modifier: 15, traits: [], damage: [] }
+        ]
+      }),
+      { onRollAttack }
+    );
+    const second = screen.getByRole('button', { name: 'Roll Maul 2nd attack (+10)' });
+    second.click();
+    expect(onRollAttack).toHaveBeenCalledTimes(1);
+    expect(onRollAttack.mock.calls[0][0]).toBe('spinesnapper');
+    expect(onRollAttack.mock.calls[0][1].name).toBe('Maul');
+    expect(onRollAttack.mock.calls[0][2]).toMatchObject({ step: 1, modifier: 10 });
+  });
+
+  test('clicking damage button forwards onRollDamage with the attack', () => {
+    const onRollDamage = vi.fn();
+    renderPanel(
+      combatant('spinesnapper', {
+        attacks: [
+          {
+            name: 'Maul',
+            type: 'melee',
+            modifier: 15,
+            traits: [],
+            damage: [{ dice: 1, dieSize: 12, bonus: 10, type: 'bludgeoning' }]
+          }
+        ]
+      }),
+      { onRollDamage }
+    );
+    const dmg = screen.getByRole('button', { name: 'Roll Maul damage (1d12+10 bludgeoning)' });
+    dmg.click();
+    expect(onRollDamage).toHaveBeenCalledTimes(1);
+    expect(onRollDamage.mock.calls[0][0]).toBe('spinesnapper');
+    expect(onRollDamage.mock.calls[0][1].name).toBe('Maul');
   });
 
   test('omits each ability sub-section when its array is empty', () => {
@@ -140,7 +185,61 @@ describe('CombatantDetailsPanel', () => {
 
     const active = screen.getByLabelText('Active Abilities');
     expect(active).toHaveTextContent('Brutal Charge');
-    expect(active).toHaveTextContent('2 actions');
+    // Action cost now rendered as glyph; the aria-label/title carries the readable form
+    expect(active.querySelector('[title="2 actions"]')).not.toBeNull();
+  });
+
+  test('renders degree-of-success outcomes in their own labeled rows', () => {
+    renderPanel(
+      combatant('spinesnapper', {
+        activeAbilities: [
+          {
+            name: 'Brutal Blow',
+            actions: 2,
+            description:
+              'The spinesnapper makes a Strike. If it hits, attempt a DC 22 Fortitude save.\n' +
+              'Critical Success The creature is unaffected.\n' +
+              'Success The creature is unaffected.\n' +
+              'Failure The creature is pushed 10 feet.\n' +
+              'Critical Failure The target is pushed 10 feet and knocked prone.'
+          }
+        ]
+      })
+    );
+    const active = screen.getByLabelText('Active Abilities');
+    expect(active).toHaveTextContent('Critical Success');
+    expect(active).toHaveTextContent('The target is pushed 10 feet and knocked prone.');
+  });
+
+  test('omits spellcasting section when combatant has none', () => {
+    renderPanel(combatant('fighter-1'));
+    expect(screen.queryByLabelText('Spellcasting')).not.toBeInTheDocument();
+  });
+
+  test('renders spellcasting block with slot pips that fire onUseSpellSlot', () => {
+    const onUseSpellSlot = vi.fn();
+    renderPanel(
+      combatant('yaashka', {
+        spellcasting: [
+          {
+            blockId: 'b1',
+            name: 'Divine Prepared',
+            tradition: 'divine',
+            type: 'prepared',
+            dc: 24,
+            slots: { 3: 2 },
+            entries: [{ spellSlug: 'harm', name: 'Harm', level: 3 }]
+          }
+        ]
+      }),
+      { onUseSpellSlot }
+    );
+    const sc = screen.getByLabelText('Spellcasting');
+    expect(sc).toHaveTextContent('Divine Prepared');
+    expect(sc).toHaveTextContent('Harm');
+    const useBtn = screen.getAllByRole('button', { name: 'Use a 3rd-rank slot' })[0];
+    useBtn.click();
+    expect(onUseSpellSlot).toHaveBeenCalledWith('yaashka', 'b1', 3);
   });
 
   test('renders existing notes inside the Notes section', () => {
@@ -157,7 +256,7 @@ describe('CombatantDetailsPanel', () => {
 
   test('committing a note forwards onSetNote with the combatant id', async () => {
     const onSetNote = vi.fn();
-    renderPanel(combatant('goblin-1', { notes: '' }), onSetNote);
+    renderPanel(combatant('goblin-1', { notes: '' }), { onSetNote });
     const placeholder = screen.getByRole('button', { name: 'Edit note' });
     placeholder.click();
     const textarea = await screen.findByRole('textbox', { name: 'Edit note' });

--- a/src/components/RollBubble.svelte
+++ b/src/components/RollBubble.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { fade, fly } from 'svelte/transition';
+
+  export let x: number;
+  export let y: number;
+  export let total: string;
+  export let detail: string = '';
+  export let tone: 'normal' | 'crit' | 'fumble' | 'damage' = 'normal';
+  export let badge: string = '';
+</script>
+
+<div
+  class="bubble bubble--{tone}"
+  style="left: {x}px; top: {y}px;"
+  role="status"
+  aria-live="polite"
+  in:fly={{ y: 12, duration: 140 }}
+  out:fade={{ duration: 320 }}
+>
+  {#if badge}
+    <span class="bubble__badge">{badge}</span>
+  {/if}
+  <span class="bubble__total">{total}</span>
+  {#if detail}
+    <span class="bubble__detail">{detail}</span>
+  {/if}
+</div>
+
+<style>
+  .bubble {
+    position: fixed;
+    transform: translate(-50%, -100%) translateY(-12px);
+    pointer-events: none;
+    z-index: 9999;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 6px 12px;
+    background: var(--color-panel);
+    border: 2px solid var(--color-ink);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    font-family: var(--font-serif);
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .bubble__total {
+    color: var(--color-ink);
+    font-size: 22px;
+    font-weight: 700;
+  }
+
+  .bubble__detail {
+    color: var(--color-ink-soft);
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
+
+  .bubble__badge {
+    color: var(--color-ink-mute);
+    font-family: var(--font-sans);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .bubble--crit {
+    border-color: var(--color-green);
+    background: var(--color-panel);
+  }
+  .bubble--crit .bubble__total { color: var(--color-green); font-size: 28px; }
+  .bubble--crit .bubble__badge { color: var(--color-green); }
+
+  .bubble--fumble {
+    border-color: var(--color-red);
+  }
+  .bubble--fumble .bubble__total { color: var(--color-red); font-size: 28px; }
+  .bubble--fumble .bubble__badge { color: var(--color-red); }
+
+  .bubble--damage {
+    border-color: var(--color-red);
+  }
+  .bubble--damage .bubble__total { color: var(--color-red); }
+</style>

--- a/src/components/details/AbilityCard.svelte
+++ b/src/components/details/AbilityCard.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import type { Ability } from '../../domain';
+  import { parseDegrees, type Degree } from '$lib/abilities/parse-degrees';
+  import ActionGlyph from './ActionGlyph.svelte';
+
+  export let ability: Ability;
+
+  $: parsed = parseDegrees(ability.description);
+
+  const labelMap: Record<Degree, string> = {
+    critSuccess: 'Critical Success',
+    success: 'Success',
+    failure: 'Failure',
+    critFailure: 'Critical Failure'
+  };
+</script>
+
+<article class="ability">
+  <header class="ability__head">
+    <span class="ability__name">{ability.name}</span>
+    {#if ability.actions !== undefined}
+      <ActionGlyph cost={ability.actions} />
+    {/if}
+  </header>
+  {#if ability.frequency}
+    <div class="ability__meta"><strong>Frequency:</strong> {ability.frequency}</div>
+  {/if}
+  {#if ability.trigger}
+    <div class="ability__meta"><strong>Trigger:</strong> {ability.trigger}</div>
+  {/if}
+  {#if ability.requirements}
+    <div class="ability__meta"><strong>Requirements:</strong> {ability.requirements}</div>
+  {/if}
+
+  {#if parsed.preface}
+    <p class="ability__desc">{parsed.preface}</p>
+  {/if}
+  {#if parsed.outcomes.length > 0}
+    <dl class="dos">
+      {#each parsed.outcomes as outcome (outcome.degree)}
+        <div class="dos__row dos__row--{outcome.degree}">
+          <dt>{labelMap[outcome.degree]}</dt>
+          <dd>{outcome.text}</dd>
+        </div>
+      {/each}
+    </dl>
+  {/if}
+</article>
+
+<style>
+  .ability {
+    display: block;
+  }
+
+  .ability__head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .ability__name {
+    color: var(--color-ink);
+    font-size: var(--text-base);
+    font-weight: 600;
+  }
+
+  .ability__meta {
+    margin-top: 2px;
+    color: var(--color-ink-soft);
+    font-size: var(--text-base);
+  }
+
+  .ability__desc {
+    margin: var(--space-1) 0 0;
+    color: var(--color-ink);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+  }
+
+  .dos {
+    display: grid;
+    gap: 4px;
+    margin: var(--space-2) 0 0;
+  }
+
+  .dos__row {
+    display: grid;
+    grid-template-columns: minmax(120px, max-content) 1fr;
+    gap: var(--space-2);
+    padding: 4px 8px;
+    border-left: 3px solid var(--color-rule);
+    background: rgba(255, 255, 255, 0.4);
+    border-radius: 0 4px 4px 0;
+  }
+
+  .dos__row dt {
+    margin: 0;
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+  }
+
+  .dos__row dd {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+  }
+
+  .dos__row--critSuccess { border-left-color: var(--color-green); }
+  .dos__row--critSuccess dt { color: var(--color-green); }
+
+  .dos__row--success { border-left-color: var(--color-blue); }
+  .dos__row--success dt { color: var(--color-blue); }
+
+  .dos__row--failure { border-left-color: var(--color-amber); }
+  .dos__row--failure dt { color: var(--color-amber); }
+
+  .dos__row--critFailure { border-left-color: var(--color-red); }
+  .dos__row--critFailure dt { color: var(--color-red); }
+</style>

--- a/src/components/details/ActionGlyph.svelte
+++ b/src/components/details/ActionGlyph.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { ActionCost } from '../../domain';
+  import { actionGlyph } from '$lib/abilities/action-glyph';
+
+  export let cost: ActionCost | undefined;
+
+  $: info = actionGlyph(cost);
+</script>
+
+{#if info.glyph}
+  <span class="action-glyph" aria-label={info.aria} title={info.aria}>{info.glyph}</span>
+{/if}
+
+<style>
+  .action-glyph {
+    display: inline-block;
+    color: var(--color-red);
+    font-family: var(--font-serif);
+    font-size: var(--text-base);
+    font-weight: 700;
+    letter-spacing: -1px;
+    line-height: 1;
+  }
+</style>

--- a/src/components/details/AttackRow.svelte
+++ b/src/components/details/AttackRow.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import type { Attack } from '../../domain';
+  import { mapVariants, type MapVariant } from '$lib/dice/map';
+  import { formatDamage, formatModifier } from '$lib/abilities/format-damage';
+
+  export let attack: Attack;
+  export let onRollAttack: (attack: Attack, variant: MapVariant) => void;
+  export let onRollDamage: (attack: Attack) => void;
+
+  $: variants = mapVariants(attack.modifier, attack.traits);
+  $: damageLabel = formatDamage(attack.damage);
+</script>
+
+<article class="row">
+  <header class="row__head">
+    <span class="row__name">{attack.name}</span>
+    <span class="row__type">{attack.type}</span>
+    {#if attack.traits.length > 0}
+      <span class="row__traits">{attack.traits.join(', ')}</span>
+    {/if}
+  </header>
+  <div class="row__rolls">
+    <div class="row__attacks">
+      {#each variants as variant (variant.step)}
+        <button
+          type="button"
+          class="btn btn--attack"
+          aria-label="Roll {attack.name} {variant.label} attack ({formatModifier(variant.modifier)})"
+          onclick={() => onRollAttack(attack, variant)}
+        >
+          <span class="btn__label">{variant.label}</span>
+          <span class="btn__mod">{formatModifier(variant.modifier)}</span>
+        </button>
+      {/each}
+    </div>
+    {#if attack.damage.length > 0}
+      <button
+        type="button"
+        class="btn btn--damage"
+        aria-label="Roll {attack.name} damage ({damageLabel})"
+        onclick={() => onRollDamage(attack)}
+      >
+        <span class="btn__label">Dmg</span>
+        <span class="btn__mod">{damageLabel}</span>
+      </button>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .row {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .row__head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .row__name {
+    color: var(--color-ink);
+    font-size: var(--text-base);
+    font-weight: 600;
+  }
+
+  .row__type {
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+
+  .row__traits {
+    color: var(--color-ink-soft);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    text-transform: lowercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .row__rolls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .row__attacks {
+    display: flex;
+    gap: 4px;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    color: var(--color-ink);
+    border: 1px solid var(--color-rule);
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .btn:hover {
+    background: var(--color-panel);
+    border-color: var(--color-ink);
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+  }
+
+  .btn__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+  }
+
+  .btn--attack .btn__mod {
+    color: var(--color-red);
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    font-weight: 700;
+  }
+
+  .btn--damage .btn__mod {
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+</style>

--- a/src/components/details/AttackRow.svelte
+++ b/src/components/details/AttackRow.svelte
@@ -4,8 +4,8 @@
   import { formatDamage, formatModifier } from '$lib/abilities/format-damage';
 
   export let attack: Attack;
-  export let onRollAttack: (attack: Attack, variant: MapVariant) => void;
-  export let onRollDamage: (attack: Attack) => void;
+  export let onRollAttack: (attack: Attack, variant: MapVariant, origin: { x: number; y: number }) => void;
+  export let onRollDamage: (attack: Attack, origin: { x: number; y: number }) => void;
 
   $: variants = mapVariants(attack.modifier, attack.traits);
   $: damageLabel = formatDamage(attack.damage);
@@ -26,7 +26,7 @@
           type="button"
           class="btn btn--attack"
           aria-label="Roll {attack.name} {variant.label} attack ({formatModifier(variant.modifier)})"
-          onclick={() => onRollAttack(attack, variant)}
+          onclick={(e) => onRollAttack(attack, variant, { x: e.clientX, y: e.clientY })}
         >
           <span class="btn__label">{variant.label}</span>
           <span class="btn__mod">{formatModifier(variant.modifier)}</span>
@@ -38,7 +38,7 @@
         type="button"
         class="btn btn--damage"
         aria-label="Roll {attack.name} damage ({damageLabel})"
-        onclick={() => onRollDamage(attack)}
+        onclick={(e) => onRollDamage(attack, { x: e.clientX, y: e.clientY })}
       >
         <span class="btn__label">Dmg</span>
         <span class="btn__mod">{damageLabel}</span>

--- a/src/components/details/SpellcastingBlockView.svelte
+++ b/src/components/details/SpellcastingBlockView.svelte
@@ -1,0 +1,377 @@
+<script lang="ts">
+  import type { CombatantSpellcasting } from '../../domain';
+  import { buildSpellcastingView } from '$lib/spellcasting/view';
+  import { formatModifier } from '$lib/abilities/format-damage';
+
+  export let block: CombatantSpellcasting;
+  export let onUseSlot: (blockId: string, rank: number) => void;
+  export let onRestoreSlot: (blockId: string, rank: number) => void;
+  export let onUseFocus: (blockId: string) => void;
+  export let onRestoreFocus: (blockId: string) => void;
+  export let onUseInnate: (blockId: string, spellSlug: string) => void;
+  export let onRestoreInnate: (blockId: string, spellSlug: string) => void;
+
+  $: view = buildSpellcastingView(block);
+
+  function ordinal(n: number): string {
+    const m10 = n % 10;
+    const m100 = n % 100;
+    if (m10 === 1 && m100 !== 11) return `${n}st`;
+    if (m10 === 2 && m100 !== 12) return `${n}nd`;
+    if (m10 === 3 && m100 !== 13) return `${n}rd`;
+    return `${n}th`;
+  }
+
+  function pipState(used: number, total: number): ('full' | 'empty')[] {
+    return Array.from({ length: total }, (_, i) => (i < total - used ? 'full' : 'empty'));
+  }
+
+  function suppressContext(e: Event) {
+    e.preventDefault();
+  }
+</script>
+
+<section class="block">
+  <header class="block__head">
+    <div class="block__title">{view.header.name}</div>
+    <div class="block__meta">
+      <span>{view.header.tradition}</span>
+      <span>·</span>
+      <span>{view.header.type}</span>
+      <span>·</span>
+      <span>DC {view.header.dc}</span>
+      {#if view.header.attackModifier !== undefined}
+        <span>·</span>
+        <span>attack {formatModifier(view.header.attackModifier)}</span>
+      {/if}
+    </div>
+  </header>
+
+  {#if view.type === 'prepared'}
+    <div class="ranks">
+      {#each view.ranks as rank (rank.rank)}
+        <div class="rank">
+          <div class="rank__head">
+            <span class="rank__label">{ordinal(rank.rank)}</span>
+            <span
+              class="rank__pips"
+              role="group"
+              aria-label="{ordinal(rank.rank)}-rank slots, {rank.total - rank.used}/{rank.total} remaining"
+            >
+              {#each pipState(rank.used, rank.total) as state, i (i)}
+                {#if state === 'full'}
+                  <button
+                    type="button"
+                    class="pip pip--full"
+                    aria-label="Use a {ordinal(rank.rank)}-rank slot"
+                    title="Click to use · right-click to restore"
+                    oncontextmenu={(e) => {
+                      e.preventDefault();
+                      onRestoreSlot(view.header.blockId, rank.rank);
+                    }}
+                    onclick={() => onUseSlot(view.header.blockId, rank.rank)}
+                  >●</button>
+                {:else}
+                  <button
+                    type="button"
+                    class="pip pip--empty"
+                    aria-label="Restore a {ordinal(rank.rank)}-rank slot"
+                    title="Click to restore"
+                    oncontextmenu={suppressContext}
+                    onclick={() => onRestoreSlot(view.header.blockId, rank.rank)}
+                  >○</button>
+                {/if}
+              {/each}
+            </span>
+            <span class="rank__count">{rank.total - rank.used}/{rank.total}</span>
+          </div>
+          {#if rank.entries.length > 0}
+            <ul class="spell-list">
+              {#each rank.entries as entry (entry.spellSlug)}
+                <li>{entry.name}{entry.count > 1 ? ` (×${entry.count})` : ''}</li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {:else if view.type === 'spontaneous'}
+    <div class="ranks">
+      {#each view.ranks as rank (rank.rank)}
+        <div class="rank">
+          <div class="rank__head">
+            <span class="rank__label">{ordinal(rank.rank)}</span>
+            <span class="rank__pips">
+              {#each pipState(rank.used, rank.total) as state, i (i)}
+                {#if state === 'full'}
+                  <button
+                    type="button"
+                    class="pip pip--full"
+                    aria-label="Use a {ordinal(rank.rank)}-rank slot"
+                    title="Click to use · right-click to restore"
+                    oncontextmenu={(e) => { e.preventDefault(); onRestoreSlot(view.header.blockId, rank.rank); }}
+                    onclick={() => onUseSlot(view.header.blockId, rank.rank)}
+                  >●</button>
+                {:else}
+                  <button
+                    type="button"
+                    class="pip pip--empty"
+                    aria-label="Restore a {ordinal(rank.rank)}-rank slot"
+                    title="Click to restore"
+                    onclick={() => onRestoreSlot(view.header.blockId, rank.rank)}
+                  >○</button>
+                {/if}
+              {/each}
+            </span>
+            <span class="rank__count">{rank.total - rank.used}/{rank.total}</span>
+          </div>
+          {#if rank.entries.length > 0}
+            <ul class="spell-list">
+              {#each rank.entries as entry (entry.spellSlug)}
+                <li>{entry.name}</li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {:else if view.type === 'focus'}
+    <div class="focus">
+      <div class="rank__head">
+        <span class="rank__label">Focus</span>
+        <span class="rank__pips">
+          {#each pipState(view.focus.used, view.focus.total) as state, i (i)}
+            {#if state === 'full'}
+              <button
+                type="button"
+                class="pip pip--full"
+                aria-label="Spend a focus point"
+                title="Click to spend · right-click to restore"
+                oncontextmenu={(e) => { e.preventDefault(); onRestoreFocus(view.header.blockId); }}
+                onclick={() => onUseFocus(view.header.blockId)}
+              >●</button>
+            {:else}
+              <button
+                type="button"
+                class="pip pip--empty"
+                aria-label="Restore a focus point"
+                title="Click to restore"
+                onclick={() => onRestoreFocus(view.header.blockId)}
+              >○</button>
+            {/if}
+          {/each}
+        </span>
+        <span class="rank__count">{view.focus.total - view.focus.used}/{view.focus.total}</span>
+      </div>
+      {#if view.entries.length > 0}
+        <ul class="spell-list">
+          {#each view.entries as entry (entry.spellSlug)}
+            <li>{entry.name} <span class="muted">({ordinal(entry.level)})</span></li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {:else}
+    {#if view.entries.length > 0}
+      <ul class="innate-list">
+        {#each view.entries as entry (entry.spellSlug)}
+          <li class="innate-row">
+            <span class="innate-name">{entry.name} <span class="muted">({ordinal(entry.level)})</span></span>
+            {#if entry.interactive && entry.max !== undefined}
+              <span class="innate-uses">
+                {#each pipState(entry.used, entry.max) as state, i (i)}
+                  {#if state === 'full'}
+                    <button
+                      type="button"
+                      class="pip pip--full"
+                      aria-label="Use {entry.name}"
+                      title="Click to use · right-click to restore"
+                      oncontextmenu={(e) => { e.preventDefault(); onRestoreInnate(view.header.blockId, entry.spellSlug); }}
+                      onclick={() => onUseInnate(view.header.blockId, entry.spellSlug)}
+                    >●</button>
+                  {:else}
+                    <button
+                      type="button"
+                      class="pip pip--empty"
+                      aria-label="Restore use of {entry.name}"
+                      title="Click to restore"
+                      onclick={() => onRestoreInnate(view.header.blockId, entry.spellSlug)}
+                    >○</button>
+                  {/if}
+                {/each}
+                <span class="rank__count">{entry.max - entry.used}/{entry.max}</span>
+              </span>
+            {:else}
+              <span class="innate-marker">{entry.marker}</span>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {/if}
+
+  {#if view.cantrips.length > 0}
+    <div class="cantrips">
+      <span class="cantrips__label">Cantrips ({ordinal(view.cantrips[0].level)})</span>
+      <ul class="spell-list">
+        {#each view.cantrips as c (c.spellSlug)}
+          <li>{c.name}</li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .block {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .block__head {
+    display: grid;
+    gap: 2px;
+  }
+
+  .block__title {
+    color: var(--color-ink);
+    font-family: var(--font-serif);
+    font-size: var(--text-base);
+    font-weight: 600;
+  }
+
+  .block__meta {
+    display: flex;
+    gap: 6px;
+    color: var(--color-ink-soft);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    text-transform: lowercase;
+  }
+
+  .ranks {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .rank {
+    display: grid;
+    gap: 2px;
+  }
+
+  .rank__head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .rank__label {
+    min-width: 36px;
+    color: var(--color-ink-mute);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+
+  .rank__pips {
+    display: inline-flex;
+    gap: 2px;
+    align-items: center;
+  }
+
+  .rank__count {
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .pip {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    width: 18px;
+    height: 18px;
+    line-height: 1;
+    font-size: 16px;
+    cursor: pointer;
+    color: var(--color-blue);
+  }
+
+  .pip--empty {
+    color: var(--color-ink-mute);
+  }
+
+  .pip:hover {
+    transform: scale(1.15);
+  }
+
+  .pip:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+    border-radius: 4px;
+  }
+
+  .spell-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 36px;
+    display: grid;
+    gap: 2px;
+    color: var(--color-ink);
+    font-size: var(--text-base);
+  }
+
+  .innate-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 4px;
+  }
+
+  .innate-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .innate-uses {
+    display: inline-flex;
+    gap: 2px;
+    align-items: center;
+  }
+
+  .innate-marker {
+    color: var(--color-ink-mute);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .cantrips {
+    display: grid;
+    gap: 4px;
+  }
+
+  .cantrips__label {
+    color: var(--color-ink-mute);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+
+  .muted {
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+</style>

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -2737,3 +2737,259 @@ describe('SET_INITIATIVE_SCORES', () => {
     expectSerializable(result.newState);
   });
 });
+
+describe('spellcasting commands', () => {
+  function casterEncounter(extras: Partial<import('./types').CombatantState> = {}) {
+    const caster = combatant('yaashka', {
+      name: 'Yaashka',
+      spellcasting: [
+        {
+          blockId: 'yaashka-prepared',
+          name: 'Divine Prepared Spells',
+          tradition: 'divine',
+          type: 'prepared',
+          dc: 24,
+          attackModifier: 16,
+          slots: { 1: 2, 3: 1 },
+          entries: [
+            { spellSlug: 'harm', name: 'Harm', level: 3 },
+            { spellSlug: 'command', name: 'Command', level: 1 }
+          ]
+        },
+        {
+          blockId: 'yaashka-focus',
+          name: 'Cleric Domain Spells',
+          tradition: 'divine',
+          type: 'focus',
+          dc: 24,
+          focusPoints: 1,
+          usedFocusPoints: 0,
+          entries: [{ spellSlug: 'athletic-rush', name: 'Athletic Rush', level: 3 }]
+        },
+        {
+          blockId: 'yaashka-innate',
+          name: 'Demon Innate',
+          tradition: 'divine',
+          type: 'innate',
+          dc: 22,
+          entries: [
+            {
+              spellSlug: 'wall-of-fire',
+              name: 'Wall of Fire',
+              level: 4,
+              frequency: { type: 'perDay', uses: 2 }
+            },
+            { spellSlug: 'detect-magic', name: 'Detect Magic', level: 1, frequency: { type: 'atWill' } }
+          ]
+        }
+      ],
+      ...extras
+    });
+
+    return activeEncounter({
+      combatants: { yaashka: caster },
+      initiative: { order: ['yaashka'], currentIndex: 0, delaying: [], scores: {} }
+    });
+  }
+
+  test('USE_SPELL_SLOT decrements remaining slots and emits event', () => {
+    const state = casterEncounter();
+    const result = applyCommand(
+      state,
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 3 }),
+      emptyEffects
+    );
+
+    expectEvents(result, [
+      {
+        type: 'spell-usage-changed',
+        combatantId: 'yaashka',
+        blockId: 'yaashka-prepared',
+        blockName: 'Divine Prepared Spells',
+        kind: 'slot',
+        action: 'used',
+        rank: 3
+      }
+    ]);
+    expect(result.newState.combatants.yaashka.spellcasting?.[0].usedSlots).toEqual({ 3: 1 });
+  });
+
+  test('USE_SPELL_SLOT rejects when no slots remain', () => {
+    const state = casterEncounter();
+    const after = applyCommand(
+      state,
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 3 }),
+      emptyEffects
+    ).newState;
+    const result = applyCommand(
+      after,
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 3 }),
+      emptyEffects
+    );
+    expectRejected(result, 'USE_SPELL_SLOT', 'No rank 3 slots remaining');
+  });
+
+  test('USE_SPELL_SLOT rejects unknown rank', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 9 }),
+      emptyEffects
+    );
+    expectRejected(result, 'USE_SPELL_SLOT', 'Block yaashka-prepared has no rank 9 slots');
+  });
+
+  test('RESTORE_SPELL_SLOT undoes a use', () => {
+    const used = applyCommand(
+      casterEncounter(),
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 1 }),
+      emptyEffects
+    ).newState;
+    const restored = applyCommand(
+      used,
+      command('RESTORE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 1 }),
+      emptyEffects
+    );
+    expect(restored.newState.combatants.yaashka.spellcasting?.[0].usedSlots).toEqual({ 1: 0 });
+    expect(restored.events[0]).toMatchObject({
+      type: 'spell-usage-changed',
+      kind: 'slot',
+      action: 'restored',
+      rank: 1
+    });
+  });
+
+  test('RESTORE_SPELL_SLOT rejects when none used', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('RESTORE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 1 }),
+      emptyEffects
+    );
+    expectRejected(result, 'RESTORE_SPELL_SLOT', 'No rank 1 slots used');
+  });
+
+  test('USE_FOCUS_POINT decrements pool and rejects on second use', () => {
+    const state = casterEncounter();
+    const after = applyCommand(
+      state,
+      command('USE_FOCUS_POINT', { combatantId: 'yaashka', blockId: 'yaashka-focus' }),
+      emptyEffects
+    );
+    expect(after.newState.combatants.yaashka.spellcasting?.[1].usedFocusPoints).toBe(1);
+
+    const second = applyCommand(
+      after.newState,
+      command('USE_FOCUS_POINT', { combatantId: 'yaashka', blockId: 'yaashka-focus' }),
+      emptyEffects
+    );
+    expectRejected(second, 'USE_FOCUS_POINT', 'No focus points remaining');
+  });
+
+  test('RESTORE_FOCUS_POINT rejects on prepared/innate blocks', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('RESTORE_FOCUS_POINT', { combatantId: 'yaashka', blockId: 'yaashka-prepared' }),
+      emptyEffects
+    );
+    expectRejected(result, 'RESTORE_FOCUS_POINT', 'Block yaashka-prepared is not a focus block');
+  });
+
+  test('USE_INNATE_SPELL tracks per-spell uses', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('USE_INNATE_SPELL', {
+        combatantId: 'yaashka',
+        blockId: 'yaashka-innate',
+        spellSlug: 'wall-of-fire'
+      }),
+      emptyEffects
+    );
+    expect(result.newState.combatants.yaashka.spellcasting?.[2].usedEntries).toEqual({
+      'wall-of-fire': 1
+    });
+    expect(result.events[0]).toMatchObject({
+      type: 'spell-usage-changed',
+      kind: 'innate',
+      action: 'used',
+      spellSlug: 'wall-of-fire',
+      spellName: 'Wall of Fire'
+    });
+  });
+
+  test('USE_INNATE_SPELL rejects at-will entries', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('USE_INNATE_SPELL', {
+        combatantId: 'yaashka',
+        blockId: 'yaashka-innate',
+        spellSlug: 'detect-magic'
+      }),
+      emptyEffects
+    );
+    expectRejected(result, 'USE_INNATE_SPELL', 'Spell detect-magic is not a per-day innate spell');
+  });
+
+  test('USE_INNATE_SPELL rejects when uses exhausted', () => {
+    const state = casterEncounter();
+    let after = applyCommand(
+      state,
+      command('USE_INNATE_SPELL', {
+        combatantId: 'yaashka',
+        blockId: 'yaashka-innate',
+        spellSlug: 'wall-of-fire'
+      }),
+      emptyEffects
+    ).newState;
+    after = applyCommand(
+      after,
+      command('USE_INNATE_SPELL', {
+        combatantId: 'yaashka',
+        blockId: 'yaashka-innate',
+        spellSlug: 'wall-of-fire'
+      }),
+      emptyEffects
+    ).newState;
+
+    const third = applyCommand(
+      after,
+      command('USE_INNATE_SPELL', {
+        combatantId: 'yaashka',
+        blockId: 'yaashka-innate',
+        spellSlug: 'wall-of-fire'
+      }),
+      emptyEffects
+    );
+    expectRejected(third, 'USE_INNATE_SPELL', 'No uses remaining for wall-of-fire');
+  });
+
+  test('rejects when combatant has no spellcasting', () => {
+    const fighter = combatant('fighter-1', { name: 'Fighter', spellcasting: undefined });
+    const state = activeEncounter({
+      combatants: { 'fighter-1': fighter },
+      initiative: { order: ['fighter-1'], currentIndex: 0, delaying: [], scores: {} }
+    });
+    const result = applyCommand(
+      state,
+      command('USE_SPELL_SLOT', { combatantId: 'fighter-1', blockId: 'x', rank: 1 }),
+      emptyEffects
+    );
+    expectRejected(result, 'USE_SPELL_SLOT', 'Combatant fighter-1 has no spellcasting blocks');
+  });
+
+  test('rejects when block id does not match', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('USE_FOCUS_POINT', { combatantId: 'yaashka', blockId: 'no-such-block' }),
+      emptyEffects
+    );
+    expectRejected(result, 'USE_FOCUS_POINT', 'Spellcasting block no-such-block not found');
+  });
+
+  test('result remains JSON-serializable', () => {
+    const result = applyCommand(
+      casterEncounter(),
+      command('USE_SPELL_SLOT', { combatantId: 'yaashka', blockId: 'yaashka-prepared', rank: 3 }),
+      emptyEffects
+    );
+    expectSerializable(result.newState);
+  });
+});

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -1,6 +1,7 @@
 import type {
   AppliedEffect,
   CombatantId,
+  CombatantSpellcasting,
   CombatantState,
   Command,
   CommandResult,
@@ -11,10 +12,14 @@ import type {
   EffectLibrary,
   EncounterPhase,
   EncounterState,
+  FocusPointPayload,
+  InnateSpellPayload,
   Prompt,
   PromptBoundary,
   PromptResolution,
-  TurnBoundarySuggestion
+  RestoreSpellSlotPayload,
+  TurnBoundarySuggestion,
+  UseSpellSlotPayload
 } from './types';
 
 const allowedPhases: Record<CommandType, EncounterPhase[]> = {
@@ -120,6 +125,18 @@ export function applyCommand(state: EncounterState, command: Command, effectLibr
       return markDead(state, command.payload.combatantId, effectLibrary);
     case 'REVIVE':
       return revive(state, command.payload.combatantId);
+    case 'USE_SPELL_SLOT':
+      return useSpellSlot(state, command.payload);
+    case 'RESTORE_SPELL_SLOT':
+      return restoreSpellSlot(state, command.payload);
+    case 'USE_FOCUS_POINT':
+      return useFocusPoint(state, command.payload);
+    case 'RESTORE_FOCUS_POINT':
+      return restoreFocusPoint(state, command.payload);
+    case 'USE_INNATE_SPELL':
+      return useInnateSpell(state, command.payload);
+    case 'RESTORE_INNATE_SPELL':
+      return restoreInnateSpell(state, command.payload);
     default:
       return reject(state, command.type, `${command.type} is not implemented in the first domain slice`);
   }
@@ -1670,6 +1687,231 @@ function revive(state: EncounterState, combatantId: CombatantId): CommandResult 
   }
 
   return updateCombatant(state, { ...combatant, isAlive: true }, [{ type: 'combatant-revived', combatantId }]);
+}
+
+interface SpellLookup {
+  combatant: CombatantState;
+  block: CombatantSpellcasting;
+  blockIndex: number;
+}
+
+function findSpellBlock(
+  state: EncounterState,
+  combatantId: CombatantId,
+  blockId: string,
+  commandType: CommandType
+): SpellLookup | { rejection: CommandResult } {
+  const combatant = state.combatants[combatantId];
+  if (!combatant) {
+    return { rejection: reject(state, commandType, `Combatant ${combatantId} not found`) };
+  }
+  const blocks = combatant.spellcasting;
+  if (!blocks || blocks.length === 0) {
+    return {
+      rejection: reject(state, commandType, `Combatant ${combatantId} has no spellcasting blocks`)
+    };
+  }
+  const blockIndex = blocks.findIndex((b) => b.blockId === blockId);
+  if (blockIndex === -1) {
+    return { rejection: reject(state, commandType, `Spellcasting block ${blockId} not found`) };
+  }
+  return { combatant, block: blocks[blockIndex], blockIndex };
+}
+
+function withUpdatedSpellBlock(
+  state: EncounterState,
+  combatant: CombatantState,
+  blockIndex: number,
+  updatedBlock: CombatantSpellcasting,
+  events: DomainEvent[]
+): CommandResult {
+  const blocks = combatant.spellcasting!.slice();
+  blocks[blockIndex] = updatedBlock;
+  return updateCombatant(state, { ...combatant, spellcasting: blocks }, events);
+}
+
+function useSpellSlot(state: EncounterState, payload: UseSpellSlotPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'USE_SPELL_SLOT');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  if (!block.slots || block.slots[payload.rank] === undefined) {
+    return reject(state, 'USE_SPELL_SLOT', `Block ${block.blockId} has no rank ${payload.rank} slots`);
+  }
+  const total = block.slots[payload.rank];
+  const used = block.usedSlots?.[payload.rank] ?? 0;
+  if (used >= total) {
+    return reject(state, 'USE_SPELL_SLOT', `No rank ${payload.rank} slots remaining`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = {
+    ...block,
+    usedSlots: { ...(block.usedSlots ?? {}), [payload.rank]: used + 1 }
+  };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'slot',
+      action: 'used',
+      rank: payload.rank
+    }
+  ]);
+}
+
+function restoreSpellSlot(state: EncounterState, payload: RestoreSpellSlotPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'RESTORE_SPELL_SLOT');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  if (!block.slots || block.slots[payload.rank] === undefined) {
+    return reject(state, 'RESTORE_SPELL_SLOT', `Block ${block.blockId} has no rank ${payload.rank} slots`);
+  }
+  const used = block.usedSlots?.[payload.rank] ?? 0;
+  if (used <= 0) {
+    return reject(state, 'RESTORE_SPELL_SLOT', `No rank ${payload.rank} slots used`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = {
+    ...block,
+    usedSlots: { ...(block.usedSlots ?? {}), [payload.rank]: used - 1 }
+  };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'slot',
+      action: 'restored',
+      rank: payload.rank
+    }
+  ]);
+}
+
+function useFocusPoint(state: EncounterState, payload: FocusPointPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'USE_FOCUS_POINT');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  if (block.type !== 'focus' || block.focusPoints === undefined) {
+    return reject(state, 'USE_FOCUS_POINT', `Block ${block.blockId} is not a focus block`);
+  }
+  const used = block.usedFocusPoints ?? 0;
+  if (used >= block.focusPoints) {
+    return reject(state, 'USE_FOCUS_POINT', `No focus points remaining`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = { ...block, usedFocusPoints: used + 1 };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'focus',
+      action: 'used'
+    }
+  ]);
+}
+
+function restoreFocusPoint(state: EncounterState, payload: FocusPointPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'RESTORE_FOCUS_POINT');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  if (block.type !== 'focus') {
+    return reject(state, 'RESTORE_FOCUS_POINT', `Block ${block.blockId} is not a focus block`);
+  }
+  const used = block.usedFocusPoints ?? 0;
+  if (used <= 0) {
+    return reject(state, 'RESTORE_FOCUS_POINT', `No focus points used`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = { ...block, usedFocusPoints: used - 1 };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'focus',
+      action: 'restored'
+    }
+  ]);
+}
+
+function useInnateSpell(state: EncounterState, payload: InnateSpellPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'USE_INNATE_SPELL');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  const entry = block.entries.find((e) => e.spellSlug === payload.spellSlug);
+  if (!entry) {
+    return reject(state, 'USE_INNATE_SPELL', `Spell ${payload.spellSlug} not found on block ${block.blockId}`);
+  }
+  if (!entry.frequency || entry.frequency.type !== 'perDay') {
+    return reject(
+      state,
+      'USE_INNATE_SPELL',
+      `Spell ${payload.spellSlug} is not a per-day innate spell`
+    );
+  }
+  const used = block.usedEntries?.[payload.spellSlug] ?? 0;
+  if (used >= entry.frequency.uses) {
+    return reject(state, 'USE_INNATE_SPELL', `No uses remaining for ${payload.spellSlug}`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = {
+    ...block,
+    usedEntries: { ...(block.usedEntries ?? {}), [payload.spellSlug]: used + 1 }
+  };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'innate',
+      action: 'used',
+      spellSlug: entry.spellSlug,
+      spellName: entry.name
+    }
+  ]);
+}
+
+function restoreInnateSpell(state: EncounterState, payload: InnateSpellPayload): CommandResult {
+  const lookup = findSpellBlock(state, payload.combatantId, payload.blockId, 'RESTORE_INNATE_SPELL');
+  if ('rejection' in lookup) return lookup.rejection;
+  const { combatant, block, blockIndex } = lookup;
+
+  const entry = block.entries.find((e) => e.spellSlug === payload.spellSlug);
+  if (!entry) {
+    return reject(state, 'RESTORE_INNATE_SPELL', `Spell ${payload.spellSlug} not found on block ${block.blockId}`);
+  }
+  const used = block.usedEntries?.[payload.spellSlug] ?? 0;
+  if (used <= 0) {
+    return reject(state, 'RESTORE_INNATE_SPELL', `No uses recorded for ${payload.spellSlug}`);
+  }
+
+  const updatedBlock: CombatantSpellcasting = {
+    ...block,
+    usedEntries: { ...(block.usedEntries ?? {}), [payload.spellSlug]: used - 1 }
+  };
+  return withUpdatedSpellBlock(state, combatant, blockIndex, updatedBlock, [
+    {
+      type: 'spell-usage-changed',
+      combatantId: combatant.id,
+      blockId: block.blockId,
+      blockName: block.name,
+      kind: 'innate',
+      action: 'restored',
+      spellSlug: entry.spellSlug,
+      spellName: entry.name
+    }
+  ]);
 }
 
 function updateHp(

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -271,6 +271,29 @@ export interface SetEffectDurationPayload {
   newDuration: Duration;
 }
 
+export interface UseSpellSlotPayload {
+  combatantId: CombatantId;
+  blockId: string;
+  rank: number;
+}
+
+export interface RestoreSpellSlotPayload {
+  combatantId: CombatantId;
+  blockId: string;
+  rank: number;
+}
+
+export interface FocusPointPayload {
+  combatantId: CombatantId;
+  blockId: string;
+}
+
+export interface InnateSpellPayload {
+  combatantId: CombatantId;
+  blockId: string;
+  spellSlug: string;
+}
+
 export type PromptResolution =
   | { type: 'accept' }
   | { type: 'setValue'; value: number }
@@ -309,12 +332,12 @@ export type Command =
   | BaseCommand<'SET_EFFECT_VALUE', SetEffectValuePayload>
   | BaseCommand<'MODIFY_EFFECT_VALUE', ModifyEffectValuePayload>
   | BaseCommand<'SET_EFFECT_DURATION', SetEffectDurationPayload>
-  | BaseCommand<'USE_SPELL_SLOT', Record<string, unknown>>
-  | BaseCommand<'RESTORE_SPELL_SLOT', Record<string, unknown>>
-  | BaseCommand<'USE_FOCUS_POINT', Record<string, unknown>>
-  | BaseCommand<'RESTORE_FOCUS_POINT', Record<string, unknown>>
-  | BaseCommand<'USE_INNATE_SPELL', Record<string, unknown>>
-  | BaseCommand<'RESTORE_INNATE_SPELL', Record<string, unknown>>
+  | BaseCommand<'USE_SPELL_SLOT', UseSpellSlotPayload>
+  | BaseCommand<'RESTORE_SPELL_SLOT', RestoreSpellSlotPayload>
+  | BaseCommand<'USE_FOCUS_POINT', FocusPointPayload>
+  | BaseCommand<'RESTORE_FOCUS_POINT', FocusPointPayload>
+  | BaseCommand<'USE_INNATE_SPELL', InnateSpellPayload>
+  | BaseCommand<'RESTORE_INNATE_SPELL', InnateSpellPayload>
   | BaseCommand<'SET_SPELL_SLOT_USAGE', Record<string, unknown>>
   | BaseCommand<'SET_FOCUS_USAGE', Record<string, unknown>>
   | BaseCommand<'SET_INNATE_USAGE', Record<string, unknown>>
@@ -443,6 +466,17 @@ export type DomainEvent =
       damageType?: string;
     }
   | { type: 'hp-reached-zero'; combatantId: CombatantId }
+  | {
+      type: 'spell-usage-changed';
+      combatantId: CombatantId;
+      blockId: string;
+      blockName: string;
+      kind: 'slot' | 'focus' | 'innate';
+      action: 'used' | 'restored';
+      rank?: number;
+      spellSlug?: string;
+      spellName?: string;
+    }
   | { type: 'command-rejected'; commandType: CommandType; reason: string };
 
 export type EffectCategory = 'condition' | 'spell' | 'affliction' | 'persistent-damage' | 'custom';

--- a/src/lib/abilities/action-glyph.test.ts
+++ b/src/lib/abilities/action-glyph.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { actionGlyph } from './action-glyph';
+
+describe('actionGlyph', () => {
+  test('1 action → ◆', () => {
+    expect(actionGlyph(1)).toEqual({ glyph: '◆', aria: '1 action' });
+  });
+
+  test('2 actions → ◆◆', () => {
+    expect(actionGlyph(2)).toEqual({ glyph: '◆◆', aria: '2 actions' });
+  });
+
+  test('3 actions → ◆◆◆', () => {
+    expect(actionGlyph(3)).toEqual({ glyph: '◆◆◆', aria: '3 actions' });
+  });
+
+  test('reaction → ↺', () => {
+    expect(actionGlyph('reaction')).toEqual({ glyph: '↺', aria: 'Reaction' });
+  });
+
+  test('free → ◇', () => {
+    expect(actionGlyph('free')).toEqual({ glyph: '◇', aria: 'Free action' });
+  });
+
+  test('undefined → empty glyph and label', () => {
+    expect(actionGlyph(undefined)).toEqual({ glyph: '', aria: '' });
+  });
+});

--- a/src/lib/abilities/action-glyph.ts
+++ b/src/lib/abilities/action-glyph.ts
@@ -1,0 +1,17 @@
+import type { ActionCost } from '../../domain';
+
+export interface ActionGlyphInfo {
+  glyph: string;
+  aria: string;
+}
+
+const EMPTY: ActionGlyphInfo = { glyph: '', aria: '' };
+
+export function actionGlyph(cost: ActionCost | undefined): ActionGlyphInfo {
+  if (cost === undefined) return EMPTY;
+  if (cost === 'free') return { glyph: '◇', aria: 'Free action' };
+  if (cost === 'reaction') return { glyph: '↺', aria: 'Reaction' };
+  if (cost === 1) return { glyph: '◆', aria: '1 action' };
+  if (cost === 2) return { glyph: '◆◆', aria: '2 actions' };
+  return { glyph: '◆◆◆', aria: '3 actions' };
+}

--- a/src/lib/abilities/format-damage.test.ts
+++ b/src/lib/abilities/format-damage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { formatDamage, formatModifier } from './format-damage';
+
+describe('formatDamage', () => {
+  test('renders single dice + bonus + type', () => {
+    expect(formatDamage([{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }])).toBe('1d8+3 slashing');
+  });
+
+  test('renders persistent suffix', () => {
+    expect(formatDamage([{ dice: 1, dieSize: 6, type: 'fire', persistent: true }])).toBe(
+      '1d6 fire persistent'
+    );
+  });
+
+  test('joins multiple components with " + "', () => {
+    expect(
+      formatDamage([
+        { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
+        { dice: 1, dieSize: 6, type: 'fire', persistent: true },
+        { bonus: 2, type: 'precision' }
+      ])
+    ).toBe('2d8+4 piercing + 1d6 fire persistent + +2 precision');
+  });
+
+  test('renders flat bonus-only damage', () => {
+    expect(formatDamage([{ bonus: 5, type: 'fire' }])).toBe('+5 fire');
+  });
+
+  test('renders dice-only damage with no bonus', () => {
+    expect(formatDamage([{ dice: 1, dieSize: 6, type: 'bleed' }])).toBe('1d6 bleed');
+  });
+});
+
+describe('formatModifier', () => {
+  test('prefixes positive with +', () => {
+    expect(formatModifier(7)).toBe('+7');
+  });
+  test('keeps negative with -', () => {
+    expect(formatModifier(-3)).toBe('-3');
+  });
+  test('renders zero as +0', () => {
+    expect(formatModifier(0)).toBe('+0');
+  });
+});

--- a/src/lib/abilities/format-damage.ts
+++ b/src/lib/abilities/format-damage.ts
@@ -1,0 +1,18 @@
+import type { DamageComponent } from '../../domain';
+
+export function formatDamage(damage: DamageComponent[]): string {
+  return damage
+    .map((d) => {
+      const dice = d.dice && d.dieSize ? `${d.dice}d${d.dieSize}` : '';
+      const bonus = d.bonus ? (d.bonus > 0 ? `+${d.bonus}` : `${d.bonus}`) : '';
+      const persistent = d.persistent ? ' persistent' : '';
+      const head = `${dice}${bonus}` || (d.bonus === 0 ? '0' : '');
+      const tail = `${d.type}${persistent}`;
+      return head ? `${head} ${tail}` : tail;
+    })
+    .join(' + ');
+}
+
+export function formatModifier(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}

--- a/src/lib/abilities/parse-degrees.test.ts
+++ b/src/lib/abilities/parse-degrees.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest';
+import { parseDegrees } from './parse-degrees';
+
+describe('parseDegrees', () => {
+  test('parses Brutal Blow with all four outcomes', () => {
+    const text =
+      'The spinesnapper makes a claw or weapon Strike. If it hits, in addition to dealing damage, the creature must attempt a DC 22 Fortitude saving throw, with the following effects.\n' +
+      'Critical Success The creature is unaffected and the spinesnapper is flat-footed until the start of its next turn.\n' +
+      'Success The creature is unaffected.\n' +
+      'Failure The creature is pushed 10 feet.\n' +
+      'Critical Failure The target is pushed 10 feet and knocked prone.';
+
+    const result = parseDegrees(text);
+
+    expect(result.preface).toMatch(/^The spinesnapper makes/);
+    expect(result.preface).toMatch(/with the following effects\.$/);
+    expect(result.outcomes).toHaveLength(4);
+    expect(result.outcomes[0]).toEqual({
+      degree: 'critSuccess',
+      text: 'The creature is unaffected and the spinesnapper is flat-footed until the start of its next turn.'
+    });
+    expect(result.outcomes[1]).toEqual({ degree: 'success', text: 'The creature is unaffected.' });
+    expect(result.outcomes[2]).toEqual({ degree: 'failure', text: 'The creature is pushed 10 feet.' });
+    expect(result.outcomes[3]).toEqual({
+      degree: 'critFailure',
+      text: 'The target is pushed 10 feet and knocked prone.'
+    });
+  });
+
+  test('returns empty outcomes when no degree labels appear', () => {
+    const text =
+      '30 feet. A creature that enters the aura must attempt a DC 21 Fortitude save. On a failure, the creature is sickened 1.';
+    const result = parseDegrees(text);
+    expect(result.preface).toBe(text);
+    expect(result.outcomes).toEqual([]);
+  });
+
+  test('does not split mid-prose "failure" inside a sentence', () => {
+    const text = 'On a failure, the creature is sickened 1, and on a critical failure, the creature also takes a -5 penalty.';
+    const result = parseDegrees(text);
+    expect(result.outcomes).toEqual([]);
+    expect(result.preface).toBe(text);
+  });
+
+  test('handles outcomes separated by colons', () => {
+    const text =
+      'The target attempts a Reflex save.\nCritical Success: Unaffected.\nSuccess: Half damage.\nFailure: Full damage.\nCritical Failure: Double damage.';
+    const result = parseDegrees(text);
+    expect(result.outcomes.map((o) => o.degree)).toEqual([
+      'critSuccess',
+      'success',
+      'failure',
+      'critFailure'
+    ]);
+    expect(result.outcomes[0].text).toBe('Unaffected.');
+    expect(result.outcomes[3].text).toBe('Double damage.');
+  });
+
+  test('empty input returns empty preface and outcomes', () => {
+    expect(parseDegrees('')).toEqual({ preface: '', outcomes: [] });
+  });
+});

--- a/src/lib/abilities/parse-degrees.ts
+++ b/src/lib/abilities/parse-degrees.ts
@@ -1,0 +1,57 @@
+export type Degree = 'critSuccess' | 'success' | 'failure' | 'critFailure';
+
+export interface DegreeOutcome {
+  degree: Degree;
+  text: string;
+}
+
+export interface ParsedAbility {
+  preface: string;
+  outcomes: DegreeOutcome[];
+}
+
+const LABEL_TO_DEGREE: Record<string, Degree> = {
+  'critical success': 'critSuccess',
+  'success': 'success',
+  'failure': 'failure',
+  'critical failure': 'critFailure'
+};
+
+const SPLIT_RE = /(?:^|\n)[ \t]*(Critical Success|Critical Failure|Success|Failure)\b[ \t:.\-]*/g;
+
+// Splits an ability description into a preface block and zero or more degree-of-success
+// outcomes. Recognises the four standard PF2e labels at the start of a line (allowing
+// leading spaces and an optional separator like ":", ".", or "-"). If no labels are
+// found, returns the whole text as preface with an empty outcomes list — the caller
+// renders the description unchanged.
+export function parseDegrees(description: string): ParsedAbility {
+  const text = description ?? '';
+
+  const matches: { index: number; label: string; end: number }[] = [];
+  for (const match of text.matchAll(SPLIT_RE)) {
+    if (match.index === undefined) continue;
+    const labelStart = match[0].indexOf(match[1], 0);
+    matches.push({
+      index: match.index + labelStart,
+      label: match[1],
+      end: match.index + match[0].length
+    });
+  }
+
+  if (matches.length === 0) {
+    return { preface: text.trim(), outcomes: [] };
+  }
+
+  const preface = text.slice(0, matches[0].index).trim();
+  const outcomes: DegreeOutcome[] = matches.map((m, i) => {
+    const next = matches[i + 1];
+    const sliceEnd = next ? next.index : text.length;
+    const body = text.slice(m.end, sliceEnd).trim();
+    return {
+      degree: LABEL_TO_DEGREE[m.label.toLowerCase()],
+      text: body
+    };
+  });
+
+  return { preface, outcomes };
+}

--- a/src/lib/combat-log/format.test.ts
+++ b/src/lib/combat-log/format.test.ts
@@ -330,6 +330,97 @@ describe('formatEvent — exhaustive over DomainEvent', () => {
       message: "ghost's turn (round 1)."
     });
   });
+
+  test('spell-usage-changed: slot used with remaining count', () => {
+    const caster = makeCombatant('yaashka', 'Yaashka');
+    const stateWithCaster: EncounterState = {
+      ...newEncounterState(),
+      combatants: {
+        yaashka: {
+          ...caster,
+          spellcasting: [
+            {
+              blockId: 'b1',
+              name: 'Divine Prepared',
+              tradition: 'divine',
+              type: 'prepared',
+              dc: 24,
+              slots: { 3: 3 },
+              usedSlots: { 3: 1 },
+              entries: []
+            }
+          ]
+        }
+      } as EncounterState['combatants']
+    };
+    expect(
+      fmt(
+        {
+          type: 'spell-usage-changed',
+          combatantId: 'yaashka',
+          blockId: 'b1',
+          blockName: 'Divine Prepared',
+          kind: 'slot',
+          action: 'used',
+          rank: 3
+        },
+        stateWithCaster
+      )
+    ).toMatchObject({ message: 'Yaashka cast a 3rd-rank spell (2/3 remaining).', tone: 'info' });
+  });
+
+  test('spell-usage-changed: slot restored', () => {
+    expect(
+      fmt({
+        type: 'spell-usage-changed',
+        combatantId: 'goblin-1',
+        blockId: 'b',
+        blockName: 'X',
+        kind: 'slot',
+        action: 'restored',
+        rank: 1
+      })
+    ).toMatchObject({ message: 'Goblin Warrior recovered a 1st-rank slot.' });
+  });
+
+  test('spell-usage-changed: focus used and restored', () => {
+    expect(
+      fmt({
+        type: 'spell-usage-changed',
+        combatantId: 'goblin-1',
+        blockId: 'b',
+        blockName: 'X',
+        kind: 'focus',
+        action: 'used'
+      })
+    ).toMatchObject({ message: 'Goblin Warrior spent a focus point.' });
+
+    expect(
+      fmt({
+        type: 'spell-usage-changed',
+        combatantId: 'goblin-1',
+        blockId: 'b',
+        blockName: 'X',
+        kind: 'focus',
+        action: 'restored'
+      })
+    ).toMatchObject({ message: 'Goblin Warrior recovered a focus point.' });
+  });
+
+  test('spell-usage-changed: innate used names the spell', () => {
+    expect(
+      fmt({
+        type: 'spell-usage-changed',
+        combatantId: 'goblin-1',
+        blockId: 'b',
+        blockName: 'X',
+        kind: 'innate',
+        action: 'used',
+        spellSlug: 'wall-of-fire',
+        spellName: 'Wall of Fire'
+      })
+    ).toMatchObject({ message: 'Goblin Warrior used Wall of Fire.' });
+  });
 });
 
 describe('formatEvents — batch with stable ids', () => {

--- a/src/lib/combat-log/format.ts
+++ b/src/lib/combat-log/format.ts
@@ -138,9 +138,80 @@ export function formatEvent(event: DomainEvent, options: FormatOptions): LogEntr
     }
     case 'hp-reached-zero':
       return entry(id, `${nameOf(state, event.combatantId)} dropped to 0 HP.`, 'danger');
+    case 'spell-usage-changed':
+      return entry(id, formatSpellUsage(state, event), 'info');
     case 'command-rejected':
       return entry(id, `${event.commandType} rejected: ${event.reason}.`, 'danger');
   }
+}
+
+function formatSpellUsage(
+  state: EncounterState,
+  event: Extract<DomainEvent, { type: 'spell-usage-changed' }>
+): string {
+  const target = nameOf(state, event.combatantId);
+  if (event.kind === 'slot') {
+    if (event.action === 'used') {
+      const remaining = remainingSlots(state, event.combatantId, event.blockId, event.rank);
+      const suffix = remaining ? ` (${remaining})` : '';
+      return `${target} cast a ${ordinal(event.rank ?? 0)}-rank spell${suffix}.`;
+    }
+    return `${target} recovered a ${ordinal(event.rank ?? 0)}-rank slot.`;
+  }
+  if (event.kind === 'focus') {
+    if (event.action === 'used') {
+      const remaining = remainingFocus(state, event.combatantId, event.blockId);
+      const suffix = remaining ? ` (${remaining})` : '';
+      return `${target} spent a focus point${suffix}.`;
+    }
+    return `${target} recovered a focus point.`;
+  }
+  // innate
+  if (event.action === 'used') {
+    const remaining = remainingInnate(state, event.combatantId, event.blockId, event.spellSlug);
+    const suffix = remaining ? ` (${remaining})` : '';
+    return `${target} used ${event.spellName ?? event.spellSlug ?? 'an innate spell'}${suffix}.`;
+  }
+  return `${target} recovered a use of ${event.spellName ?? event.spellSlug ?? 'an innate spell'}.`;
+}
+
+function remainingSlots(state: EncounterState, combatantId: CombatantId, blockId: string, rank: number | undefined): string {
+  if (rank === undefined) return '';
+  const block = state.combatants[combatantId]?.spellcasting?.find((b) => b.blockId === blockId);
+  if (!block?.slots) return '';
+  const total = block.slots[rank] ?? 0;
+  const used = block.usedSlots?.[rank] ?? 0;
+  return `${total - used}/${total} remaining`;
+}
+
+function remainingFocus(state: EncounterState, combatantId: CombatantId, blockId: string): string {
+  const block = state.combatants[combatantId]?.spellcasting?.find((b) => b.blockId === blockId);
+  if (!block || block.focusPoints === undefined) return '';
+  const used = block.usedFocusPoints ?? 0;
+  return `${block.focusPoints - used}/${block.focusPoints} remaining`;
+}
+
+function remainingInnate(
+  state: EncounterState,
+  combatantId: CombatantId,
+  blockId: string,
+  spellSlug: string | undefined
+): string {
+  if (!spellSlug) return '';
+  const block = state.combatants[combatantId]?.spellcasting?.find((b) => b.blockId === blockId);
+  const entry = block?.entries.find((e) => e.spellSlug === spellSlug);
+  if (!entry?.frequency || entry.frequency.type !== 'perDay') return '';
+  const used = block?.usedEntries?.[spellSlug] ?? 0;
+  return `${entry.frequency.uses - used}/${entry.frequency.uses} remaining`;
+}
+
+function ordinal(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return `${n}st`;
+  if (mod10 === 2 && mod100 !== 12) return `${n}nd`;
+  if (mod10 === 3 && mod100 !== 13) return `${n}rd`;
+  return `${n}th`;
 }
 
 /**

--- a/src/lib/dice/map.test.ts
+++ b/src/lib/dice/map.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { mapVariants } from './map';
+
+describe('mapVariants', () => {
+  test('non-agile attack: +0 / -5 / -10', () => {
+    expect(mapVariants(15, ['shove'])).toEqual([
+      { step: 0, label: '1st', modifier: 15 },
+      { step: 1, label: '2nd', modifier: 10 },
+      { step: 2, label: '3rd', modifier: 5 }
+    ]);
+  });
+
+  test('agile attack: +0 / -4 / -8', () => {
+    expect(mapVariants(15, ['agile'])).toEqual([
+      { step: 0, label: '1st', modifier: 15 },
+      { step: 1, label: '2nd', modifier: 11 },
+      { step: 2, label: '3rd', modifier: 7 }
+    ]);
+  });
+
+  test('agile detection is case-insensitive', () => {
+    expect(mapVariants(10, ['Agile'])[1].modifier).toBe(6);
+    expect(mapVariants(10, ['AGILE'])[2].modifier).toBe(2);
+  });
+
+  test('handles empty traits as non-agile', () => {
+    expect(mapVariants(8, [])).toEqual([
+      { step: 0, label: '1st', modifier: 8 },
+      { step: 1, label: '2nd', modifier: 3 },
+      { step: 2, label: '3rd', modifier: -2 }
+    ]);
+  });
+
+  test('propagates negative base modifiers correctly', () => {
+    expect(mapVariants(-2, ['agile'])).toEqual([
+      { step: 0, label: '1st', modifier: -2 },
+      { step: 1, label: '2nd', modifier: -6 },
+      { step: 2, label: '3rd', modifier: -10 }
+    ]);
+  });
+});

--- a/src/lib/dice/map.ts
+++ b/src/lib/dice/map.ts
@@ -1,0 +1,19 @@
+export interface MapVariant {
+  step: 0 | 1 | 2;
+  label: string;
+  modifier: number;
+}
+
+// Per pf2e-creature-types-spec §3.3, MAP penalties are not stored — they're
+// computed at display time from the base modifier and the agile trait.
+//   agile     →  +0 / -4 / -8
+//   non-agile →  +0 / -5 / -10
+export function mapVariants(baseModifier: number, traits: readonly string[] = []): MapVariant[] {
+  const agile = traits.some((t) => t.toLowerCase() === 'agile');
+  const step = agile ? 4 : 5;
+  return [
+    { step: 0, label: '1st', modifier: baseModifier },
+    { step: 1, label: '2nd', modifier: baseModifier - step },
+    { step: 2, label: '3rd', modifier: baseModifier - step * 2 }
+  ];
+}

--- a/src/lib/dice/roll.test.ts
+++ b/src/lib/dice/roll.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { rollAttack, rollD20, rollDamage } from './roll';
+
+describe('rollD20', () => {
+  test('returns 11 with deterministic 0.5 rng', () => {
+    expect(rollD20(() => 0.5)).toBe(11);
+  });
+
+  test('returns 1 at the lower bound', () => {
+    expect(rollD20(() => 0)).toBe(1);
+  });
+
+  test('returns 20 at the upper bound', () => {
+    // 0.9999... * 20 → 19, +1 = 20
+    expect(rollD20(() => 0.9999)).toBe(20);
+  });
+});
+
+describe('rollAttack', () => {
+  test('total = d20 + modifier', () => {
+    const result = rollAttack(7, () => 0.5);
+    expect(result).toEqual({ d20: 11, modifier: 7, total: 18 });
+  });
+
+  test('handles negative modifiers', () => {
+    const result = rollAttack(-2, () => 0);
+    expect(result).toEqual({ d20: 1, modifier: -2, total: -1 });
+  });
+});
+
+describe('rollDamage', () => {
+  test('rolls a single dice + bonus component', () => {
+    const result = rollDamage([{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }], () => 0.5);
+    // 0.5 * 8 = 4, +1 → 5; +3 = 8
+    expect(result.total).toBe(8);
+    expect(result.breakdown).toBe('1d8+3 slashing (8)');
+  });
+
+  test('sums multiple components and joins breakdown with " + "', () => {
+    const result = rollDamage(
+      [
+        { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
+        { dice: 1, dieSize: 6, type: 'fire', persistent: true }
+      ],
+      () => 0.5
+    );
+    // 2d8: 5+5 = 10, +4 = 14; 1d6: 4
+    expect(result.total).toBe(18);
+    expect(result.breakdown).toBe('2d8+4 piercing (14) + 1d6 fire persistent (4)');
+  });
+
+  test('flat bonus-only component renders bonus prefix', () => {
+    const result = rollDamage([{ bonus: 5, type: 'fire' }], () => 0.5);
+    expect(result.total).toBe(5);
+    expect(result.breakdown).toBe('+5 fire (5)');
+  });
+
+  test('dice-only component (e.g. persistent bleed)', () => {
+    const result = rollDamage([{ dice: 1, dieSize: 4, type: 'bleed', persistent: true }], () => 0);
+    // 0 * 4 → 0, +1 = 1
+    expect(result.total).toBe(1);
+    expect(result.breakdown).toBe('1d4 bleed persistent (1)');
+  });
+});

--- a/src/lib/dice/roll.ts
+++ b/src/lib/dice/roll.ts
@@ -1,0 +1,55 @@
+import type { DamageComponent } from '../../domain';
+
+export type Rng = () => number;
+
+const defaultRng: Rng = () => Math.random();
+
+export interface AttackRollResult {
+  d20: number;
+  modifier: number;
+  total: number;
+}
+
+export interface DamageRollResult {
+  total: number;
+  breakdown: string;
+}
+
+export function rollD20(rng: Rng = defaultRng): number {
+  return Math.floor(rng() * 20) + 1;
+}
+
+export function rollAttack(modifier: number, rng: Rng = defaultRng): AttackRollResult {
+  const d20 = rollD20(rng);
+  return { d20, modifier, total: d20 + modifier };
+}
+
+export function rollDamage(
+  components: readonly DamageComponent[],
+  rng: Rng = defaultRng
+): DamageRollResult {
+  let total = 0;
+  const parts: string[] = [];
+
+  for (const comp of components) {
+    let sub = 0;
+    const dicePart =
+      comp.dice && comp.dieSize ? `${comp.dice}d${comp.dieSize}` : '';
+    if (comp.dice && comp.dieSize) {
+      for (let i = 0; i < comp.dice; i++) {
+        sub += Math.floor(rng() * comp.dieSize) + 1;
+      }
+    }
+    const bonusPart = comp.bonus ? (comp.bonus > 0 ? `+${comp.bonus}` : `${comp.bonus}`) : '';
+    if (comp.bonus) sub += comp.bonus;
+
+    const persistent = comp.persistent ? ' persistent' : '';
+    const tail = `${comp.type}${persistent}`;
+    const formula = `${dicePart}${bonusPart}`;
+    const label = formula ? `${formula} ${tail}` : tail;
+    parts.push(`${label} (${sub})`);
+    total += sub;
+  }
+
+  return { total, breakdown: parts.join(' + ') };
+}

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import {
+  appendInfoLog,
   clampValue,
   combatantCardActions,
   combatantVisualState,
+  COMBAT_LOG_CAP,
   dispatchEncounterCommand,
   formatDuration,
   groupConditionsByCategory,
@@ -979,5 +981,36 @@ describe('resolveApplyChoice with note', () => {
       effectId: 'off-guard',
       note: undefined
     });
+  });
+});
+
+describe('appendInfoLog', () => {
+  test('appends an entry with the supplied id, message, and tone', () => {
+    const state = newEncounterState();
+    const next = appendInfoLog(state, 'roll-1', 'Goblin attacked at +12: 18', 'info');
+    expect(next.combatLog).toEqual([{ id: 'roll-1', message: 'Goblin attacked at +12: 18', tone: 'info' }]);
+  });
+
+  test('defaults tone to info', () => {
+    const next = appendInfoLog(newEncounterState(), 'roll-1', 'msg');
+    expect(next.combatLog[0].tone).toBe('info');
+  });
+
+  test('respects COMBAT_LOG_CAP by dropping oldest entries', () => {
+    let state = newEncounterState();
+    for (let i = 0; i < COMBAT_LOG_CAP + 1; i++) {
+      state = appendInfoLog(state, `roll-${i}`, `m-${i}`);
+    }
+    expect(state.combatLog).toHaveLength(COMBAT_LOG_CAP);
+    // oldest (roll-0) should have been dropped
+    expect(state.combatLog[0].id).toBe('roll-1');
+    expect(state.combatLog[state.combatLog.length - 1].id).toBe(`roll-${COMBAT_LOG_CAP}`);
+  });
+
+  test('returns a new state object (does not mutate input)', () => {
+    const state = newEncounterState();
+    const next = appendInfoLog(state, 'roll-1', 'msg');
+    expect(next).not.toBe(state);
+    expect(state.combatLog).toEqual([]);
   });
 });

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -136,23 +136,41 @@ export function toCommand<T extends CommandType>(
 
 export function dispatchEncounterCommand(state: EncounterState, command: Command): DispatchResult {
   const result = applyCommand(state, command, effectLibrary);
-  const newEntries = formatEvents(result.events, {
+  return appendLogEntries(result.newState, result.events, formatEvents(result.events, {
     commandId: command.id,
     state: result.newState
-  });
+  }));
+}
 
-  if (newEntries.length === 0) {
-    return { state: result.newState, events: result.events };
+function appendLogEntries(
+  state: EncounterState,
+  events: DomainEvent[],
+  entries: LogEntry[]
+): DispatchResult {
+  if (entries.length === 0) {
+    return { state, events };
   }
-
-  const merged = [...result.newState.combatLog, ...newEntries];
+  const merged = [...state.combatLog, ...entries];
   const cappedLog: LogEntry[] =
     merged.length > COMBAT_LOG_CAP ? merged.slice(merged.length - COMBAT_LOG_CAP) : merged;
+  return { state: { ...state, combatLog: cappedLog }, events };
+}
 
-  return {
-    state: { ...result.newState, combatLog: cappedLog },
-    events: result.events
-  };
+// Appends a single log entry to encounter.combatLog without going through the
+// reducer. Used for client-side dice rolls that don't (and shouldn't) mutate
+// domain state. The entry id must be unique within the log; callers typically
+// use a monotonic counter to guarantee that.
+export function appendInfoLog(
+  state: EncounterState,
+  entryId: string,
+  message: string,
+  tone: LogEntry['tone'] = 'info'
+): EncounterState {
+  const entry: LogEntry = { id: entryId, message, tone };
+  const merged = [...state.combatLog, entry];
+  const cappedLog =
+    merged.length > COMBAT_LOG_CAP ? merged.slice(merged.length - COMBAT_LOG_CAP) : merged;
+  return { ...state, combatLog: cappedLog };
 }
 
 export function currentCombatant(state: EncounterState): CombatantState | undefined {

--- a/src/lib/spellcasting/view.test.ts
+++ b/src/lib/spellcasting/view.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import { buildSpellcastingView } from './view';
+import type { CombatantSpellcasting } from '../../domain';
+
+function preparedBlock(
+  overrides: Partial<CombatantSpellcasting> = {}
+): CombatantSpellcasting {
+  return {
+    blockId: 'yaashka-divine-prepared',
+    name: 'Divine Prepared Spells',
+    tradition: 'divine',
+    type: 'prepared',
+    dc: 24,
+    attackModifier: 16,
+    slots: { 1: 4, 2: 4, 3: 3 },
+    entries: [
+      { spellSlug: 'harm', name: 'Harm', level: 3 },
+      { spellSlug: 'spiritual-weapon', name: 'Spiritual Weapon', level: 2, count: 2 },
+      { spellSlug: 'command', name: 'Command', level: 1, count: 2 },
+      { spellSlug: 'detect-magic', name: 'Detect Magic', level: 3, isCantrip: true }
+    ],
+    ...overrides
+  };
+}
+
+describe('buildSpellcastingView (prepared)', () => {
+  test('partitions cantrips and groups non-cantrips by rank, ascending', () => {
+    const view = buildSpellcastingView(preparedBlock());
+    expect(view.type).toBe('prepared');
+    if (view.type !== 'prepared') return;
+    expect(view.ranks.map((r) => r.rank)).toEqual([1, 2, 3]);
+    expect(view.cantrips).toEqual([{ spellSlug: 'detect-magic', name: 'Detect Magic', level: 3 }]);
+  });
+
+  test('reflects usedSlots in per-rank used count', () => {
+    const view = buildSpellcastingView(preparedBlock({ usedSlots: { 3: 1 } }));
+    if (view.type !== 'prepared') throw new Error('expected prepared');
+    expect(view.ranks.find((r) => r.rank === 3)).toMatchObject({ total: 3, used: 1 });
+    expect(view.ranks.find((r) => r.rank === 1)).toMatchObject({ total: 4, used: 0 });
+  });
+
+  test('preserves prepared duplicates via count field', () => {
+    const view = buildSpellcastingView(preparedBlock());
+    if (view.type !== 'prepared') throw new Error('expected prepared');
+    const rank2 = view.ranks.find((r) => r.rank === 2)!;
+    expect(rank2.entries).toEqual([{ spellSlug: 'spiritual-weapon', name: 'Spiritual Weapon', count: 2 }]);
+  });
+});
+
+describe('buildSpellcastingView (focus)', () => {
+  test('exposes focus pool total/used and lists entries', () => {
+    const block: CombatantSpellcasting = {
+      blockId: 'cleric-focus',
+      name: 'Cleric Domain Spells',
+      tradition: 'divine',
+      type: 'focus',
+      dc: 24,
+      focusPoints: 1,
+      usedFocusPoints: 0,
+      entries: [{ spellSlug: 'athletic-rush', name: 'Athletic Rush', level: 3 }]
+    };
+    const view = buildSpellcastingView(block);
+    if (view.type !== 'focus') throw new Error('expected focus');
+    expect(view.focus).toEqual({ total: 1, used: 0 });
+    expect(view.entries).toEqual([{ spellSlug: 'athletic-rush', name: 'Athletic Rush', level: 3 }]);
+  });
+});
+
+describe('buildSpellcastingView (innate)', () => {
+  test('marks per-day as interactive and at-will/constant as non-interactive', () => {
+    const block: CombatantSpellcasting = {
+      blockId: 'dragon-innate',
+      name: 'Innate Spells',
+      tradition: 'arcane',
+      type: 'innate',
+      dc: 30,
+      entries: [
+        { spellSlug: 'wall-of-fire', name: 'Wall of Fire', level: 7, frequency: { type: 'perDay', uses: 3 } },
+        { spellSlug: 'detect-magic', name: 'Detect Magic', level: 1, frequency: { type: 'atWill' } },
+        { spellSlug: 'mage-armor', name: 'Mage Armor', level: 1, frequency: { type: 'constant' } }
+      ],
+      usedEntries: { 'wall-of-fire': 1 }
+    };
+    const view = buildSpellcastingView(block);
+    if (view.type !== 'innate') throw new Error('expected innate');
+
+    const wallOfFire = view.entries.find((e) => e.spellSlug === 'wall-of-fire')!;
+    expect(wallOfFire).toMatchObject({ used: 1, max: 3, interactive: true, marker: '3/day' });
+
+    const detect = view.entries.find((e) => e.spellSlug === 'detect-magic')!;
+    expect(detect.interactive).toBe(false);
+    expect(detect.marker).toBe('at will');
+
+    const mageArmor = view.entries.find((e) => e.spellSlug === 'mage-armor')!;
+    expect(mageArmor.interactive).toBe(false);
+    expect(mageArmor.marker).toBe('constant');
+  });
+});
+
+describe('buildSpellcastingView (spontaneous)', () => {
+  test('groups repertoire by rank using slots map', () => {
+    const block: CombatantSpellcasting = {
+      blockId: 'sorc-arcane',
+      name: 'Arcane Spontaneous Spells',
+      tradition: 'arcane',
+      type: 'spontaneous',
+      dc: 22,
+      slots: { 1: 4, 2: 3 },
+      entries: [
+        { spellSlug: 'magic-missile', name: 'Magic Missile', level: 1 },
+        { spellSlug: 'invisibility', name: 'Invisibility', level: 2 }
+      ],
+      usedSlots: { 2: 1 }
+    };
+    const view = buildSpellcastingView(block);
+    if (view.type !== 'spontaneous') throw new Error('expected spontaneous');
+    expect(view.ranks.map((r) => r.rank)).toEqual([1, 2]);
+    expect(view.ranks.find((r) => r.rank === 2)).toMatchObject({ total: 3, used: 1 });
+    expect(view.ranks.find((r) => r.rank === 1)?.entries[0].name).toBe('Magic Missile');
+  });
+});

--- a/src/lib/spellcasting/view.ts
+++ b/src/lib/spellcasting/view.ts
@@ -1,0 +1,174 @@
+import type { CombatantSpellcasting, SpellListEntry, SpellFrequency } from '../../domain';
+
+export interface SlotRow {
+  rank: number;
+  total: number;
+  used: number;
+}
+
+export interface PreparedRankGroup {
+  rank: number;
+  total: number;
+  used: number;
+  entries: PreparedEntryView[];
+}
+
+export interface PreparedEntryView {
+  spellSlug: string;
+  name: string;
+  count: number;
+}
+
+export interface SpontaneousRankGroup {
+  rank: number;
+  total: number;
+  used: number;
+  entries: SpellListEntry[];
+}
+
+export interface InnateEntryView {
+  spellSlug: string;
+  name: string;
+  level: number;
+  frequency: SpellFrequency | undefined;
+  used: number;
+  max: number | undefined;
+  interactive: boolean;
+  marker: string;
+}
+
+export interface CantripView {
+  spellSlug: string;
+  name: string;
+  level: number;
+}
+
+export type SpellcastingView =
+  | { type: 'prepared'; header: HeaderView; ranks: PreparedRankGroup[]; cantrips: CantripView[] }
+  | { type: 'spontaneous'; header: HeaderView; ranks: SpontaneousRankGroup[]; cantrips: CantripView[] }
+  | { type: 'innate'; header: HeaderView; entries: InnateEntryView[]; cantrips: CantripView[] }
+  | {
+      type: 'focus';
+      header: HeaderView;
+      focus: { total: number; used: number };
+      entries: { spellSlug: string; name: string; level: number }[];
+      cantrips: CantripView[];
+    };
+
+export interface HeaderView {
+  blockId: string;
+  name: string;
+  tradition: string;
+  type: string;
+  dc: number;
+  attackModifier: number | undefined;
+}
+
+function header(block: CombatantSpellcasting): HeaderView {
+  return {
+    blockId: block.blockId,
+    name: block.name,
+    tradition: block.tradition,
+    type: block.type,
+    dc: block.dc,
+    attackModifier: block.attackModifier
+  };
+}
+
+function partition(entries: SpellListEntry[]): { cantrips: SpellListEntry[]; spells: SpellListEntry[] } {
+  const cantrips: SpellListEntry[] = [];
+  const spells: SpellListEntry[] = [];
+  for (const e of entries) {
+    if (e.isCantrip) cantrips.push(e);
+    else spells.push(e);
+  }
+  return { cantrips, spells };
+}
+
+function toCantripView(e: SpellListEntry): CantripView {
+  return { spellSlug: e.spellSlug, name: e.name, level: e.level };
+}
+
+function frequencyMarker(freq: SpellFrequency | undefined): string {
+  if (!freq) return '';
+  if (freq.type === 'atWill') return 'at will';
+  if (freq.type === 'constant') return 'constant';
+  return `${freq.uses}/day`;
+}
+
+export function buildSpellcastingView(block: CombatantSpellcasting): SpellcastingView {
+  const h = header(block);
+  const { cantrips, spells } = partition(block.entries);
+  const cantripViews = cantrips.map(toCantripView);
+
+  if (block.type === 'prepared') {
+    const slots = block.slots ?? {};
+    const used = block.usedSlots ?? {};
+    const byRank = new Map<number, PreparedEntryView[]>();
+    for (const e of spells) {
+      const list = byRank.get(e.level) ?? [];
+      list.push({ spellSlug: e.spellSlug, name: e.name, count: e.count ?? 1 });
+      byRank.set(e.level, list);
+    }
+    const ranks: PreparedRankGroup[] = Object.keys(slots)
+      .map((k) => parseInt(k, 10))
+      .sort((a, b) => a - b)
+      .map((rank) => ({
+        rank,
+        total: slots[rank] ?? 0,
+        used: used[rank] ?? 0,
+        entries: (byRank.get(rank) ?? []).slice()
+      }));
+    return { type: 'prepared', header: h, ranks, cantrips: cantripViews };
+  }
+
+  if (block.type === 'spontaneous') {
+    const slots = block.slots ?? {};
+    const used = block.usedSlots ?? {};
+    const byRank = new Map<number, SpellListEntry[]>();
+    for (const e of spells) {
+      const list = byRank.get(e.level) ?? [];
+      list.push(e);
+      byRank.set(e.level, list);
+    }
+    const ranks: SpontaneousRankGroup[] = Object.keys(slots)
+      .map((k) => parseInt(k, 10))
+      .sort((a, b) => a - b)
+      .map((rank) => ({
+        rank,
+        total: slots[rank] ?? 0,
+        used: used[rank] ?? 0,
+        entries: (byRank.get(rank) ?? []).slice()
+      }));
+    return { type: 'spontaneous', header: h, ranks, cantrips: cantripViews };
+  }
+
+  if (block.type === 'focus') {
+    const total = block.focusPoints ?? 0;
+    const used = block.usedFocusPoints ?? 0;
+    return {
+      type: 'focus',
+      header: h,
+      focus: { total, used },
+      entries: spells.map((e) => ({ spellSlug: e.spellSlug, name: e.name, level: e.level })),
+      cantrips: cantripViews
+    };
+  }
+
+  // innate
+  const usedEntries = block.usedEntries ?? {};
+  const innate: InnateEntryView[] = spells.map((e) => {
+    const max = e.frequency?.type === 'perDay' ? e.frequency.uses : undefined;
+    return {
+      spellSlug: e.spellSlug,
+      name: e.name,
+      level: e.level,
+      frequency: e.frequency,
+      used: usedEntries[e.spellSlug] ?? 0,
+      max,
+      interactive: max !== undefined,
+      marker: frequencyMarker(e.frequency)
+    };
+  });
+  return { type: 'innate', header: h, entries: innate, cantrips: cantripViews };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
   import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
   import RadialConditionMenu from '../components/RadialConditionMenu.svelte';
   import EffectModal from '../components/EffectModal.svelte';
+  import RollBubble from '../components/RollBubble.svelte';
   import {
     appendInfoLog,
     combatantCardActions,
@@ -700,21 +701,56 @@
     return `local-roll-${rollCounter++}`;
   }
 
-  function rollAttackFor(combatantId: string, attack: Attack, variant: MapVariant) {
+  type BubbleTone = 'normal' | 'crit' | 'fumble' | 'damage';
+  interface RollBubbleEntry {
+    id: string;
+    x: number;
+    y: number;
+    total: string;
+    detail: string;
+    tone: BubbleTone;
+    badge: string;
+  }
+  let bubbles: RollBubbleEntry[] = [];
+  const BUBBLE_LIFETIME_MS = 1800;
+
+  function showBubble(entry: Omit<RollBubbleEntry, 'id'>) {
+    const id = nextRollId();
+    bubbles = [...bubbles, { ...entry, id }];
+    setTimeout(() => {
+      bubbles = bubbles.filter((b) => b.id !== id);
+    }, BUBBLE_LIFETIME_MS);
+  }
+
+  function rollAttackFor(combatantId: string, attack: Attack, variant: MapVariant, origin: { x: number; y: number }) {
     const c = encounter.combatants[combatantId];
     if (!c) return;
     const result = rollAttackDice(variant.modifier);
-    const tone = result.d20 === 20 ? 'success' : result.d20 === 1 ? 'danger' : 'info';
+    const isCrit = result.d20 === 20;
+    const isFumble = result.d20 === 1;
+    const logTone = isCrit ? 'success' : isFumble ? 'danger' : 'info';
+    const bubbleTone: BubbleTone = isCrit ? 'crit' : isFumble ? 'fumble' : 'normal';
+    const badge = isCrit ? 'NAT 20' : isFumble ? 'NAT 1' : `${attack.name} · ${variant.label}`;
+
     encounter = appendInfoLog(
       encounter,
       nextRollId(),
       `${c.name} ${attack.name} ${variant.label}: 1d20(${result.d20}) ${formatModifier(variant.modifier)} = ${result.total}`,
-      tone
+      logTone
     );
     persistence.persist(encounter);
+
+    showBubble({
+      x: origin.x,
+      y: origin.y,
+      total: String(result.total),
+      detail: `1d20(${result.d20}) ${formatModifier(variant.modifier)}`,
+      tone: bubbleTone,
+      badge
+    });
   }
 
-  function rollDamageFor(combatantId: string, attack: Attack) {
+  function rollDamageFor(combatantId: string, attack: Attack, origin: { x: number; y: number }) {
     const c = encounter.combatants[combatantId];
     if (!c || attack.damage.length === 0) return;
     const result = rollDamageDice(attack.damage);
@@ -725,6 +761,15 @@
       'danger'
     );
     persistence.persist(encounter);
+
+    showBubble({
+      x: origin.x,
+      y: origin.y,
+      total: `${result.total} dmg`,
+      detail: result.breakdown,
+      tone: 'damage',
+      badge: `${attack.name}`
+    });
   }
 
   function useSpellSlot(combatantId: string, blockId: string, rank: number) {
@@ -888,6 +933,17 @@
     onClose={closeRadial}
   />
 {/if}
+
+{#each bubbles as bubble (bubble.id)}
+  <RollBubble
+    x={bubble.x}
+    y={bubble.y}
+    total={bubble.total}
+    detail={bubble.detail}
+    tone={bubble.tone}
+    badge={bubble.badge}
+  />
+{/each}
 
 {#if effectModal && effectModalCombatant}
   <EffectModal

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import RadialConditionMenu from '../components/RadialConditionMenu.svelte';
   import EffectModal from '../components/EffectModal.svelte';
   import {
+    appendInfoLog,
     combatantCardActions,
     currentCombatant,
     dispatchEncounterCommand,
@@ -35,6 +36,10 @@
     type ManualCombatantInput,
     type TemplateAdjustmentChoice
   } from '$lib/encounter-app';
+  import { rollAttack as rollAttackDice, rollDamage as rollDamageDice } from '$lib/dice/roll';
+  import type { MapVariant } from '$lib/dice/map';
+  import { formatModifier } from '$lib/abilities/format-damage';
+  import type { Attack } from '../domain';
   import {
     resolveHpEdit,
     type CommittableEdit,
@@ -690,6 +695,57 @@
     runCommand(toCommand('SET_NOTE', { combatantId, note }, nextCommandId()));
   }
 
+  let rollCounter = 1;
+  function nextRollId() {
+    return `local-roll-${rollCounter++}`;
+  }
+
+  function rollAttackFor(combatantId: string, attack: Attack, variant: MapVariant) {
+    const c = encounter.combatants[combatantId];
+    if (!c) return;
+    const result = rollAttackDice(variant.modifier);
+    const tone = result.d20 === 20 ? 'success' : result.d20 === 1 ? 'danger' : 'info';
+    encounter = appendInfoLog(
+      encounter,
+      nextRollId(),
+      `${c.name} ${attack.name} ${variant.label}: 1d20(${result.d20}) ${formatModifier(variant.modifier)} = ${result.total}`,
+      tone
+    );
+    persistence.persist(encounter);
+  }
+
+  function rollDamageFor(combatantId: string, attack: Attack) {
+    const c = encounter.combatants[combatantId];
+    if (!c || attack.damage.length === 0) return;
+    const result = rollDamageDice(attack.damage);
+    encounter = appendInfoLog(
+      encounter,
+      nextRollId(),
+      `${c.name} ${attack.name} damage: ${result.breakdown} = ${result.total}`,
+      'danger'
+    );
+    persistence.persist(encounter);
+  }
+
+  function useSpellSlot(combatantId: string, blockId: string, rank: number) {
+    runCommand(toCommand('USE_SPELL_SLOT', { combatantId, blockId, rank }, nextCommandId()));
+  }
+  function restoreSpellSlot(combatantId: string, blockId: string, rank: number) {
+    runCommand(toCommand('RESTORE_SPELL_SLOT', { combatantId, blockId, rank }, nextCommandId()));
+  }
+  function useFocusPoint(combatantId: string, blockId: string) {
+    runCommand(toCommand('USE_FOCUS_POINT', { combatantId, blockId }, nextCommandId()));
+  }
+  function restoreFocusPoint(combatantId: string, blockId: string) {
+    runCommand(toCommand('RESTORE_FOCUS_POINT', { combatantId, blockId }, nextCommandId()));
+  }
+  function useInnateSpell(combatantId: string, blockId: string, spellSlug: string) {
+    runCommand(toCommand('USE_INNATE_SPELL', { combatantId, blockId, spellSlug }, nextCommandId()));
+  }
+  function restoreInnateSpell(combatantId: string, blockId: string, spellSlug: string) {
+    runCommand(toCommand('RESTORE_INNATE_SPELL', { combatantId, blockId, spellSlug }, nextCommandId()));
+  }
+
   function resolvePrompt(promptId: string, resolution: PromptResolution) {
     runCommand(toCommand('RESOLVE_PROMPT', { promptId, resolution }, nextCommandId()));
   }
@@ -798,7 +854,18 @@
     </section>
 
     <aside class="workspace__details">
-      <CombatantDetailsPanel combatant={selectedCombatant} onSetNote={setNote} />
+      <CombatantDetailsPanel
+        combatant={selectedCombatant}
+        onSetNote={setNote}
+        onRollAttack={rollAttackFor}
+        onRollDamage={rollDamageFor}
+        onUseSpellSlot={useSpellSlot}
+        onRestoreSpellSlot={restoreSpellSlot}
+        onUseFocusPoint={useFocusPoint}
+        onRestoreFocusPoint={restoreFocusPoint}
+        onUseInnateSpell={useInnateSpell}
+        onRestoreInnateSpell={restoreInnateSpell}
+      />
     </aside>
 
     <section class="workspace__log">
@@ -871,6 +938,11 @@
 
   .workspace__details {
     grid-area: details;
+    position: sticky;
+    top: 12px;
+    align-self: start;
+    max-height: calc(100vh - 24px);
+    overflow-y: auto;
   }
 
   .workspace__log {
@@ -950,6 +1022,12 @@
         'library track'
         'details details'
         'log     log';
+    }
+
+    .workspace__details {
+      position: static;
+      max-height: none;
+      overflow: visible;
     }
   }
 


### PR DESCRIPTION
## Summary

Overhauls the right-side combatant details panel — addresses every issue raised in the original ask: MAP variants on attacks, click-to-roll, sticky right panel, action glyphs, formatted degree-of-success outcomes, and spellcasting display + click-to-use.

- **Attacks** now expose three MAP buttons (1st / 2nd / 3rd) computed at render time per `pf2e-creature-types-spec.md` §3.3 (agile = -4/-8, otherwise -5/-10). Each button rolls 1d20+modifier and appends the result to the combat log. Damage button rolls the structured damage formula.
- **Sticky right panel** (`position: sticky; top: 12px; max-height: calc(100vh - 24px); overflow-y: auto`) on desktop, reverts to static layout below the existing 1180px responsive breakpoint.
- **Action cost** renders as Unicode glyphs (◆, ◆◆, ◆◆◆, ↺, ◇).
- **Degree-of-success** outcomes inside ability descriptions are parsed via regex and rendered as colored, labeled rows. No schema change, no YAML migration — works against every existing creature.
- **Spellcasting** blocks are rendered for the first time: prepared / spontaneous slot pips per rank, focus pool, per-day innate counters, at-will / constant markers, cantrips. Click pip = use, right-click = restore.
- **Section order** is now Defenses → Passive → Reactive → Attacks → Active → Spellcasting → GM Notes, putting Attacks adjacent to Active Abilities.

### Domain
- Implements the previously-stubbed `USE_*` / `RESTORE_*` reducer arms for slot, focus, and innate spells per `pf2e-spellcasting-spec.md` §6.
- Tightens command payload types from `Record<string, unknown>` to typed shapes.
- Adds the `spell-usage-changed` discriminated event variant; combat log formatter narrates it (e.g. "Yaashka cast a 3rd-rank spell (2/3 remaining).", "Dragon used Wall of Fire.").

### Helpers (all pure, all under `src/lib`)
- `dice/{roll,map}` — roll d20/damage with injectable RNG; MAP variant computation.
- `abilities/{action-glyph,parse-degrees,format-damage}` — view-shape utilities.
- `spellcasting/view` — block → renderable view with pip arrays.
- `appendInfoLog` in `encounter-app.ts` centralises `COMBAT_LOG_CAP` so client-side roll log entries don't duplicate the cap logic.

`Math.random` lives only in `src/lib/dice/roll.ts`, keeping `src/domain` pure.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings (411 files)
- [x] `npm run test:run` — 648 tests pass (added: 39 helper tests, 13 reducer arm tests, 6 log-formatter tests, expanded panel tests for new layout / MAP / spellcasting / DoS rendering)
- [x] `npm run audit` — passes (3 low-severity deps inherited from @sveltejs/kit, below the moderate gate)
- [x] `npm run build` — Cloudflare static build succeeds (3.94s)
- [ ] Manual smoke (please verify in dev): select Yaashka → click each MAP, click damage, click slot pip, right-click slot pip, click focus pip; select Spinesnapper → verify Brutal Blow renders 4 labeled outcome rows and action costs show as ◆◆ glyphs; scroll the combatant list with many combatants and confirm the details panel stays visible; resize below 1180px and confirm the panel reverts to non-sticky stacked layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)