### PR TITLE
Persistent damage: per-card resolve, end-of-turn timing, glyph + dice chips

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CombatantState, EncounterState } from '../domain';
+  import type { CombatantState, EncounterState, Prompt, PromptResolution } from '../domain';
   import {
     clampValue,
     combatantVisualState,
@@ -11,11 +11,14 @@
   } from '$lib/encounter-app';
   import type { CommittableEdit, HpEditField } from '$lib/hp-input';
   import { templateLabel } from '$lib/template-label';
+  import { persistentEffectIdToDamageType } from '$lib/effects/damage-type-glyph';
   import InlineNumberEdit from './InlineNumberEdit.svelte';
   import Button from './ui/Button.svelte';
   import Chip from './ui/Chip.svelte';
   import IconButton from './ui/IconButton.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import DamageTypeGlyph from './ui/DamageTypeGlyph.svelte';
+  import CombatantPromptResolution from './CombatantPromptResolution.svelte';
 
   export let combatant: CombatantState;
   export let isCurrent: boolean;
@@ -42,6 +45,16 @@
     | undefined = undefined;
   export let initiativeScore: number | undefined = undefined;
   export let onSetInitiative: ((id: string, value: number | null) => void) | undefined = undefined;
+  export let pendingPrompts: Prompt[] = [];
+  export let combatantsById: Record<string, CombatantState> = {};
+  export let onResolvePrompt: (promptId: string, resolution: PromptResolution) => void = () => {};
+  export let onApplyPersistentDamage: (
+    combatantId: string,
+    amount: number,
+    damageType: string
+  ) => void = () => {};
+
+  $: cardPrompts = pendingPrompts.filter((p) => p.targetId === combatant.id);
 
   const LONG_PRESS_MS = 400;
   const LONG_PRESS_TOLERANCE_PX = 6;
