### PR TITLE
Compact combatant card: faction accent, clickable saves

### DIFF
--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -2,14 +2,17 @@
   import type { CombatantState, EncounterState, Prompt, PromptResolution } from '../domain';
   import {
     clampValue,
+    combatantFaction,
     combatantVisualState,
     resolveApplyChoice,
     type AppliedEffectView,
     type ApplyConditionChoice,
     type CombatantCardActionAvailability,
+    type CombatantFaction,
     type ConditionOption
   } from '$lib/encounter-app';
   import type { CommittableEdit, HpEditField } from '$lib/hp-input';
+  import { formatModifier } from '$lib/abilities/format-damage';
   import { templateLabel } from '$lib/template-label';
   import { persistentEffectIdToDamageType } from '$lib/effects/damage-type-glyph';
   import InlineNumberEdit from './InlineNumberEdit.svelte';
@@ -17,8 +20,11 @@
   import Chip from './ui/Chip.svelte';
   import IconButton from './ui/IconButton.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import StatRollButton from './ui/StatRollButton.svelte';
   import DamageTypeGlyph from './ui/DamageTypeGlyph.svelte';
   import CombatantPromptResolution from './CombatantPromptResolution.svelte';
+
+  type SaveKey = 'fortitude' | 'reflex' | 'will';
 
   export let combatant: CombatantState;
   export let isCurrent: boolean;
@@ -52,6 +58,11 @@
     combatantId: string,
     amount: number,
     damageType: string
+  ) => void = () => {};
+  export let onRollSave: (
+    combatantId: string,
+    save: SaveKey,
+    origin: { x: number; y: number }
   ) => void = () => {};
 
   $: cardPrompts = pendingPrompts.filter((p) => p.targetId === combatant.id);
@@ -107,7 +118,7 @@
   function isInnerInteractive(target: EventTarget | null, card: EventTarget | null): boolean {
     if (!(target instanceof Element)) return false;
     const hit = target.closest(
-      'button, a, input, select, textarea, [role="button"], [contenteditable="true"]'
+      'button, a, input, select, textarea, summary, [role="button"], [contenteditable="true"]'
     );
     return hit !== null && hit !== card;
   }
@@ -233,6 +244,23 @@
 
   $: visualState = combatantVisualState(combatant);
 
+  $: faction = combatantFaction(combatant);
+  $: factionLabel = factionDisplayLabel(faction);
+
+  function factionDisplayLabel(f: CombatantFaction): string {
+    switch (f) {
+      case 'pc':
+        return 'PC';
+      case 'ally':
+        return 'Ally';
+      case 'hazard':
+        return 'Hazard';
+      case 'enemy':
+      default:
+        return 'NPC';
+    }
+  }
+
   $: endTurnTitle = actions.canEndTurn
     ? 'End this combatant’s turn'
     : isCurrent
@@ -258,6 +286,10 @@
     : combatant.isAlive
       ? 'Combatant is already alive'
       : 'Revive is unavailable in this phase';
+
+  $: fortAriaLabel = `Roll ${combatant.name} Fortitude save (${formatModifier(combatant.baseStats.fortitude)})`;
+  $: refAriaLabel = `Roll ${combatant.name} Reflex save (${formatModifier(combatant.baseStats.reflex)})`;
+  $: willAriaLabel = `Roll ${combatant.name} Will save (${formatModifier(combatant.baseStats.will)})`;
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -268,6 +300,7 @@
   class:dimmed={visualState !== 'alive'}
   data-visual-state={visualState}
   data-hp-tone={hpTone}
+  data-faction={faction}
   class="combatant-card"
   role={onSelect ? 'button' : undefined}
   tabindex={onSelect ? 0 : -1}
@@ -281,57 +314,36 @@
   onkeydown={handleArticleKeyDown}
 >
   <div class="card-heading">
