### PR TITLE
Conditions modify displayed stats and rolls

### DIFF
--- a/pf2e-conditions-library-spec.md
+++ b/pf2e-conditions-library-spec.md
@@ -56,7 +56,9 @@ These are added to the `StatTarget` type:
 ```typescript
 type StatTarget =
   | "ac" | "fortitude" | "reflex" | "will" | "perception"
-  | "attackRolls" | "allDCs" | "allSaves" | "allSkills"
+  | "attackRolls" | "damageRolls"
+  | "allDCs" | "spellDcs" | "spellAttacks"
+  | "allSaves" | "allSkills"
   | "strSkills" | "dexSkills" | "intSkills" | "wisSkills" | "chaSkills"
   | "mentalSkills"
   | string            // specific skill: "athletics", "stealth", etc.
@@ -199,12 +201,14 @@ Status penalty equal to value on mental checks, spell attack rolls, and spell DC
   modifiers: [
     { stat: "mentalSkills", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
     { stat: "will",         bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "spellDcs",     bonusType: "status", value: { kind: "effectValue", sign: -1 } },
+    { stat: "spellAttacks", bonusType: "status", value: { kind: "effectValue", sign: -1 } },
   ],
-  description: "Also applies to spell attack rolls and spell DCs (not in stat model). When casting a spell, DC 5 + value flat check or spell is lost.",
+  description: "When casting a spell, DC 5 + value flat check or the spell is lost.",
 }
 ```
 
-No automated spell attack or spell DC modifiers — those spell stats are outside the current combatant stat model.
+Spell DCs and spell attacks are automated via the `spellDcs` and `spellAttacks` stat targets. The DC 5 + value flat check on spellcasting is procedural and stays in `description` for GM reference.
 
 #### Drained (1–4)
 

--- a/pf2e-tracker-v2-architecture-spec.md
+++ b/pf2e-tracker-v2-architecture-spec.md
@@ -332,8 +332,8 @@ type StatTarget =
   | "ac"
   | "fortitude" | "reflex" | "will" | "allSaves"
   | "perception"