@@ -400,8 +413,20 @@
     {/if}
 
     {#each appliedEffectsView as view (view.instanceId)}
-      <span class="condition-chip" class:condition-chip--implied={view.source.kind === 'implied'}>
-        <span class="condition-name">{view.name}</span>
+      {@const isPersistent = view.effectId.startsWith('persistent-')}
+      {@const damageType = isPersistent ? persistentEffectIdToDamageType(view.effectId) : null}
+      <span
+        class="condition-chip"
+        class:condition-chip--implied={view.source.kind === 'implied'}
+        class:condition-chip--persistent={isPersistent}
+      >
+        {#if isPersistent && damageType}
+          <DamageTypeGlyph type={damageType} />
+        {/if}
+        <span class="condition-name">{isPersistent ? (damageType ?? view.name) : view.name}</span>
+        {#if isPersistent && view.note}
+          <span class="condition-dice">{view.note}</span>
+        {/if}
         {#if view.value.kind === 'valued'}
           {#if editingInstanceId === view.instanceId}
             <input
@@ -480,6 +505,18 @@
       </div>
     {/if}
   </div>
+
+  {#if cardPrompts.length > 0}
+    <div class="card-prompt-resolution">
+      <CombatantPromptResolution
+        prompts={cardPrompts}
+        {combatantsById}
+        {phase}
+        onResolve={onResolvePrompt}
+        {onApplyPersistentDamage}
+      />
+    </div>
+  {/if}
 
   <div class="card-turn-actions" aria-label="Turn and lifecycle controls">
     <Button
@@ -808,14 +845,41 @@
     opacity: 0.78;
   }
 
+  .condition-chip--persistent {
+    background: #fff3f0;
+    border-color: var(--color-red);
+    border-left: 3px solid var(--color-red);
+    color: var(--color-red);
+  }
+
+  .condition-chip--persistent .condition-name {
+    text-transform: capitalize;
+  }
+
   .condition-name {
     font-weight: 700;
+  }
+
+  .condition-dice {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    color: var(--color-red);
+    background: #fff;
+    padding: 0 4px;
+    border: var(--border-thin);
+    border-color: var(--color-red);
+    border-radius: 2px;
   }
 
   .condition-duration {
     color: var(--color-ink-mute);
     font-weight: 500;
     font-size: var(--text-xs);
+  }
+
+  .card-prompt-resolution {
+    margin-top: var(--space-2);
   }
 
   .condition-parent {

--- a/src/components/CombatantPromptResolution.svelte
+++ b/src/components/CombatantPromptResolution.svelte
@@ -35,12 +35,6 @@
   $: setValueDrafts = reconcileDrafts(prompts, persistentBranches, setValueDrafts);
   $: damageDrafts = reconcileDamageDrafts(prompts, persistentBranches, damageDrafts);
 
-  function findEffect(p: Prompt): AppliedEffect | undefined {
-    return combatantsById[p.targetId]?.appliedEffects.find(
-      (effect) => effect.instanceId === p.effectInstanceId
-    );
-  }
-
   function computePersistentBranches(
     list: Prompt[],
     byId: Record<string, CombatantState>
@@ -161,21 +155,18 @@
 </script>
 
 {#if focused}
-  <aside
-    class="prompt-panel"
-    aria-labelledby="prompt-resolution-title"
+  <div
+    class="prompt-block"
+    aria-label="Awaiting resolution"
     aria-live="polite"
   >
-    <header class="prompt-panel__header">
-      <h2 id="prompt-resolution-title">Awaiting GM resolution</h2>
-      <span class="prompt-panel__count">{prompts.length}</span>
-    </header>
+    <SectionLabel>Awaiting resolution</SectionLabel>
     <ol class="prompt-list">
       {#each prompts as prompt (prompt.id)}
         {@const target = targetLabel(prompt)}
         <li class="prompt">
           <div class="prompt__meta">
-            <SectionLabel>{boundaryLabel(prompt)}</SectionLabel>
+            <span class="prompt__boundary">{boundaryLabel(prompt)}</span>
             <span class="prompt__effect">{prompt.effectName}</span>
             {#if target}
               <span class="prompt__target">on {target}</span>
@@ -269,40 +260,18 @@
         </li>
       {/each}
     </ol>
-  </aside>
+  </div>
 {/if}
 
 <style>
-  .prompt-panel {
+  .prompt-block {
+    display: grid;
+    gap: var(--space-2);
     background: #fff7ee;
     border: 1px solid var(--color-amber);
-    border-left: 4px solid var(--color-amber);
+    border-left: 3px solid var(--color-amber);
     border-radius: var(--radius-card);
-    padding: var(--space-3) var(--space-4);
-  }
-
-  .prompt-panel__header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--space-2);
-    margin-bottom: var(--space-3);
-  }
-
-  h2 {
-    margin: 0;
-    font-family: var(--font-serif);
-    font-size: var(--text-md);
-    font-weight: 600;
-    line-height: var(--leading-tight);
-    color: var(--color-amber);
-  }
-
-  .prompt-panel__count {
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--color-amber);
+    padding: var(--space-2) var(--space-3);
   }
 
   .prompt-list {
@@ -316,7 +285,6 @@
   .prompt {
     background: var(--color-panel);
     border: var(--border-thin);
-    border-left: 3px solid var(--color-amber);
     padding: var(--space-2) var(--space-3);
     display: grid;
     gap: var(--space-2);
@@ -329,6 +297,14 @@
     gap: var(--space-2);
     font-size: var(--text-sm);
     color: var(--color-ink-soft);
+  }
+
+  .prompt__boundary {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-amber);
   }
 
   .prompt__effect {

--- a/src/components/CombatantPromptResolution.test.ts
+++ b/src/components/CombatantPromptResolution.test.ts
@@ -8,7 +8,7 @@ import type {
   Prompt,
   PromptResolution
 } from '../domain';
-import PromptResolutionPanel from './PromptResolutionPanel.svelte';
+import CombatantPromptResolution from './CombatantPromptResolution.svelte';
 
 type ResolveHandler = (promptId: string, resolution: PromptResolution) => void;
 type ApplyDamageHandler = (combatantId: string, amount: number, damageType: string) => void;
@@ -34,7 +34,7 @@ function renderPanel(props: {
   const onResolve: Mock<ResolveHandler> = props.onResolve ?? vi.fn<ResolveHandler>();
   const onApplyPersistentDamage: Mock<ApplyDamageHandler> =
     props.onApplyPersistentDamage ?? vi.fn<ApplyDamageHandler>();
-  const utils = render(PromptResolutionPanel, {
+  const utils = render(CombatantPromptResolution, {
     props: {
       prompts: props.prompts,
       combatantsById: props.combatantsById ?? combatants,
@@ -46,10 +46,10 @@ function renderPanel(props: {
   return { ...utils, onResolve, onApplyPersistentDamage };
 }
 
-describe('PromptResolutionPanel', () => {
+describe('CombatantPromptResolution', () => {
   test('renders nothing when there are no pending prompts', () => {
     const { container } = renderPanel({ prompts: [] });
-    expect(container.querySelector('aside')).toBeNull();
+    expect(container.querySelector('.prompt-block')).toBeNull();
   });
 
   test('renders nothing when phase is not RESOLVING even if prompts exist', () => {
@@ -57,16 +57,15 @@ describe('PromptResolutionPanel', () => {
       prompts: [prompt({ suggestionType: { type: 'reminder', description: 'x' } })],
       phase: 'ACTIVE'
     });
-    expect(container.querySelector('aside')).toBeNull();
+    expect(container.querySelector('.prompt-block')).toBeNull();
   });
 
-  test('renders focused container with aria-live and the GM heading when active', () => {
+  test('renders focused container with aria-live when active', () => {
     renderPanel({
       prompts: [prompt({ suggestionType: { type: 'reminder', description: 'x' } })]
     });
-    const region = screen.getByLabelText('Awaiting GM resolution');
+    const region = screen.getByLabelText('Awaiting resolution');
     expect(region).toHaveAttribute('aria-live', 'polite');
-    expect(screen.getByRole('heading', { level: 2, name: 'Awaiting GM resolution' })).toBeInTheDocument();
   });
 
   test('suggestDecrement prompt: shows owner boundary, target name, description, and four resolution controls', async () => {
@@ -504,7 +503,7 @@ describe('PromptResolutionPanel', () => {
       onResolve: vi.fn<ResolveHandler>() as unknown as ResolveHandler
     };
 
-    const { rerender } = render(PromptResolutionPanel, {
+    const { rerender } = render(CombatantPromptResolution, {
       props: { ...baseProps, prompts: [promptA] }
     });
 

--- a/src/domain/effects/library.test.ts
+++ b/src/domain/effects/library.test.ts
@@ -139,7 +139,7 @@ describe('effectLibrary', () => {
       category: 'persistent-damage',
       hasValue: false,
       modifiers: [],
-      turnStartSuggestion: {
+      turnEndSuggestion: {
         type: 'promptResolution',
         description: 'Take {note} fire damage, then flat check DC 15 to remove.'
       }

--- a/src/domain/effects/library.ts
+++ b/src/domain/effects/library.ts
@@ -24,12 +24,12 @@ function persistentDamage(type: string, name: string): EffectDefinition {
     category: 'persistent-damage',
     hasValue: false,
     modifiers: [],
-    turnStartSuggestion: {
+    turnEndSuggestion: {
       type: 'promptResolution',
       description: `Take {note} ${type} damage, then flat check DC 15 to remove.`
     },
     description:
-      'At start of turn: take damage, then DC 15 flat check to end. Assisted recovery lowers DC to 10. Multiple sources: take only the highest.'
+      'At end of turn: take damage, then DC 15 flat check to end. Assisted recovery lowers DC to 10. Multiple sources: take only the highest.'
   };
 }
 

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -317,7 +317,7 @@ describe('applyCommand prompt resolution slice', () => {
       pendingPrompts: [
         {
           id: 'prompt-persistent',
-          boundary: { type: 'turnStart', ownerId: 'fighter-1' },
+          boundary: { type: 'turnEnd', ownerId: 'fighter-1' },
           targetId: 'fighter-1',
           effectInstanceId: 'persistent-fire-1',
           effectName: 'Persistent Fire',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,6 @@
   import CombatantCard from '../components/CombatantCard.svelte';
   import CombatantDetailsPanel from '../components/CombatantDetailsPanel.svelte';
   import LibraryPane from '../components/LibraryPane.svelte';
-  import PromptResolutionPanel from '../components/PromptResolutionPanel.svelte';
   import RadialConditionMenu from '../components/RadialConditionMenu.svelte';
   import EffectModal from '../components/EffectModal.svelte';
   import RollBubble from '../components/RollBubble.svelte';
@@ -847,13 +846,6 @@
     </div>
 
     <section class="workspace__track" aria-label="Combatants">
-      <PromptResolutionPanel
-        prompts={encounter.pendingPrompts}
-        combatantsById={encounter.combatants}
-        phase={encounter.phase}
-        onResolve={resolvePrompt}
-        onApplyPersistentDamage={applyPersistentDamageFromPrompt}
-      />
       {#if unorderedCombatants.length > 0}
         <div class="not-yet-rolled" aria-label="Not yet rolled">
           <h3>Not yet rolled</h3>
@@ -898,6 +890,10 @@
             onSetInitiative={setInitiativeScore}
             isFirst={index === 0}
             isLast={index === orderedCombatants.length - 1}
+            pendingPrompts={encounter.pendingPrompts}
+            combatantsById={encounter.combatants}
+            onResolvePrompt={resolvePrompt}
+            onApplyPersistentDamage={applyPersistentDamageFromPrompt}
           />
         {/each}
       </div>


### PR DESCRIPTION
## Summary

- **Timing/wording fix.** Persistent damage now uses `turnEndSuggestion` so prompts fire at the **end** of the affected creature's turn (matching PF2e RAW), not at the start. The resolution panel's "Start of X's turn" label was a downstream symptom of this — it now correctly reads "End of X's turn".
- **Resolution moves onto the combatant card.** The global `PromptResolutionPanel` sidebar is replaced by an inline resolution block on each combatant's card, filtered by `targetId`. Same controls (Roll, Apply damage, Dismiss, Remove effect, Set value, etc.), now where the GM is already looking.
- **Stylized persistent chips.** Persistent-damage chips on the card now lead with the damage-type glyph (reusing `<DamageTypeGlyph>`) and show the dice expression in mono with a red accent — distinct from generic condition chips at a glance.

A fourth item from the original brief — optional duration on persistent damage — was explicitly dropped during brainstorming. RAW resolution via flat check is sufficient.

## Files

- `src/domain/effects/library.ts` — `turnStartSuggestion` → `turnEndSuggestion`, description text
- `src/components/CombatantPromptResolution.svelte` — new (extracted from the old panel; outer `<aside>` + heading wrapper dropped, fits inside a card)
- `src/components/PromptResolutionPanel.svelte` — deleted
- `src/components/CombatantCard.svelte` — accepts `pendingPrompts` / callbacks; renders inline resolution; styles persistent chips with glyph + dice + red accent
- `src/routes/+page.svelte` — drops sidebar mount, plumbs props to `<CombatantCard>`
- Tests: renamed/migrated from `PromptResolutionPanel.test.ts`; updated wrapper assertions; updated stale `turnStart` → `turnEnd` boundary in a synthetic prompt fixture and in the persistent-damage library test.

## Test plan

- [x] `npm run check` (svelte-check + tsc on domain)
- [x] `npm run test:run` — 674 tests, all passing
- [x] `npm run audit` — only 3 low-severity findings (below the moderate gate)
- [x] `npm run build` — static build succeeds
- [x] Manual browser pass: apply persistent fire 2d6 to a combatant, confirm red chip + glyph + dice on the card; end that combatant's turn, confirm the resolve UI appears inline on the card with "End of X's turn"; Roll → Apply Damage drops HP; Remove clears the chip and advances cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)