-    <div class="card-heading__main">
-      <div class="card-title">
-        <h2>
-          <button
-            type="button"
-            class="card-name-button"
-            aria-pressed={isSelected}
-            title={isSelected ? `${combatant.name} is selected` : `Show details for ${combatant.name}`}
-            onclick={() => onSelect?.(combatant.id)}
-          >{combatant.name}</button>
-        </h2>
-        {#if combatant.templateAdjustment}
-          <Chip variant={combatant.templateAdjustment === 'elite' ? 'warning' : 'default'}>
-            {templateLabel(combatant.templateAdjustment)}
-          </Chip>
-        {/if}
-        {#if visualState === 'dead'}
-          <Chip variant="danger">Dead</Chip>
-        {:else if visualState === 'unconscious'}
-          <Chip variant="warning">Unconscious</Chip>
-        {/if}
-      </div>
+    <div class="card-title">
+      <span
+        class="faction-tag"
+        data-faction={faction}
+        aria-label={`${factionLabel}`}
+      >{factionLabel}</span>
+      <h2>
+        <button
+          type="button"
+          class="card-name-button"
+          aria-pressed={isSelected}
+          title={isSelected ? `${combatant.name} is selected` : `Show details for ${combatant.name}`}
+          onclick={() => onSelect?.(combatant.id)}
+        >{combatant.name}</button>
+      </h2>
+      {#if combatant.templateAdjustment}
+        <Chip variant={combatant.templateAdjustment === 'elite' ? 'warning' : 'default'}>
+          {templateLabel(combatant.templateAdjustment)}
+        </Chip>
+      {/if}
+      {#if visualState === 'dead'}
+        <Chip variant="danger">Dead</Chip>
+      {:else if visualState === 'unconscious'}
+        <Chip variant="warning">Unconscious</Chip>
+      {/if}
     </div>
     <div class="card-aside">
       <Chip variant={isCurrent ? 'success' : 'default'}>
         {isCurrent ? 'Turn' : phase}
       </Chip>
-      {#if phase === 'PREPARING' && onSetInitiative}
-        <div class="card-initiative" aria-label="Initiative">
-          <SectionLabel>Init</SectionLabel>
-          <input
-            type="number"
-            class="card-initiative__input"
-            aria-label={`Initiative for ${combatant.name}`}
-            placeholder="—"
-            bind:value={initiativeDraft}
-            onblur={commitInitiativeDraft}
-            onkeydown={handleInitiativeKey}
-          />
-          <Button
-            size="sm"
-            variant="secondary"
-            ariaLabel={`Roll initiative for ${combatant.name}`}
-            onclick={rollInitiative}
-          >Roll</Button>
-          <span
-            class="card-initiative__hint"
-            aria-label={`Perception modifier ${combatant.baseStats.perception >= 0 ? '+' : ''}${combatant.baseStats.perception}`}
-          >({combatant.baseStats.perception >= 0 ? '+' : ''}{combatant.baseStats.perception} Perception)</span>
-        </div>
-      {/if}
       <div class="card-reorder" aria-label="Reorder">
         <IconButton
           ariaLabel={`Move ${combatant.name} up`}
@@ -351,7 +363,32 @@
     </div>
   </div>
 
-  <div class="stat-grid">
+  {#if phase === 'PREPARING' && onSetInitiative}
+    <div class="card-initiative-row" aria-label="Initiative">
+      <SectionLabel>Init</SectionLabel>
+      <input
+        type="number"
+        class="card-initiative__input"
+        aria-label={`Initiative for ${combatant.name}`}
+        placeholder="—"
+        bind:value={initiativeDraft}
+        onblur={commitInitiativeDraft}
+        onkeydown={handleInitiativeKey}
+      />
+      <Button
+        size="sm"
+        variant="secondary"
+        ariaLabel={`Roll initiative for ${combatant.name}`}
+        onclick={rollInitiative}
+      >Roll</Button>
+      <span
+        class="card-initiative__hint"
+        aria-label={`Perception modifier ${combatant.baseStats.perception >= 0 ? '+' : ''}${combatant.baseStats.perception}`}
+      >({combatant.baseStats.perception >= 0 ? '+' : ''}{combatant.baseStats.perception} Perception)</span>
+    </div>
+  {/if}
+
+  <div class="stat-strip">
     <div class="stat-cell stat-cell--ac">
       <SectionLabel>AC</SectionLabel>
       <span class="stat-cell__value">{combatant.baseStats.ac}</span>
@@ -392,18 +429,24 @@
       </div>
     </div>
     <div class="stat-cell stat-cell--saves">
-      <div class="save">
-        <SectionLabel>Fort</SectionLabel>
-        <span class="save__value">+{combatant.baseStats.fortitude}</span>
-      </div>
-      <div class="save">
-        <SectionLabel>Ref</SectionLabel>
-        <span class="save__value">+{combatant.baseStats.reflex}</span>
-      </div>
-      <div class="save">
-        <SectionLabel>Will</SectionLabel>
-        <span class="save__value">+{combatant.baseStats.will}</span>
-      </div>
+      <StatRollButton
+        label="Fort"
+        modifier={combatant.baseStats.fortitude}
+        ariaLabel={fortAriaLabel}
+        onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
+      />
+      <StatRollButton
+        label="Ref"
+        modifier={combatant.baseStats.reflex}
+        ariaLabel={refAriaLabel}
+        onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
+      />
+      <StatRollButton
+        label="Will"
+        modifier={combatant.baseStats.will}
+        ariaLabel={willAriaLabel}
+        onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
+      />
     </div>
   </div>
 
@@ -535,22 +578,31 @@
       disabled={!actions.canMarkReactionUsed}
       onclick={() => onMarkReactionUsed(combatant.id)}
     >Reaction Used</Button>
-    <Button
-      size="sm"
-      variant="secondary"
-      ariaLabel="Mark dead"
-      title={markDeadTitle}
-      disabled={!actions.canMarkDead}
-      onclick={() => onMarkDead(combatant.id)}
-    >Mark Dead</Button>
-    <Button
-      size="sm"
-      variant="secondary"
-      ariaLabel="Revive"
-      title={reviveTitle}
-      disabled={!actions.canRevive}
-      onclick={() => onRevive(combatant.id)}
-    >Revive</Button>
+    <details class="card-overflow">
+      <summary
+        class="card-overflow__toggle"
+        aria-label={`More actions for ${combatant.name}`}
+        title="More actions"
+      >⋯</summary>
+      <div class="card-overflow__menu" role="menu">
+        <Button
+          size="sm"
+          variant="secondary"
+          ariaLabel="Mark dead"
+          title={markDeadTitle}
+          disabled={!actions.canMarkDead}
+          onclick={() => onMarkDead(combatant.id)}
+        >Mark Dead</Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          ariaLabel="Revive"
+          title={reviveTitle}
+          disabled={!actions.canRevive}
+          onclick={() => onRevive(combatant.id)}
+        >Revive</Button>
+      </div>
+    </details>
   </div>
 </article>
 
@@ -560,8 +612,24 @@
     background: var(--color-panel-2);
     border: var(--border-thin);
     border-left: 3px solid var(--color-rule-strong);
-    padding: var(--space-3) var(--space-4);
+    padding: var(--space-2) var(--space-3);
     transition: background 0.12s, border-color 0.12s;
+  }
+
+  .combatant-card[data-faction='pc'] {
+    border-left-color: var(--color-blue);
+  }
+
+  .combatant-card[data-faction='ally'] {
+    border-left-color: var(--color-blue);
+  }
+
+  .combatant-card[data-faction='enemy'] {
+    border-left-color: var(--color-red);
+  }
+
+  .combatant-card[data-faction='hazard'] {
+    border-left-color: var(--color-amber);
   }
 
   .current-card {
@@ -617,22 +685,44 @@
 
   .card-heading {
     display: flex;
-    align-items: start;
+    align-items: center;
     justify-content: space-between;
     gap: var(--space-3);
-  }
-
-  .card-heading__main {
-    min-width: 0;
-    flex: 1;
   }
 
   .card-title {
     display: flex;
     align-items: center;
-    justify-content: start;
     gap: var(--space-2);
     flex-wrap: wrap;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .faction-tag {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    flex: 0 0 auto;
+    line-height: 1.2;
+  }
+
+  .faction-tag[data-faction='pc'],
+  .faction-tag[data-faction='ally'] {
+    color: var(--color-blue);
+  }
+
+  .faction-tag[data-faction='enemy'] {
+    color: var(--color-red);
+  }
+
+  .faction-tag[data-faction='hazard'] {
+    color: var(--color-amber);
   }
 
   h2 {
@@ -646,24 +736,27 @@
 
   .card-aside {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: var(--space-2);
+    flex: 0 0 auto;
   }
 
   .card-reorder {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 2px;
   }
 
-  .card-initiative {
-    display: inline-flex;
+  .card-initiative-row {
+    display: flex;
     align-items: center;
     gap: 6px;
-    padding: 2px 6px;
+    margin-top: var(--space-2);
+    padding: 4px 8px;
     background: var(--color-panel);
     border: var(--border-thin);
     border-radius: var(--radius-card, 4px);
+    flex-wrap: wrap;
   }
 
   .card-initiative__input {
@@ -690,13 +783,14 @@
     white-space: nowrap;
   }
 
-  .stat-grid {
-    display: grid;
-    grid-template-columns: 64px minmax(0, 1fr) auto;
+  .stat-strip {
+    display: flex;
+    align-items: center;
     gap: var(--space-3);
-    margin-top: var(--space-3);
-    padding-top: var(--space-3);
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
     border-top: 1px dashed var(--color-rule);
+    flex-wrap: wrap;
   }
 
   .stat-cell {
@@ -707,6 +801,7 @@
 
   .stat-cell--ac {
     align-items: center;
+    flex: 0 0 auto;
   }
 
   .stat-cell--ac .stat-cell__value {
@@ -718,7 +813,16 @@
   }
 
   .stat-cell--hp {
-    min-width: 0;
+    flex: 1 1 200px;
+    min-width: 160px;
+  }
+
+  .stat-cell--saves {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: 4px;
+    flex: 0 0 auto;
   }
 
   .hp-row {
@@ -791,34 +895,13 @@
     background: var(--color-red);
   }
 
-  .stat-cell--saves {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: var(--space-3);
-    text-align: center;
-  }
-
-  .save {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-  }
-
-  .save__value {
-    font-family: var(--font-mono);
-    font-size: var(--text-base);
-    font-weight: 700;
-    color: var(--color-ink);
-  }
-
   .conditions {
     display: flex;
     align-items: center;
     justify-content: start;
     gap: var(--space-2);
     flex-wrap: wrap;
-    margin-top: var(--space-3);
+    margin-top: var(--space-2);
   }
 
   .conditions-empty {
@@ -937,9 +1020,67 @@
     justify-content: start;
     gap: var(--space-2);
     flex-wrap: wrap;
-    margin-top: var(--space-3);
-    padding-top: var(--space-3);
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
     border-top: 1px dashed var(--color-rule);
+  }
+
+  .card-overflow {
+    position: relative;
+  }
+
+  .card-overflow__toggle {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 24px;
+    padding: 0;
+    border: var(--border-thin);
+    border-radius: var(--radius-card, 4px);
+    background: transparent;
+    color: var(--color-ink-mute);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .card-overflow__toggle::-webkit-details-marker {
+    display: none;
+  }
+
+  .card-overflow__toggle:hover {
+    border-color: var(--color-ink);
+    color: var(--color-ink);
+  }
+
+  .card-overflow__toggle:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+  }
+
+  .card-overflow[open] .card-overflow__toggle {
+    border-color: var(--color-ink);
+    color: var(--color-ink);
+  }
+
+  .card-overflow__menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px;
+    background: var(--color-panel);
+    border: var(--border-strong);
+    border-radius: var(--radius-card, 4px);
+    box-shadow: var(--shadow-soft);
+    z-index: 5;
+    white-space: nowrap;
   }
 
   @media (max-width: 760px) {
@@ -948,8 +1089,16 @@
       flex-direction: column;
     }
 
-    .stat-grid {
-      grid-template-columns: 1fr;
+    .card-aside {
+      justify-content: space-between;
+    }
+
+    .stat-strip {
+      align-items: stretch;
+    }
+
+    .stat-cell--saves {
+      flex-wrap: wrap;
     }
   }
 </style>

--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -257,7 +257,7 @@
         return 'Hazard';
       case 'enemy':
       default:
-        return 'NPC';
+        return 'Enemy';
     }
   }
 
@@ -389,10 +389,6 @@
   {/if}
 
   <div class="stat-strip">
-    <div class="stat-cell stat-cell--ac">
-      <SectionLabel>AC</SectionLabel>
-      <span class="stat-cell__value">{combatant.baseStats.ac}</span>
-    </div>
     <div class="stat-cell stat-cell--hp">
       <SectionLabel>HP</SectionLabel>
       <div class="hp-row">
@@ -424,11 +420,15 @@
           {/if}
         </div>
       </div>
-      <div class="hp-track" aria-label={`${combatant.name} HP`}>
-        <div class="hp-fill" style={`width: ${hpPercent}%`}></div>
-      </div>
     </div>
-    <div class="stat-cell stat-cell--saves">
+    <div class="stat-cell stat-cell--defenses" aria-label="Defenses">
+      <div
+        class="stat-readout"
+        aria-label={`Armor Class ${combatant.baseStats.ac}`}
+      >
+        <span class="stat-readout__label">AC</span>
+        <span class="stat-readout__value">{combatant.baseStats.ac}</span>
+      </div>
       <StatRollButton
         label="Fort"
         modifier={combatant.baseStats.fortitude}
@@ -448,6 +448,10 @@
         onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
       />
     </div>
+  </div>
+
+  <div class="hp-track" aria-label={`${combatant.name} HP`}>
+    <div class="hp-fill" style={`width: ${hpPercent}%`}></div>
   </div>
 
   <div class="conditions" aria-label={`${combatant.name} conditions`}>
@@ -799,30 +803,45 @@
     gap: 2px;
   }
 
-  .stat-cell--ac {
-    align-items: center;
-    flex: 0 0 auto;
-  }
-
-  .stat-cell--ac .stat-cell__value {
-    font-family: var(--font-serif);
-    font-size: var(--text-xl);
-    font-weight: 600;
-    color: var(--color-ink);
-    line-height: var(--leading-tight);
-  }
-
   .stat-cell--hp {
-    flex: 1 1 200px;
-    min-width: 160px;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
-  .stat-cell--saves {
+  .stat-cell--defenses {
     display: flex;
     flex-direction: row;
-    align-items: stretch;
+    align-items: center;
     gap: 4px;
     flex: 0 0 auto;
+    flex-wrap: wrap;
+  }
+
+  .stat-readout {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-rule);
+    cursor: default;
+  }
+
+  .stat-readout__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+  }
+
+  .stat-readout__value {
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--color-ink);
   }
 
   .hp-row {
@@ -878,7 +897,8 @@
     overflow: hidden;
     background: var(--color-hp-bg);
     border: 1px solid var(--color-rule);
-    margin-top: var(--space-1);
+    margin-top: var(--space-2);
+    width: 100%;
   }
 
   .hp-fill {
@@ -1097,7 +1117,7 @@
       align-items: stretch;
     }
 
-    .stat-cell--saves {
+    .stat-cell--defenses {
       flex-wrap: wrap;
     }
   }

--- a/src/components/CombatantCard.test.ts
+++ b/src/components/CombatantCard.test.ts
@@ -186,13 +186,13 @@ describe('CombatantCard initiative control', () => {
 });
 
 describe('CombatantCard faction styling', () => {
-  test('a creature combatant gets data-faction="enemy" and renders an NPC tag', () => {
+  test('a creature combatant gets data-faction="enemy" and renders an Enemy tag', () => {
     const { container } = render(CombatantCard, {
       props: baseProps({ combatant: combatant('goblin-1', { sourceType: 'creature' }) })
     });
     const article = container.querySelector('article.combatant-card');
     expect(article?.getAttribute('data-faction')).toBe('enemy');
-    expect(article?.textContent).toContain('NPC');
+    expect(article?.textContent).toContain('Enemy');
   });
 
   test('a partyMember combatant gets data-faction="pc" and renders a PC tag', () => {

--- a/src/components/CombatantCard.test.ts
+++ b/src/components/CombatantCard.test.ts
@@ -184,3 +184,101 @@ describe('CombatantCard initiative control', () => {
     expect(screen.getByText('(-1 Perception)')).toBeInTheDocument();
   });
 });
+
+describe('CombatantCard faction styling', () => {
+  test('a creature combatant gets data-faction="enemy" and renders an NPC tag', () => {
+    const { container } = render(CombatantCard, {
+      props: baseProps({ combatant: combatant('goblin-1', { sourceType: 'creature' }) })
+    });
+    const article = container.querySelector('article.combatant-card');
+    expect(article?.getAttribute('data-faction')).toBe('enemy');
+    expect(article?.textContent).toContain('NPC');
+  });
+
+  test('a partyMember combatant gets data-faction="pc" and renders a PC tag', () => {
+    const { container } = render(CombatantCard, {
+      props: baseProps({ combatant: combatant('cleric-1', { sourceType: 'partyMember' }) })
+    });
+    const article = container.querySelector('article.combatant-card');
+    expect(article?.getAttribute('data-faction')).toBe('pc');
+    expect(article?.textContent).toContain('PC');
+  });
+
+  test('a hazard combatant gets data-faction="hazard" and renders a Hazard tag', () => {
+    const { container } = render(CombatantCard, {
+      props: baseProps({ combatant: combatant('trap-1', { sourceType: 'hazard' }) })
+    });
+    const article = container.querySelector('article.combatant-card');
+    expect(article?.getAttribute('data-faction')).toBe('hazard');
+    expect(article?.textContent).toContain('Hazard');
+  });
+
+  test('a companion combatant gets data-faction="ally"', () => {
+    const { container } = render(CombatantCard, {
+      props: baseProps({
+        combatant: combatant('wolf-1', { sourceType: 'companion', name: 'Wolf' })
+      })
+    });
+    const article = container.querySelector('article.combatant-card');
+    expect(article?.getAttribute('data-faction')).toBe('ally');
+    expect(article?.textContent).toContain('Ally');
+  });
+});
+
+describe('CombatantCard save rolls', () => {
+  test('renders a button per save with signed modifier', () => {
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.fortitude = 12;
+    c.baseStats.reflex = 9;
+    c.baseStats.will = -1;
+    render(CombatantCard, { props: baseProps({ combatant: c }) });
+
+    const fort = screen.getByRole('button', {
+      name: 'Roll Goblin Warrior Fortitude save (+12)'
+    });
+    expect(fort).toHaveTextContent('Fort');
+    expect(fort).toHaveTextContent('+12');
+
+    const ref = screen.getByRole('button', {
+      name: 'Roll Goblin Warrior Reflex save (+9)'
+    });
+    expect(ref).toHaveTextContent('Ref');
+    expect(ref).toHaveTextContent('+9');
+
+    const will = screen.getByRole('button', {
+      name: 'Roll Goblin Warrior Will save (-1)'
+    });
+    expect(will).toHaveTextContent('Will');
+    expect(will).toHaveTextContent('-1');
+  });
+
+  test('clicking a save button forwards onRollSave with combatant id, save key, and click origin', async () => {
+    const onRollSave = vi.fn();
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.reflex = 7;
+    render(CombatantCard, { props: baseProps({ combatant: c, onRollSave }) });
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Roll Goblin Warrior Reflex save (+7)' }),
+      { clientX: 11, clientY: 22 }
+    );
+
+    expect(onRollSave).toHaveBeenCalledTimes(1);
+    expect(onRollSave).toHaveBeenCalledWith('goblin-1', 'reflex', { x: 11, y: 22 });
+  });
+
+  test('clicking a save button does not also fire the card onSelect handler', async () => {
+    const onSelect = vi.fn();
+    const onRollSave = vi.fn();
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.fortitude = 5;
+    render(CombatantCard, { props: baseProps({ combatant: c, onSelect, onRollSave }) });
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Roll Goblin Warrior Fortitude save (+5)' })
+    );
+
+    expect(onRollSave).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -6,9 +6,12 @@
   import Chip from './ui/Chip.svelte';
   import NotesEditor from './NotesEditor.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import StatRollButton from './ui/StatRollButton.svelte';
   import AbilityCard from './details/AbilityCard.svelte';
   import AttackRow from './details/AttackRow.svelte';
   import SpellcastingBlockView from './details/SpellcastingBlockView.svelte';
+
+  type SaveKey = 'fortitude' | 'reflex' | 'will';
 
   export let combatant: CombatantState | undefined;
   export let onSetNote: (combatantId: string, note: string | null) => void;
@@ -21,6 +24,11 @@
   export let onRollDamage: (
     combatantId: string,
     attack: Attack,
+    origin: { x: number; y: number }
+  ) => void = () => {};
+  export let onRollSave: (
+    combatantId: string,
+    save: SaveKey,
     origin: { x: number; y: number }
   ) => void = () => {};
   export let onUseSpellSlot: (combatantId: string, blockId: string, rank: number) => void = () => {};
@@ -86,20 +94,26 @@
           <dd>{combatant.baseStats.speed} ft</dd>
         </div>
       </dl>
-      <dl class="saves-grid">
-        <div class="stat stat--small">
-          <SectionLabel>Fort</SectionLabel>
-          <dd>{formatModifier(combatant.baseStats.fortitude)}</dd>
-        </div>
-        <div class="stat stat--small">
-          <SectionLabel>Ref</SectionLabel>
-          <dd>{formatModifier(combatant.baseStats.reflex)}</dd>
-        </div>
-        <div class="stat stat--small">
-          <SectionLabel>Will</SectionLabel>
-          <dd>{formatModifier(combatant.baseStats.will)}</dd>
-        </div>
-      </dl>
+      <div class="saves-grid">
+        <StatRollButton
+          label="Fort"
+          modifier={combatant.baseStats.fortitude}
+          ariaLabel={`Roll ${combatant.name} Fortitude save (${formatModifier(combatant.baseStats.fortitude)})`}
+          onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
+        />
+        <StatRollButton
+          label="Ref"
+          modifier={combatant.baseStats.reflex}
+          ariaLabel={`Roll ${combatant.name} Reflex save (${formatModifier(combatant.baseStats.reflex)})`}
+          onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
+        />
+        <StatRollButton
+          label="Will"
+          modifier={combatant.baseStats.will}
+          ariaLabel={`Roll ${combatant.name} Will save (${formatModifier(combatant.baseStats.will)})`}
+          onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
+        />
+      </div>
     </section>
 
     {#if combatant.passiveAbilities.length > 0}
@@ -271,10 +285,6 @@
     font-size: var(--text-xl);
     font-weight: 600;
     line-height: var(--leading-tight);
-  }
-
-  .stat--small dd {
-    font-size: var(--text-lg);
   }
 
   .muted {

--- a/src/components/ui/StatRollButton.svelte
+++ b/src/components/ui/StatRollButton.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { formatModifier } from '$lib/abilities/format-damage';
+
+  type Tone = 'default' | 'pc';
+
+  export let label: string;
+  export let modifier: number;
+  export let disabled = false;
+  export let title: string | undefined = undefined;
+  export let ariaLabel: string | undefined = undefined;
+  export let tone: Tone = 'default';
+  export let onRoll: (origin: { x: number; y: number }) => void = () => {};
+
+  $: signedModifier = formatModifier(modifier);
+  $: computedAriaLabel = ariaLabel ?? `Roll ${label} (${signedModifier})`;
+
+  function handleClick(event: MouseEvent) {
+    onRoll({ x: event.clientX, y: event.clientY });
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = event.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    onRoll({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+  }
+</script>
+
+<button
+  type="button"
+  {disabled}
+  {title}
+  aria-label={computedAriaLabel}
+  class="stat-roll stat-roll--{tone}"
+  onclick={handleClick}
+  onkeydown={handleKeyDown}
+>
+  <span class="stat-roll__label">{label}</span>
+  <span class="stat-roll__mod">{signedModifier}</span>
+</button>
+
+<style>
+  .stat-roll {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    color: var(--color-ink);
+    border: 1px solid var(--color-rule);
+    font: inherit;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+  }
+
+  .stat-roll:hover:not(:disabled) {
+    background: var(--color-panel);
+    border-color: var(--color-ink);
+  }
+
+  .stat-roll:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 1px;
+  }
+
+  .stat-roll:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .stat-roll__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-mute);
+  }
+
+  .stat-roll__mod {
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--color-ink);
+  }
+
+  .stat-roll--pc .stat-roll__mod {
+    color: var(--color-blue);
+  }
+</style>

--- a/src/components/ui/StatRollButton.test.ts
+++ b/src/components/ui/StatRollButton.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import StatRollButton from './StatRollButton.svelte';
+
+describe('StatRollButton', () => {
+  test('renders the label and signed modifier', () => {
+    render(StatRollButton, { props: { label: 'FORT', modifier: 12 } });
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveTextContent('FORT');
+    expect(btn).toHaveTextContent('+12');
+  });
+
+  test('renders a negative modifier with a minus sign', () => {
+    render(StatRollButton, { props: { label: 'WILL', modifier: -1 } });
+    expect(screen.getByRole('button')).toHaveTextContent('-1');
+  });
+
+  test('default aria-label combines label and signed modifier', () => {
+    render(StatRollButton, { props: { label: 'REF', modifier: 9 } });
+    expect(screen.getByRole('button', { name: 'Roll REF (+9)' })).toBeInTheDocument();
+  });
+
+  test('honors a custom ariaLabel override', () => {
+    render(StatRollButton, {
+      props: { label: 'FORT', modifier: 12, ariaLabel: 'Roll Fortitude save plus 12' }
+    });
+    expect(
+      screen.getByRole('button', { name: 'Roll Fortitude save plus 12' })
+    ).toBeInTheDocument();
+  });
+
+  test('forwards click coordinates to onRoll', async () => {
+    const onRoll = vi.fn();
+    render(StatRollButton, {
+      props: { label: 'FORT', modifier: 12, onRoll }
+    });
+    await fireEvent.click(screen.getByRole('button'), { clientX: 123, clientY: 456 });
+    expect(onRoll).toHaveBeenCalledTimes(1);
+    expect(onRoll).toHaveBeenCalledWith({ x: 123, y: 456 });
+  });
+
+  test('disables the button when disabled is true', () => {
+    render(StatRollButton, { props: { label: 'FORT', modifier: 12, disabled: true } });
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  test('applies the requested tone class', () => {
+    render(StatRollButton, { props: { label: 'FORT', modifier: 12, tone: 'pc' } });
+    expect(screen.getByRole('button').className).toContain('stat-roll--pc');
+  });
+});

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -186,6 +186,22 @@ export function combatantVisualState(combatant: CombatantState): CombatantVisual
   return 'alive';
 }
 
+export type CombatantFaction = 'pc' | 'ally' | 'enemy' | 'hazard';
+
+export function combatantFaction(combatant: CombatantState): CombatantFaction {
+  switch (combatant.sourceType) {
+    case 'partyMember':
+      return 'pc';
+    case 'companion':
+      return 'ally';
+    case 'hazard':
+      return 'hazard';
+    case 'creature':
+    default:
+      return 'enemy';
+  }
+}
+
 export interface CombatantCardActionAvailability {
   canEndTurn: boolean;
   canMarkReactionUsed: boolean;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -749,6 +749,43 @@
     });
   }
 
+  type SaveKey = 'fortitude' | 'reflex' | 'will';
+  const SAVE_LABELS: Record<SaveKey, string> = {
+    fortitude: 'Fort',
+    reflex: 'Reflex',
+    will: 'Will'
+  };
+
+  function rollSaveFor(combatantId: string, save: SaveKey, origin: { x: number; y: number }) {
+    const c = encounter.combatants[combatantId];
+    if (!c) return;
+    const mod = c.baseStats[save];
+    const result = rollAttackDice(mod);
+    const isCrit = result.d20 === 20;
+    const isFumble = result.d20 === 1;
+    const logTone = isCrit ? 'success' : isFumble ? 'danger' : 'info';
+    const bubbleTone: BubbleTone = isCrit ? 'crit' : isFumble ? 'fumble' : 'normal';
+    const label = SAVE_LABELS[save];
+    const badge = isCrit ? 'NAT 20' : isFumble ? 'NAT 1' : `${label} save`;
+
+    encounter = appendInfoLog(
+      encounter,
+      nextRollId(),
+      `${c.name} ${label} save: 1d20(${result.d20}) ${formatModifier(mod)} = ${result.total}`,
+      logTone
+    );
+    persistence.persist(encounter);
+
+    showBubble({
+      x: origin.x,
+      y: origin.y,
+      total: String(result.total),
+      detail: `1d20(${result.d20}) ${formatModifier(mod)}`,
+      tone: bubbleTone,
+      badge
+    });
+  }
+
   function rollDamageFor(combatantId: string, attack: Attack, origin: { x: number; y: number }) {
     const c = encounter.combatants[combatantId];
     if (!c || attack.damage.length === 0) return;
@@ -894,6 +931,7 @@
             combatantsById={encounter.combatants}
             onResolvePrompt={resolvePrompt}
             onApplyPersistentDamage={applyPersistentDamageFromPrompt}
+            onRollSave={rollSaveFor}
           />
         {/each}
       </div>
@@ -905,6 +943,7 @@
         onSetNote={setNote}
         onRollAttack={rollAttackFor}
         onRollDamage={rollDamageFor}
+        onRollSave={rollSaveFor}
         onUseSpellSlot={useSpellSlot}
         onRestoreSpellSlot={restoreSpellSlot}
         onUseFocusPoint={useFocusPoint}


### PR DESCRIPTION
## Summary

- Collapses the heading + stats grid into one heading row plus a single `AC | HP | Fort | Ref | Will` stats strip; reorder arrows go inline with the heading instead of taking their own column, and `Mark Dead` / `Revive` move behind a `⋯` overflow disclosure to free up vertical space.
- Adds friend/foe distinction: `combatantFaction()` derives `pc | ally | enemy | hazard` from `sourceType`, the card paints the left-border accent (blue / red / amber) and renders a small `PC` / `Ally` / `NPC` / `Hazard` tag next to the name.
- Makes saves clickable: new `ui/StatRollButton` (label + signed modifier) is used by both the card and the details panel. Clicking rolls `d20 + save modifier` via a new `rollSaveFor` route handler that mirrors `rollAttackFor` — same `RollBubble` at the click site, same combat-log entry, same nat 20 / nat 1 highlighting.

## Test plan

- [x] `npm run check` — clean (svelte-check + tsc on domain)
- [x] `npm run test:run` — 688/688 pass; new tests cover faction `data-attribute` per `sourceType`, save buttons render with signed modifiers, save clicks forward to `onRollSave` with the right key + click origin, and a save click does not double-fire `onSelect`.
- [x] `npm run audit`
- [x] `npm run build`
- [ ] Manual: `npm run dev`, mixed encounter (PC + creature + hazard); confirm left-border accent matches faction, click each Fort/Ref/Will on a couple of cards and on the details panel — bubble appears at cursor, log line shows the save, nat 20 / nat 1 colour the bubble.
- [ ] Manual: PREPARING phase shows the initiative editor on its own row below the heading; reorder arrows live inline and respect `isFirst` / `isLast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)