-  | "attackRolls"
-  | "allDCs"
+  | "attackRolls" | "damageRolls"
+  | "allDCs" | "spellDcs" | "spellAttacks"
   | "allSkills"
   | string    // specific skill: "athletics", "stealth", etc.
 ```
@@ -365,7 +365,10 @@ interface ComputedStats {
   will: { final: number; base: number; modifiers: AppliedModifier[] }
   perception: { final: number; base: number; modifiers: AppliedModifier[] }
   attackRolls: { total: number; modifiers: AppliedModifier[] }
+  damageRolls: { total: number; modifiers: AppliedModifier[] }
   allDCs: { total: number; modifiers: AppliedModifier[] }
+  spellDcs: { total: number; modifiers: AppliedModifier[] }
+  spellAttacks: { total: number; modifiers: AppliedModifier[] }
   skills: Record<string, { final: number; base: number; modifiers: AppliedModifier[] }>
 }
 

--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -4,6 +4,8 @@
     clampValue,
     combatantFaction,
     combatantVisualState,
+    computeCombatantStats,
+    formatStatTooltip,
     resolveApplyChoice,
     type AppliedEffectView,
     type ApplyConditionChoice,
@@ -176,7 +178,7 @@
   function rollInitiative() {
     if (!onSetInitiative) return;
     const die = Math.floor(Math.random() * 20) + 1;
-    onSetInitiative(combatant.id, die + combatant.baseStats.perception);
+    onSetInitiative(combatant.id, die + computed.perception.final);
   }
 
   let pickerOpen = false;
@@ -287,9 +289,27 @@
       ? 'Combatant is already alive'
       : 'Revive is unavailable in this phase';
 
-  $: fortAriaLabel = `Roll ${combatant.name} Fortitude save (${formatModifier(combatant.baseStats.fortitude)})`;
-  $: refAriaLabel = `Roll ${combatant.name} Reflex save (${formatModifier(combatant.baseStats.reflex)})`;
-  $: willAriaLabel = `Roll ${combatant.name} Will save (${formatModifier(combatant.baseStats.will)})`;
+  $: computed = computeCombatantStats(combatant);
+  $: acTooltip = formatStatTooltip(computed.ac.base, computed.ac.final, computed.ac.modifiers);
+  $: fortTooltip = formatStatTooltip(
+    computed.fortitude.base,
+    computed.fortitude.final,
+    computed.fortitude.modifiers
+  );
+  $: refTooltip = formatStatTooltip(
+    computed.reflex.base,
+    computed.reflex.final,
+    computed.reflex.modifiers
+  );
+  $: willTooltip = formatStatTooltip(
+    computed.will.base,
+    computed.will.final,
+    computed.will.modifiers
+  );
+
+  $: fortAriaLabel = `Roll ${combatant.name} Fortitude save (${formatModifier(computed.fortitude.final)})`;
+  $: refAriaLabel = `Roll ${combatant.name} Reflex save (${formatModifier(computed.reflex.final)})`;
+  $: willAriaLabel = `Roll ${combatant.name} Will save (${formatModifier(computed.will.final)})`;
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -383,8 +403,14 @@
       >Roll</Button>
       <span
         class="card-initiative__hint"
-        aria-label={`Perception modifier ${combatant.baseStats.perception >= 0 ? '+' : ''}${combatant.baseStats.perception}`}
-      >({combatant.baseStats.perception >= 0 ? '+' : ''}{combatant.baseStats.perception} Perception)</span>
+        class:modified={computed.perception.final !== computed.perception.base}
+        title={formatStatTooltip(
+          computed.perception.base,
+          computed.perception.final,
+          computed.perception.modifiers
+        )}
+        aria-label={`Perception modifier ${computed.perception.final >= 0 ? '+' : ''}${computed.perception.final}`}
+      >({computed.perception.final >= 0 ? '+' : ''}{computed.perception.final} Perception)</span>
     </div>
   {/if}
 
@@ -424,30 +450,40 @@
     <div class="stat-cell stat-cell--defenses" aria-label="Defenses">
       <div
         class="stat-readout"
-        aria-label={`Armor Class ${combatant.baseStats.ac}`}
+        title={acTooltip}
+        aria-label={`Armor Class ${computed.ac.final}${computed.ac.final !== computed.ac.base ? ` (base ${computed.ac.base})` : ''}`}
       >
         <span class="stat-readout__label">AC</span>
-        <span class="stat-readout__value">{combatant.baseStats.ac}</span>
+        <span
+          class="stat-readout__value"
+          class:modified={computed.ac.final !== computed.ac.base}
+        >{computed.ac.final}</span>
       </div>
       <StatRollButton
         label="Fort"
-        modifier={combatant.baseStats.fortitude}
+        modifier={computed.fortitude.final}
         tone="save"
         ariaLabel={fortAriaLabel}
+        breakdownTitle={fortTooltip}
+        modified={computed.fortitude.final !== computed.fortitude.base}
         onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
       />
       <StatRollButton
         label="Ref"
-        modifier={combatant.baseStats.reflex}
+        modifier={computed.reflex.final}
         tone="save"
         ariaLabel={refAriaLabel}
+        breakdownTitle={refTooltip}
+        modified={computed.reflex.final !== computed.reflex.base}
         onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
       />
       <StatRollButton
         label="Will"
-        modifier={combatant.baseStats.will}
+        modifier={computed.will.final}
         tone="save"
         ariaLabel={willAriaLabel}
+        breakdownTitle={willTooltip}
+        modified={computed.will.final !== computed.will.base}
         onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
       />
     </div>
@@ -854,6 +890,17 @@
     font-size: var(--text-base);
     font-weight: 700;
     color: var(--color-ink);
+  }
+
+  .stat-readout__value.modified {
+    color: var(--effect-cond);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+  }
+
+  .card-initiative__hint.modified {
+    color: var(--effect-cond);
   }
 
   .hp-row {

--- a/src/components/CombatantCard.test.ts
+++ b/src/components/CombatantCard.test.ts
@@ -282,3 +282,98 @@ describe('CombatantCard save rolls', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 });
+
+describe('CombatantCard conditions modify stats', () => {
+  function withFrightened(value: number) {
+    return combatant('goblin-1', {
+      name: 'Goblin Warrior',
+      appliedEffects: [
+        {
+          instanceId: 'frightened-1',
+          effectId: 'frightened',
+          value,
+          duration: { type: 'unlimited' }
+        }
+      ]
+    });
+  }
+
+  test('Frightened 2: AC = base − 2 and save buttons drop by 2', () => {
+    const c = withFrightened(2);
+    c.baseStats.ac = 18;
+    c.baseStats.fortitude = 9;
+    c.baseStats.reflex = 8;
+    c.baseStats.will = 7;
+    const { container } = render(CombatantCard, { props: baseProps({ combatant: c }) });
+
+    const acValue = container.querySelector('.stat-readout__value');
+    expect(acValue?.textContent).toBe('16');
+    expect(acValue?.classList.contains('modified')).toBe(true);
+
+    expect(screen.getByRole('button', { name: 'Roll Goblin Warrior Fortitude save (+7)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Goblin Warrior Reflex save (+6)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll Goblin Warrior Will save (+5)' })).toBeInTheDocument();
+  });
+
+  test('Off-Guard alone: AC = base − 2 (circumstance)', () => {
+    const c = combatant('goblin-1', {
+      name: 'Goblin Warrior',
+      appliedEffects: [
+        { instanceId: 'og-1', effectId: 'off-guard', duration: { type: 'unlimited' } }
+      ]
+    });
+    c.baseStats.ac = 18;
+    const { container } = render(CombatantCard, { props: baseProps({ combatant: c }) });
+
+    const acValue = container.querySelector('.stat-readout__value');
+    expect(acValue?.textContent).toBe('16');
+  });
+
+  test('Frightened 2 + Off-Guard: AC stacks to base − 4 (status + circumstance)', () => {
+    const c = combatant('goblin-1', {
+      name: 'Goblin Warrior',
+      appliedEffects: [
+        { instanceId: 'fr-1', effectId: 'frightened', value: 2, duration: { type: 'unlimited' } },
+        { instanceId: 'og-1', effectId: 'off-guard', duration: { type: 'unlimited' } }
+      ]
+    });
+    c.baseStats.ac = 18;
+    const { container } = render(CombatantCard, { props: baseProps({ combatant: c }) });
+
+    const acValue = container.querySelector('.stat-readout__value');
+    expect(acValue?.textContent).toBe('14');
+  });
+
+  test('Frightened 1 + Sickened 2: AC = base − 2 (only worse same-type status applies)', () => {
+    const c = combatant('goblin-1', {
+      name: 'Goblin Warrior',
+      appliedEffects: [
+        { instanceId: 'fr-1', effectId: 'frightened', value: 1, duration: { type: 'unlimited' } },
+        { instanceId: 'sk-1', effectId: 'sickened', value: 2, duration: { type: 'unlimited' } }
+      ]
+    });
+    c.baseStats.ac = 18;
+    const { container } = render(CombatantCard, { props: baseProps({ combatant: c }) });
+
+    const acValue = container.querySelector('.stat-readout__value');
+    expect(acValue?.textContent).toBe('16');
+  });
+
+  test('Roll initiative uses computed perception (Frightened 2 → die + perception − 2)', async () => {
+    const c = combatant('goblin-1', { name: 'Goblin Warrior' });
+    c.baseStats.perception = 7;
+    c.appliedEffects = [
+      { instanceId: 'fr-1', effectId: 'frightened', value: 2, duration: { type: 'unlimited' } }
+    ];
+    const onSetInitiative = vi.fn();
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // d20 = 11
+    try {
+      render(CombatantCard, { props: baseProps({ combatant: c, onSetInitiative }) });
+      await fireEvent.click(screen.getByRole('button', { name: 'Roll initiative for Goblin Warrior' }));
+      // 11 + (7 - 2) = 16
+      expect(onSetInitiative).toHaveBeenCalledWith('goblin-1', 16);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
-  import type { Ability, Attack, CombatantState } from '../domain';
+  import type { Ability, Attack, CombatantState, ComputedStats } from '../domain';
   import { templateLabel } from '$lib/template-label';
   import { formatModifier } from '$lib/abilities/format-damage';
+  import {
+    computeCombatantStats,
+    formatModifierBreakdown,
+    formatStatTooltip
+  } from '$lib/encounter-app';
   import type { MapVariant } from '$lib/dice/map';
   import Chip from './ui/Chip.svelte';
   import NotesEditor from './NotesEditor.svelte';
@@ -53,6 +58,19 @@
         .filter(Boolean)
         .join(' · ')
     : '';
+
+  $: computed = combatant ? computeCombatantStats(combatant) : null;
+
+  function statTooltip(stat: ComputedStats['ac']): string {
+    return formatStatTooltip(stat.base, stat.final, stat.modifiers);
+  }
+
+  function bucketTooltip(label: string, total: number, mods: ComputedStats['attackRolls']['modifiers']): string {
+    if (total === 0) return '';
+    const breakdown = formatModifierBreakdown(mods);
+    const sign = total >= 0 ? '+' : '';
+    return breakdown ? `${label} ${sign}${total} (${breakdown})` : `${label} ${sign}${total}`;
+  }
 </script>
 
 <aside class="details" aria-label="Combatant details">
@@ -76,7 +94,10 @@
       <dl class="defenses-grid">
         <div class="stat">
           <SectionLabel>AC</SectionLabel>
-          <dd>{combatant.baseStats.ac}</dd>
+          <dd
+            title={computed ? statTooltip(computed.ac) : ''}
+            class:modified={computed && computed.ac.final !== computed.ac.base}
+          >{computed ? computed.ac.final : combatant.baseStats.ac}</dd>
         </div>
         <div class="stat">
           <SectionLabel>HP</SectionLabel>
@@ -87,7 +108,10 @@
         </div>
         <div class="stat">
           <SectionLabel>Perception</SectionLabel>
-          <dd>{formatModifier(combatant.baseStats.perception)}</dd>
+          <dd
+            title={computed ? statTooltip(computed.perception) : ''}
+            class:modified={computed && computed.perception.final !== computed.perception.base}
+          >{formatModifier(computed ? computed.perception.final : combatant.baseStats.perception)}</dd>
         </div>
         <div class="stat">
           <SectionLabel>Speed</SectionLabel>
@@ -97,23 +121,29 @@
       <div class="saves-grid">
         <StatRollButton
           label="Fort"
-          modifier={combatant.baseStats.fortitude}
+          modifier={computed ? computed.fortitude.final : combatant.baseStats.fortitude}
           tone="save"
-          ariaLabel={`Roll ${combatant.name} Fortitude save (${formatModifier(combatant.baseStats.fortitude)})`}
+          ariaLabel={`Roll ${combatant.name} Fortitude save (${formatModifier(computed ? computed.fortitude.final : combatant.baseStats.fortitude)})`}
+          breakdownTitle={computed ? statTooltip(computed.fortitude) : undefined}
+          modified={!!computed && computed.fortitude.final !== computed.fortitude.base}
           onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
         />
         <StatRollButton
           label="Ref"
-          modifier={combatant.baseStats.reflex}
+          modifier={computed ? computed.reflex.final : combatant.baseStats.reflex}
           tone="save"
-          ariaLabel={`Roll ${combatant.name} Reflex save (${formatModifier(combatant.baseStats.reflex)})`}
+          ariaLabel={`Roll ${combatant.name} Reflex save (${formatModifier(computed ? computed.reflex.final : combatant.baseStats.reflex)})`}
+          breakdownTitle={computed ? statTooltip(computed.reflex) : undefined}
+          modified={!!computed && computed.reflex.final !== computed.reflex.base}
           onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
         />
         <StatRollButton
           label="Will"
-          modifier={combatant.baseStats.will}
+          modifier={computed ? computed.will.final : combatant.baseStats.will}
           tone="save"
-          ariaLabel={`Roll ${combatant.name} Will save (${formatModifier(combatant.baseStats.will)})`}
+          ariaLabel={`Roll ${combatant.name} Will save (${formatModifier(computed ? computed.will.final : combatant.baseStats.will)})`}
+          breakdownTitle={computed ? statTooltip(computed.will) : undefined}
+          modified={!!computed && computed.will.final !== computed.will.base}
           onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
         />
       </div>
@@ -149,6 +179,14 @@
             <li>
               <AttackRow
                 attack={attack as Attack}
+                attackBonus={computed ? computed.attackRolls.total : 0}
+                damageBonus={computed ? computed.damageRolls.total : 0}
+                attackTooltip={computed
+                  ? bucketTooltip('attack', computed.attackRolls.total, computed.attackRolls.modifiers)
+                  : ''}
+                damageTooltip={computed
+                  ? bucketTooltip('damage', computed.damageRolls.total, computed.damageRolls.modifiers)
+                  : ''}
                 onRollAttack={(a, v, origin) => onRollAttack(combatant.id, a, v, origin)}
                 onRollDamage={(a, origin) => onRollDamage(combatant.id, a, origin)}
               />
@@ -176,6 +214,14 @@
           {#each combatant.spellcasting as block (block.blockId)}
             <SpellcastingBlockView
               {block}
+              dcBonus={computed ? computed.spellDcs.total : 0}
+              attackBonus={computed ? computed.spellAttacks.total : 0}
+              dcTooltip={computed
+                ? bucketTooltip('DC', computed.spellDcs.total, computed.spellDcs.modifiers)
+                : ''}
+              attackTooltip={computed
+                ? bucketTooltip('attack', computed.spellAttacks.total, computed.spellAttacks.modifiers)
+                : ''}
               onUseSlot={(blockId, rank) => onUseSpellSlot(combatant.id, blockId, rank)}
               onRestoreSlot={(blockId, rank) => onRestoreSpellSlot(combatant.id, blockId, rank)}
               onUseFocus={(blockId) => onUseFocusPoint(combatant.id, blockId)}
@@ -288,6 +334,13 @@
     font-size: var(--text-xl);
     font-weight: 600;
     line-height: var(--leading-tight);
+  }
+
+  .stat dd.modified {
+    color: var(--effect-cond);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
   }
 
   .muted {

--- a/src/components/details/AttackRow.svelte
+++ b/src/components/details/AttackRow.svelte
@@ -4,11 +4,16 @@
   import { formatDamage, formatModifier } from '$lib/abilities/format-damage';
 
   export let attack: Attack;
+  export let attackBonus: number = 0;
+  export let damageBonus: number = 0;
+  export let attackTooltip: string = '';
+  export let damageTooltip: string = '';
   export let onRollAttack: (attack: Attack, variant: MapVariant, origin: { x: number; y: number }) => void;
   export let onRollDamage: (attack: Attack, origin: { x: number; y: number }) => void;
 
-  $: variants = mapVariants(attack.modifier, attack.traits);
+  $: variants = mapVariants(attack.modifier + attackBonus, attack.traits);
   $: damageLabel = formatDamage(attack.damage);
+  $: damageBonusSuffix = damageBonus !== 0 ? ` ${damageBonus > 0 ? '+' : ''}${damageBonus}` : '';
 </script>
 
 <article class="row">
@@ -25,6 +30,8 @@
         <button
           type="button"
           class="btn btn--attack"
+          class:btn--modified={attackBonus !== 0}
+          title={attackTooltip}
           aria-label="Roll {attack.name} {variant.label} attack ({formatModifier(variant.modifier)})"
           onclick={(e) => onRollAttack(attack, variant, { x: e.clientX, y: e.clientY })}
         >
@@ -37,11 +44,13 @@
       <button
         type="button"
         class="btn btn--damage"
-        aria-label="Roll {attack.name} damage ({damageLabel})"
+        class:btn--modified={damageBonus !== 0}
+        title={damageTooltip}
+        aria-label="Roll {attack.name} damage ({damageLabel}{damageBonusSuffix})"
         onclick={(e) => onRollDamage(attack, { x: e.clientX, y: e.clientY })}
       >
         <span class="btn__label">Dmg</span>
-        <span class="btn__mod">{damageLabel}</span>
+        <span class="btn__mod">{damageLabel}{damageBonusSuffix}</span>
       </button>
     {/if}
   </div>
@@ -149,5 +158,11 @@
 
   .btn--damage .btn__mod {
     font-size: var(--text-sm);
+  }
+
+  .btn--modified .btn__mod {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
   }
 </style>

--- a/src/components/details/SpellcastingBlockView.svelte
+++ b/src/components/details/SpellcastingBlockView.svelte
@@ -4,6 +4,10 @@
   import { formatModifier } from '$lib/abilities/format-damage';
 
   export let block: CombatantSpellcasting;
+  export let dcBonus: number = 0;
+  export let attackBonus: number = 0;
+  export let dcTooltip: string = '';
+  export let attackTooltip: string = '';
   export let onUseSlot: (blockId: string, rank: number) => void;
   export let onRestoreSlot: (blockId: string, rank: number) => void;
   export let onUseFocus: (blockId: string) => void;
@@ -39,10 +43,10 @@
       <span>·</span>
       <span>{view.header.type}</span>
       <span>·</span>
-      <span>DC {view.header.dc}</span>
+      <span class:modified={dcBonus !== 0} title={dcTooltip}>DC {view.header.dc + dcBonus}</span>
       {#if view.header.attackModifier !== undefined}
         <span>·</span>
-        <span>attack {formatModifier(view.header.attackModifier)}</span>
+        <span class:modified={attackBonus !== 0} title={attackTooltip}>attack {formatModifier(view.header.attackModifier + attackBonus)}</span>
       {/if}
     </div>
   </header>
@@ -373,5 +377,12 @@
     color: var(--color-ink-mute);
     font-family: var(--font-mono);
     font-size: var(--text-xs);
+  }
+
+  .block__meta .modified {
+    color: var(--effect-cond);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
   }
 </style>

--- a/src/components/ui/StatRollButton.svelte
+++ b/src/components/ui/StatRollButton.svelte
@@ -7,12 +7,15 @@
   export let modifier: number;
   export let disabled = false;
   export let title: string | undefined = undefined;
+  export let breakdownTitle: string | undefined = undefined;
+  export let modified = false;
   export let ariaLabel: string | undefined = undefined;
   export let tone: Tone = 'default';
   export let onRoll: (origin: { x: number; y: number }) => void = () => {};
 
   $: signedModifier = formatModifier(modifier);
   $: computedAriaLabel = ariaLabel ?? `Roll ${label} (${signedModifier})`;
+  $: effectiveTitle = breakdownTitle ?? title;
 
   function handleClick(event: MouseEvent) {
     onRoll({ x: event.clientX, y: event.clientY });
@@ -29,9 +32,10 @@
 <button
   type="button"
   {disabled}
-  {title}
+  title={effectiveTitle}
   aria-label={computedAriaLabel}
   class="stat-roll stat-roll--{tone}"
+  class:stat-roll--modified={modified}
   onclick={handleClick}
   onkeydown={handleKeyDown}
 >
@@ -129,5 +133,12 @@
   .stat-roll--save:hover:not(:disabled) {
     background: var(--color-panel);
     border-color: var(--roll-sav);
+  }
+
+  .stat-roll--modified .stat-roll__mod {
+    color: var(--effect-cond);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
   }
 </style>

--- a/src/domain/effects/derivation.test.ts
+++ b/src/domain/effects/derivation.test.ts
@@ -148,7 +148,49 @@ describe('deriveStats', () => {
     expect(computed.perception).toEqual({ base: 6, final: 6, modifiers: [] });
     expect(computed.skills.stealth).toEqual({ base: 11, final: 11, modifiers: [] });
     expect(computed.attackRolls).toEqual({ total: 0, modifiers: [] });
+    expect(computed.damageRolls).toEqual({ total: 0, modifiers: [] });
     expect(computed.allDCs).toEqual({ total: 0, modifiers: [] });
+    expect(computed.spellDcs).toEqual({ total: 0, modifiers: [] });
+    expect(computed.spellAttacks).toEqual({ total: 0, modifiers: [] });
+  });
+
+  test('routes damageRolls, spellDcs, spellAttacks status modifiers to their own buckets', () => {
+    const customWithBuckets: EffectLibrary = {
+      ...customLibrary,
+      damageStatus: {
+        id: 'damageStatus',
+        name: 'Damage Status',
+        category: 'custom',
+        hasValue: false,
+        modifiers: [{ stat: 'damageRolls', bonusType: 'status', value: -2 }]
+      },
+      spellDcStatus: {
+        id: 'spellDcStatus',
+        name: 'Spell DC Status',
+        category: 'custom',
+        hasValue: false,
+        modifiers: [{ stat: 'spellDcs', bonusType: 'status', value: -2 }]
+      },
+      spellAttackStatus: {
+        id: 'spellAttackStatus',
+        name: 'Spell Attack Status',
+        category: 'custom',
+        hasValue: false,
+        modifiers: [{ stat: 'spellAttacks', bonusType: 'status', value: -2 }]
+      }
+    };
+
+    const computed = deriveStats(
+      baseStats,
+      [applied('damageStatus'), applied('spellDcStatus'), applied('spellAttackStatus')],
+      customWithBuckets
+    );
+
+    expect(computed.damageRolls.total).toBe(-2);
+    expect(computed.spellDcs.total).toBe(-2);
+    expect(computed.spellAttacks.total).toBe(-2);
+    expect(computed.attackRolls.total).toBe(0);
+    expect(computed.allDCs.total).toBe(0);
   });
 
   test('keeps only the worse same-type status penalty from Frightened and Sickened', () => {

--- a/src/domain/effects/derivation.ts
+++ b/src/domain/effects/derivation.ts
@@ -13,7 +13,9 @@ import type {
 } from '../types';
 
 type BaseStatKey = 'ac' | 'fortitude' | 'reflex' | 'will' | 'perception';
-type BucketKey = 'attackRolls' | 'allDCs';
+type BucketKey = 'attackRolls' | 'damageRolls' | 'allDCs' | 'spellDcs' | 'spellAttacks';
+
+const bucketKeys: BucketKey[] = ['attackRolls', 'damageRolls', 'allDCs', 'spellDcs', 'spellAttacks'];
 type ModifierTarget =
   | { kind: 'base'; key: BaseStatKey }
   | { kind: 'bucket'; key: BucketKey }
@@ -44,7 +46,10 @@ export function deriveStats(
     perception: computeBaseStat(baseStats.perception, modifiersByTarget.perception),
     skills: computeSkills(baseStats.skills, modifiersByTarget.skills),
     attackRolls: computeBucket(modifiersByTarget.attackRolls),
-    allDCs: computeBucket(modifiersByTarget.allDCs)
+    damageRolls: computeBucket(modifiersByTarget.damageRolls),
+    allDCs: computeBucket(modifiersByTarget.allDCs),
+    spellDcs: computeBucket(modifiersByTarget.spellDcs),
+    spellAttacks: computeBucket(modifiersByTarget.spellAttacks)
   };
 }
 
@@ -62,7 +67,10 @@ function collectModifiers(
     will: [],
     perception: [],
     attackRolls: [],
+    damageRolls: [],
     allDCs: [],
+    spellDcs: [],
+    spellAttacks: [],
     skills: Object.fromEntries(Object.keys(baseStats.skills).map((skill) => [skill, []]))
   } as {
     [K in BaseStatKey | BucketKey]: AppliedModifier[];
@@ -244,7 +252,7 @@ function isBaseStatKey(stat: StatTarget): stat is BaseStatKey {
 }
 
 function isBucketKey(stat: StatTarget): stat is BucketKey {
-  return stat === 'attackRolls' || stat === 'allDCs';
+  return bucketKeys.includes(stat as BucketKey);
 }
 
 function isSkillMetaTarget(

--- a/src/domain/effects/library.test.ts
+++ b/src/domain/effects/library.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'vitest';
 import { effectLibrary } from './library';
-import type { BonusType, Modifier, ModifierValue, StatTarget, TurnBoundarySuggestion } from '../types';
+import { deriveStats } from './derivation';
+import type {
+  AppliedEffect,
+  BonusType,
+  CreatureBaseStats,
+  Modifier,
+  ModifierValue,
+  StatTarget,
+  TurnBoundarySuggestion
+} from '../types';
 
 const supportedBonusTypes = new Set<BonusType>(['status', 'circumstance', 'item', 'untyped']);
 
@@ -12,7 +21,10 @@ const supportedStatTargets = new Set<StatTarget>([
   'allSaves',
   'perception',
   'attackRolls',
+  'damageRolls',
   'allDCs',
+  'spellDcs',
+  'spellAttacks',
   'allSkills',
   'strSkills',
   'dexSkills',
@@ -130,6 +142,109 @@ describe('effectLibrary', () => {
       hasValue: false,
       impliedEffects: ['clumsy']
     });
+  });
+
+  test('wires Stupefied to spell DC and spell attack rolls via deriveStats', () => {
+    const baseStats: CreatureBaseStats = {
+      hp: 30,
+      ac: 18,
+      fortitude: 7,
+      reflex: 7,
+      will: 9,
+      perception: 8,
+      speed: 25,
+      skills: { arcana: 10, occultism: 9 }
+    };
+    const applied: AppliedEffect = {
+      instanceId: 'stupefied-2',
+      effectId: 'stupefied',
+      value: 2,
+      duration: { type: 'unlimited' }
+    };
+
+    const computed = deriveStats(baseStats, [applied], effectLibrary);
+
+    expect(computed.spellDcs.total).toBe(-2);
+    expect(computed.spellAttacks.total).toBe(-2);
+    expect(computed.will.final).toBe(7);
+    expect(computed.skills.arcana.final).toBe(8);
+  });
+
+  test('wires Bless and Bane attack-roll modifiers', () => {
+    const baseStats: CreatureBaseStats = {
+      hp: 20,
+      ac: 18,
+      fortitude: 7,
+      reflex: 7,
+      will: 7,
+      perception: 6,
+      speed: 25,
+      skills: {}
+    };
+    const blessed: AppliedEffect = { instanceId: 'b1', effectId: 'bless', duration: { type: 'unlimited' } };
+    const baned: AppliedEffect = { instanceId: 'b2', effectId: 'bane', duration: { type: 'unlimited' } };
+
+    expect(deriveStats(baseStats, [blessed], effectLibrary).attackRolls.total).toBe(1);
+    expect(deriveStats(baseStats, [baned], effectLibrary).attackRolls.total).toBe(-1);
+  });
+
+  test('wires Inspire Courage to attack and damage rolls', () => {
+    const baseStats: CreatureBaseStats = {
+      hp: 20,
+      ac: 18,
+      fortitude: 7,
+      reflex: 7,
+      will: 7,
+      perception: 6,
+      speed: 25,
+      skills: {}
+    };
+    const applied: AppliedEffect = { instanceId: 'ic', effectId: 'inspire-courage', duration: { type: 'unlimited' } };
+
+    const computed = deriveStats(baseStats, [applied], effectLibrary);
+
+    expect(computed.attackRolls.total).toBe(1);
+    expect(computed.damageRolls.total).toBe(1);
+  });
+
+  test('wires Inspire Defense to AC and saves', () => {
+    const baseStats: CreatureBaseStats = {
+      hp: 20,
+      ac: 18,
+      fortitude: 7,
+      reflex: 7,
+      will: 7,
+      perception: 6,
+      speed: 25,
+      skills: {}
+    };
+    const applied: AppliedEffect = { instanceId: 'id', effectId: 'inspire-defense', duration: { type: 'unlimited' } };
+
+    const computed = deriveStats(baseStats, [applied], effectLibrary);
+
+    expect(computed.ac.final).toBe(19);
+    expect(computed.fortitude.final).toBe(8);
+    expect(computed.reflex.final).toBe(8);
+    expect(computed.will.final).toBe(8);
+  });
+
+  test('wires Mage Armor to AC as item bonus', () => {
+    const baseStats: CreatureBaseStats = {
+      hp: 20,
+      ac: 18,
+      fortitude: 7,
+      reflex: 7,
+      will: 7,
+      perception: 6,
+      speed: 25,
+      skills: {}
+    };
+    const applied: AppliedEffect = { instanceId: 'ma', effectId: 'mage-armor', duration: { type: 'unlimited' } };
+
+    const computed = deriveStats(baseStats, [applied], effectLibrary);
+
+    expect(computed.ac.final).toBe(19);
+    expect(computed.ac.modifiers[0]?.bonusType).toBe('item');
   });
 
   test('models persistent damage as note-driven prompt definitions', () => {

--- a/src/domain/effects/library.ts
+++ b/src/domain/effects/library.ts
@@ -88,10 +88,12 @@ export const effectLibrary: EffectLibrary = {
     maxValue: 4,
     modifiers: [
       { stat: 'mentalSkills', bonusType: 'status', value: negativeEffectValue },
-      { stat: 'will', bonusType: 'status', value: negativeEffectValue }
+      { stat: 'will', bonusType: 'status', value: negativeEffectValue },
+      { stat: 'spellDcs', bonusType: 'status', value: negativeEffectValue },
+      { stat: 'spellAttacks', bonusType: 'status', value: negativeEffectValue }
     ],
     description:
-      'Also applies to spell attack rolls and spell DCs. When casting a spell, DC 5 + value flat check or spell is lost.'
+      'When casting a spell, DC 5 + value flat check or the spell is lost.'
   }),
   drained: condition({
     id: 'drained',
@@ -393,14 +395,14 @@ export const effectLibrary: EffectLibrary = {
     id: 'bless',
     name: 'Bless',
     hasValue: false,
-    modifiers: [],
+    modifiers: [{ stat: 'attackRolls', bonusType: 'status', value: 1 }],
     description: 'Allies in a 5-foot emanation gain a +1 status bonus to attack rolls. Sustained; emanation grows by 10 ft each turn (max 30 ft).'
   }),
   bane: spellEffect({
     id: 'bane',
     name: 'Bane',
     hasValue: false,
-    modifiers: [],
+    modifiers: [{ stat: 'attackRolls', bonusType: 'status', value: -1 }],
     description: 'Enemies in a 5-foot emanation that fail Will save take a -1 status penalty to attack rolls. Sustained; emanation grows.'
   }),
   haste: spellEffect({
@@ -429,22 +431,28 @@ export const effectLibrary: EffectLibrary = {
     id: 'inspire-courage',
     name: 'Inspire Courage',
     hasValue: false,
-    modifiers: [],
-    description: 'Allies in a 60-foot emanation gain a +1 status bonus to attack rolls, damage rolls, and saves vs fear. Composition cantrip; 1 round.'
+    modifiers: [
+      { stat: 'attackRolls', bonusType: 'status', value: 1 },
+      { stat: 'damageRolls', bonusType: 'status', value: 1 }
+    ],
+    description: 'Allies in a 60-foot emanation gain a +1 status bonus to attack rolls, damage rolls, and saves vs fear (the save bonus is too narrow to automate). Composition cantrip; 1 round.'
   }),
   'inspire-defense': spellEffect({
     id: 'inspire-defense',
     name: 'Inspire Defense',
     hasValue: false,
-    modifiers: [],
-    description: 'Allies in a 60-foot emanation gain a +1 status bonus to AC and saves, plus resistance equal to half the bardic level to physical damage. Composition cantrip; 1 round.'
+    modifiers: [
+      { stat: 'ac', bonusType: 'status', value: 1 },
+      { stat: 'allSaves', bonusType: 'status', value: 1 }
+    ],
+    description: 'Allies in a 60-foot emanation gain a +1 status bonus to AC and saves, plus resistance equal to half the bardic level to physical damage (resistance not automated). Composition cantrip; 1 round.'
   }),
   'mage-armor': spellEffect({
     id: 'mage-armor',
     name: 'Mage Armor',
     hasValue: false,
-    modifiers: [],
-    description: 'Target gains a +1 item bonus to AC and a maximum Dex cap of +5. 24 hours.'
+    modifiers: [{ stat: 'ac', bonusType: 'item', value: 1 }],
+    description: 'Target gains a +1 item bonus to AC and a maximum Dex cap of +5 (Dex cap not modeled). 24 hours.'
   }),
   shield: spellEffect({
     id: 'shield',

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -491,7 +491,10 @@ export type StatTarget =
   | 'allSaves'
   | 'perception'
   | 'attackRolls'
+  | 'damageRolls'
   | 'allDCs'
+  | 'spellDcs'
+  | 'spellAttacks'
   | 'allSkills'
   | 'strSkills'
   | 'dexSkills'
@@ -537,7 +540,10 @@ export interface ComputedStats {
   perception: ComputedStat;
   skills: Record<string, ComputedStat>;
   attackRolls: ComputedModifierBucket;
+  damageRolls: ComputedModifierBucket;
   allDCs: ComputedModifierBucket;
+  spellDcs: ComputedModifierBucket;
+  spellAttacks: ComputedModifierBucket;
 }
 
 export type TurnBoundarySuggestion =

--- a/src/lib/dice/roll.test.ts
+++ b/src/lib/dice/roll.test.ts
@@ -30,7 +30,7 @@ describe('rollAttack', () => {
 
 describe('rollDamage', () => {
   test('rolls a single dice + bonus component', () => {
-    const result = rollDamage([{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }], () => 0.5);
+    const result = rollDamage([{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }], {}, () => 0.5);
     // 0.5 * 8 = 4, +1 → 5; +3 = 8
     expect(result.total).toBe(8);
     expect(result.breakdown).toBe('1d8+3 slashing (8)');
@@ -42,6 +42,7 @@ describe('rollDamage', () => {
         { dice: 2, dieSize: 8, bonus: 4, type: 'piercing' },
         { dice: 1, dieSize: 6, type: 'fire', persistent: true }
       ],
+      {},
       () => 0.5
     );
     // 2d8: 5+5 = 10, +4 = 14; 1d6: 4
@@ -50,15 +51,45 @@ describe('rollDamage', () => {
   });
 
   test('flat bonus-only component renders bonus prefix', () => {
-    const result = rollDamage([{ bonus: 5, type: 'fire' }], () => 0.5);
+    const result = rollDamage([{ bonus: 5, type: 'fire' }], {}, () => 0.5);
     expect(result.total).toBe(5);
     expect(result.breakdown).toBe('+5 fire (5)');
   });
 
   test('dice-only component (e.g. persistent bleed)', () => {
-    const result = rollDamage([{ dice: 1, dieSize: 4, type: 'bleed', persistent: true }], () => 0);
+    const result = rollDamage([{ dice: 1, dieSize: 4, type: 'bleed', persistent: true }], {}, () => 0);
     // 0 * 4 → 0, +1 = 1
     expect(result.total).toBe(1);
     expect(result.breakdown).toBe('1d4 bleed persistent (1)');
+  });
+
+  test('appends positive flatBonus with default label and adds to total', () => {
+    const result = rollDamage(
+      [{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }],
+      { flatBonus: 1 },
+      () => 0.5
+    );
+    expect(result.total).toBe(9);
+    expect(result.breakdown).toBe('1d8+3 slashing (8) + +1 status');
+  });
+
+  test('appends negative flatBonus and subtracts from total', () => {
+    const result = rollDamage(
+      [{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }],
+      { flatBonus: -2, flatBonusLabel: 'enfeebled' },
+      () => 0.5
+    );
+    expect(result.total).toBe(6);
+    expect(result.breakdown).toBe('1d8+3 slashing (8) + -2 enfeebled');
+  });
+
+  test('zero flatBonus is omitted from breakdown', () => {
+    const result = rollDamage(
+      [{ dice: 1, dieSize: 8, bonus: 3, type: 'slashing' }],
+      { flatBonus: 0 },
+      () => 0.5
+    );
+    expect(result.total).toBe(8);
+    expect(result.breakdown).toBe('1d8+3 slashing (8)');
   });
 });

--- a/src/lib/dice/roll.ts
+++ b/src/lib/dice/roll.ts
@@ -24,8 +24,14 @@ export function rollAttack(modifier: number, rng: Rng = defaultRng): AttackRollR
   return { d20, modifier, total: d20 + modifier };
 }
 
+export interface RollDamageOptions {
+  flatBonus?: number;
+  flatBonusLabel?: string;
+}
+
 export function rollDamage(
   components: readonly DamageComponent[],
+  options: RollDamageOptions = {},
   rng: Rng = defaultRng
 ): DamageRollResult {
   let total = 0;
@@ -49,6 +55,14 @@ export function rollDamage(
     const label = formula ? `${formula} ${tail}` : tail;
     parts.push(`${label} (${sub})`);
     total += sub;
+  }
+
+  const flatBonus = options.flatBonus ?? 0;
+  if (flatBonus !== 0) {
+    const sign = flatBonus > 0 ? '+' : '';
+    const label = options.flatBonusLabel ?? 'status';
+    parts.push(`${sign}${flatBonus} ${label}`);
+    total += flatBonus;
   }
 
   return { total, breakdown: parts.join(' + ') };

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -2,13 +2,16 @@ import {
   applyCommand,
   createCombatantFromCreature,
   createCombatantFromPartyMember,
+  deriveStats,
   effectLibrary
 } from '../domain';
 import type {
   AppliedEffect,
+  AppliedModifier,
   CombatantState,
   Command,
   CommandType,
+  ComputedStats,
   Creature,
   CreatureTemplateAdjustment,
   DomainEvent,
@@ -545,4 +548,30 @@ export function listRemovableEffects(
         source: { kind: 'direct' as const }
       };
     });
+}
+
+export function computeCombatantStats(combatant: CombatantState): ComputedStats {
+  return deriveStats(combatant.baseStats, combatant.appliedEffects, effectLibrary);
+}
+
+function signed(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+export function formatModifierBreakdown(mods: readonly AppliedModifier[]): string {
+  return mods
+    .filter((m) => !m.suppressed)
+    .map((m) => `${m.sourceName}: ${signed(m.value)} ${m.bonusType}`)
+    .join('; ');
+}
+
+export function formatStatTooltip(
+  base: number,
+  final: number,
+  mods: readonly AppliedModifier[]
+): string {
+  const active = mods.filter((m) => !m.suppressed);
+  if (active.length === 0) return String(base);
+  const parts = active.map((m) => `${signed(m.value)} ${m.sourceName}`).join(' ');
+  return `${base} ${parts} = ${final}`;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,8 +14,10 @@
   import {
     appendInfoLog,
     combatantCardActions,
+    computeCombatantStats,
     currentCombatant,
     dispatchEncounterCommand,
+    formatModifierBreakdown,
     groupConditionsByCategory,
     listAfflictionOptions,
     listConditionOptions,
@@ -558,7 +560,7 @@
       const c = encounter.combatants[id];
       if (!c) continue;
       const die = Math.floor(Math.random() * 20) + 1;
-      patch[id] = die + c.baseStats.perception;
+      patch[id] = die + computeCombatantStats(c).perception.final;
     }
     if (Object.keys(patch).length === 0) return;
     runCommand(toCommand('SET_INITIATIVE_SCORES', { scores: patch }, nextCommandId()));
@@ -731,10 +733,14 @@
     const bubbleTone: BubbleTone = isCrit ? 'crit' : isFumble ? 'fumble' : 'normal';
     const badge = isCrit ? 'NAT 20' : isFumble ? 'NAT 1' : `${attack.name} · ${variant.label}`;
 
+    const stats = computeCombatantStats(c);
+    const breakdown = formatModifierBreakdown(stats.attackRolls.modifiers);
+    const breakdownSuffix = breakdown ? ` (${breakdown})` : '';
+
     encounter = appendInfoLog(
       encounter,
       nextRollId(),
-      `${c.name} ${attack.name} ${variant.label}: 1d20(${result.d20}) ${formatModifier(variant.modifier)} = ${result.total}`,
+      `${c.name} ${attack.name} ${variant.label}: 1d20(${result.d20}) ${formatModifier(variant.modifier)} = ${result.total}${breakdownSuffix}`,
       logTone
     );
     persistence.persist(encounter);
@@ -759,7 +765,9 @@
   function rollSaveFor(combatantId: string, save: SaveKey, origin: { x: number; y: number }) {
     const c = encounter.combatants[combatantId];
     if (!c) return;
-    const mod = c.baseStats[save];
+    const stats = computeCombatantStats(c);
+    const stat = stats[save];
+    const mod = stat.final;
     const result = rollAttackDice(mod);
     const isCrit = result.d20 === 20;
     const isFumble = result.d20 === 1;
@@ -768,10 +776,13 @@
     const label = SAVE_LABELS[save];
     const badge = isCrit ? 'NAT 20' : isFumble ? 'NAT 1' : `${label} save`;
 
+    const breakdown = formatModifierBreakdown(stat.modifiers);
+    const breakdownSuffix = breakdown ? ` (base ${formatModifier(stat.base)}, ${breakdown})` : '';
+
     encounter = appendInfoLog(
       encounter,
       nextRollId(),
-      `${c.name} ${label} save: 1d20(${result.d20}) ${formatModifier(mod)} = ${result.total}`,
+      `${c.name} ${label} save: 1d20(${result.d20}) ${formatModifier(mod)} = ${result.total}${breakdownSuffix}`,
       logTone
     );
     persistence.persist(encounter);
@@ -789,11 +800,15 @@
   function rollDamageFor(combatantId: string, attack: Attack, origin: { x: number; y: number }) {
     const c = encounter.combatants[combatantId];
     if (!c || attack.damage.length === 0) return;
-    const result = rollDamageDice(attack.damage);
+    const stats = computeCombatantStats(c);
+    const flatBonus = stats.damageRolls.total;
+    const result = rollDamageDice(attack.damage, { flatBonus, flatBonusLabel: 'status' });
+    const breakdown = formatModifierBreakdown(stats.damageRolls.modifiers);
+    const breakdownSuffix = breakdown ? ` (${breakdown})` : '';
     encounter = appendInfoLog(
       encounter,
       nextRollId(),
-      `${c.name} ${attack.name} damage: ${result.breakdown} = ${result.total}`,
+      `${c.name} ${attack.name} damage: ${result.breakdown} = ${result.total}${breakdownSuffix}`,
       'danger'
     );
     persistence.persist(encounter);


### PR DESCRIPTION
## Summary

- Wire `deriveStats()` through the UI so AC, saves, perception, attack rolls, damage rolls, and spell DC/attack reflect applied conditions and effects. Frightened, Off-Guard, Sickened, Bless, Bane, Inspire Courage/Defense, Mage Armor, and Stupefied now actually take effect — on both display and rolled values, with PF2e stacking already handled in the domain.
- Extend `StatTarget` / `ComputedStats` with `damageRolls`, `spellDcs`, `spellAttacks`; populate the matching modifiers on Stupefied and the previously-empty spell-effect placeholders. Specs updated to match.
- Extend `rollDamage` with an optional `flatBonus` so status damage bonuses (e.g. Inspire Courage) flow into the rolled total and breakdown.
- New orchestrator helpers in `$lib/encounter-app`: `computeCombatantStats`, `formatModifierBreakdown`, `formatStatTooltip`. UI components compute reactively per render — no memoization needed at typical encounter sizes.
- Out of scope (kept descriptive): Enfeebled / Clumsy ability-tagged attacks, Heroism rank-mapped value, Soothe / Shield, Drained max-HP / Slowed action loss / Doomed thresholds (already handled by other subsystems), Stupefied's DC 5 + value flat check on cast.

## Test plan
- [x] `npm run check` (svelte-check + tsc on domain)
- [x] `npm run test:run` (52 files, 702 tests pass — covers new derivation buckets, library wiring per condition, `rollDamage(flatBonus)`, and CombatantCard stat-modification scenarios including Frightened/Off-Guard/Sickened stacking)
- [x] `npm run audit` (3 low only; gate is moderate)
- [x] `npm run build` (static Cloudflare output produced)
- [ ] Manual `npm run dev`: apply Frightened 2 → AC, three saves, perception drop by 2 with breakdown tooltip; click a save to verify the log line includes the breakdown; apply Off-Guard alongside Frightened to confirm circumstance + status stack; apply Inspire Courage to verify attack +1 and damage +1; apply Stupefied 2 to a spellcaster to verify spell DC and spell attack drop by 2; remove conditions to confirm values restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)