### PR TITLE
Support complex hazards as encounter participants

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Tracking only. Captured in issue #49. Domain commands are stubbed in `src/domain
 
 Specs are authoritative; tracking issues hold scope so the work is not lost. None of these are in the active backlog filter.
 
-- **Hazards** — issue #50, spec `pf2e-hazards-spec.md`. Hazards as initiative participants with reactions, triggers, and disables.
+- **Hazards** — issue #50, spec `pf2e-hazards-spec.md` v0.2. ✅ Implemented: complex hazards as initiative participants with stealth-rolled init, routine banner, disable progress tracking, hardness display, YAML import, IndexedDB hazard library.
 - **Afflictions** — issue #51, spec `pf2e-afflictions-spec.md`. Poison/disease/curse staging, saves, and turn-boundary prompts.
 - **Party members** — issue #52, spec `pf2e-party-members-spec.md`. PCs as first-class persisted entities, not ad-hoc combatants.
 - **Creature types** — spec `pf2e-creature-types-spec.md`. Folds into #48 once the import-driven creature library lands.

--- a/pf2e-hazards-spec.md
+++ b/pf2e-hazards-spec.md
@@ -1,8 +1,8 @@
 # PF2e Encounter Tracker v2 — Complex Hazards Specification
 
-**Version:** 0.1 (draft)
-**Date:** 2026-04-22
-**Status:** Ready for review
+**Version:** 0.2 (draft)
+**Date:** 2026-05-11
+**Status:** Implemented
 
 ---
 
@@ -30,46 +30,69 @@ interface CombatantState {
 
 No other changes to `CombatantState`. Hazard combatants use the same fields as creature combatants: `baseStats`, `attacks`, `abilities`, `appliedEffects`, etc.
 
-### 2.2 CreatureBaseStats — Add Hardness, Make Saves Optional
+### 2.2 Discriminated baseStats: keep `CreatureBaseStats` strict, add `HazardBaseStats`
 
-Hardness is not hazard-specific — creatures can have it too (golems, animated objects, constructs). Add it to `CreatureBaseStats`. Additionally, some hazards lack certain saves. Make saves nullable.
+`CreatureBaseStats` stays strict — `ac`, `fortitude`, `reflex`, `will` remain required numbers. The 0.1 draft proposed making them `number | null` on the shared type, but that pushes null checks across every reader (UI, roll handlers, all existing creature/PC tests). The implemented design adds a separate `HazardBaseStats` and discriminates `CombatantState.baseStats` as a union narrowed by `sourceType`.
 
 ```typescript
 interface CreatureBaseStats {
   ac: number
-  fortitude: number | null          // null = hazard/entity doesn't have this save
-  reflex: number | null
-  will: number | null
+  fortitude: number
+  reflex: number
+  will: number
   perception: number
   hp: number
-  hardness?: number                 // flat damage reduction, display-only
+  speed: number
   skills: Record<string, number>
-  speed?: Record<string, number>
+  hardness?: number                 // NEW — flat DR, display-only
+}
+
+interface HazardBaseStats {
+  ac: number | null                 // null = "AC —" in the statblock
+  fortitude: number | null
+  reflex: number | null
+  will: number | null
+  perception: number                // factory defaults to 0; hazards roll Stealth
+  hp: number                        // 0 for indestructible hazards
+  speed: number                     // factory defaults to 0
+  skills: Record<string, number>    // typically empty
+  hardness?: number
+  stealth: number                   // initiative modifier
+  stealthNote?: string              // "expert", "trained in Perception", etc.
+  immunities?: string[]
   resistances?: { type: string; value: number }[]
   weaknesses?: { type: string; value: number }[]
-  immunities?: string[]
+}
+
+interface CombatantState {
+  // ...
+  sourceType: "creature" | "partyMember" | "companion" | "hazard"
+  baseStats: CreatureBaseStats | HazardBaseStats   // narrowed by sourceType
+  // ...
 }
 ```
 
-**Impact on `deriveStats()`:** When a save is `null`, the derivation skips it — no modifiers applied, no entry in `ComputedStats`. The UI displays "—" for missing saves. All existing creature and party member factories continue to set saves as numbers. Only hazard factories may produce `null`.
+**Impact on `deriveStats()`:** Accepts `CreatureBaseStats | HazardBaseStats`. When `ac`, `fortitude`, `reflex`, or `will` is `null`, the entry is omitted from `ComputedStats` and any modifier targeting that stat is silently dropped (no `suppressed` entry). Creature/PC code paths see numbers everywhere; only hazard derivations skip stats.
 
-**Impact on `ComputedStats`:** Save entries become optional:
+**Impact on `ComputedStats`:** AC and the three saves become optional. `perception` and the buckets (`attackRolls`, `damageRolls`, `allDCs`, `spellDcs`, `spellAttacks`) always populate.
 
 ```typescript
 interface ComputedStats {
-  ac: { final: number; base: number; modifiers: AppliedModifier[] }
-  fortitude?: { final: number; base: number; modifiers: AppliedModifier[] }
-  reflex?: { final: number; base: number; modifiers: AppliedModifier[] }
-  will?: { final: number; base: number; modifiers: AppliedModifier[] }
-  // ... rest unchanged
+  ac?: ComputedStat
+  fortitude?: ComputedStat
+  reflex?: ComputedStat
+  will?: ComputedStat
+  perception: ComputedStat
+  skills: Record<string, ComputedStat>
+  // ...buckets unchanged...
 }
 ```
 
-**Impact on `Creature` type:** Unchanged. All creatures have saves. The `Creature` interface keeps `fortitude: number`, etc. The nullable saves are a `CreatureBaseStats` concern — the factory that builds base stats from a `Hazard` is where `null` enters.
+**Impact on `Creature`:** Add optional `hardness?: number` (some creatures — golems, animated objects — have hardness). All other fields unchanged. The creature factory passes `hardness` through into `CreatureBaseStats.hardness`.
 
-**Impact on `PartyMember` and `Companion`:** Unchanged. PCs and companions always have all saves.
+**Impact on `PartyMember` / Companion:** Unchanged.
 
-**Hardness and APPLY_DAMAGE:** No change. `APPLY_DAMAGE` takes final numbers (command vocab spec §1.3). The GM subtracts hardness mentally before entering the damage amount, same as resistances and weaknesses. The UI displays hardness prominently so the GM remembers.
+**Hardness and APPLY_DAMAGE:** No automation. `APPLY_DAMAGE` takes the final number; the GM subtracts hardness mentally, the same pattern used for resistances and weaknesses. The UI shows hardness as a chip next to AC so the GM remembers.
 
 ### 2.3 Creature — Add Optional Hardness
 
@@ -102,13 +125,14 @@ Hazards are a new YAML entity type alongside creatures, encounters, party member
 
 ### 3.1 Hazard (Library Template)
 
+The `complexity` field from the 0.1 draft is dropped — only complex hazards are tracked today, and a literal-`"complex"` field carries no information. If simple hazards are ever modeled, reintroduce it then.
+
 ```typescript
 interface Hazard {
   id: string
   name: string
   level: number
   traits: string[]
-  complexity: "complex"              // always complex — simple hazards aren't tracked
   rarity: "common" | "uncommon" | "rare" | "unique"
 
   // Detection
@@ -202,28 +226,28 @@ The factory:
 
 The GM dispatches `ADD_COMBATANT` with the result. Standard flow.
 
-### 4.2 CombatantState — Hazard-Specific Display Data
+### 4.2 CombatantState — Hazard-Specific Display Data (split)
 
-Hazards need a few display fields that creatures don't have. Rather than polluting `CombatantState` with hazard-specific required fields, these go in an optional bag:
+The 0.1 draft put everything (routine, disable checks/progress, stealth, stealth note) into one `hazardData?` bag. The implemented design splits these by their nature:
+
+- **Defensive sense stats (`stealth`, `stealthNote`)** live on `HazardBaseStats` — parallel to `perception` on `CreatureBaseStats`. With the discriminated union, narrowing `sourceType === 'hazard'` gives you `combatant.baseStats.stealth` directly.
+- **Encounter mechanics (routine, disable checks, disable progress)** live in a smaller `hazardData?` bag on `CombatantState`. `disableProgress` is mutable encounter state indexed against `disableChecks`, so they need to stay grouped.
 
 ```typescript
 interface CombatantState {
   // ... existing fields ...
 
-  // Hazard-specific display data (only populated for sourceType: "hazard")
   hazardData?: {
     routine: HazardRoutine
     disableChecks: DisableCheck[]
     disableProgress: DisableProgress[]   // mutable — tracks successes during encounter
-    stealth: number
-    stealthNote?: string
   }
 }
 ```
 
-This keeps the hazard-specific data contained. The domain ignores `hazardData` entirely — it's display data for the UI and mutable state for disable tracking. Creatures, party members, and companions have `hazardData: undefined`.
+Creatures, PCs, and companions have `hazardData: undefined`. The factory `createCombatantFromHazard` is the only place that populates the bag.
 
-### 4.3 Disable Progress Tracking
+### 4.3 Disable Progress Tracking — domain command
 
 ```typescript
 interface DisableProgress {
@@ -241,11 +265,25 @@ disableProgress: hazard.disableChecks.map((check, i) => ({
 }))
 ```
 
-**Tracking is manual.** The GM rolls, tells the system the result. No dedicated command — the GM uses SET_NOTE or a UI action that decrements `successesRemaining` directly (orchestrator-level mutation, not a domain command).
+The 0.1 draft proposed orchestrator-level mutation (no command). The implemented design uses a domain command so disable attempts go through the same command-sourced path as every other mutation and appear in the combat log.
 
-**Why not a domain command?** Disable progress isn't domain state in the command-sourcing sense. It doesn't interact with effects, HP, initiative, or any other domain concept. It's a counter the GM ticks down. Putting it in the domain would require a new command type for minimal benefit. The orchestrator can handle the mutation and persist it as part of the combatant state snapshot.
+```typescript
+// Command
+{ type: 'RECORD_DISABLE_PROGRESS',
+  payload: { combatantId, checkIndex, delta: number } }
 
-**Full disable:** When all `disableProgress` entries have `successesRemaining === 0`, the hazard is fully disabled. The UI indicates this. The GM dispatches `MARK_DEAD` or `REMOVE_COMBATANT` to take it out of initiative. The domain doesn't auto-remove — GM authority.
+// Events
+{ type: 'disable-progress-recorded',
+  combatantId, checkIndex, previous, next }
+{ type: 'hazard-disabled', combatantId }
+```
+
+- `delta` is signed: typically `-1` on a success, `-2` on a critical success, `+1` to undo, etc.
+- Reducer clamps `successesRemaining` to `[0, requiredSuccesses]` and rejects no-op deltas.
+- Reducer rejects if the target isn't a hazard or `checkIndex` is out of range.
+- `hazard-disabled` fires exactly once, the first time all entries transition to `successesRemaining: 0`.
+
+**Full disable behavior:** Domain does not auto-`MARK_DEAD`. The UI shows a "Fully disabled" badge, and the GM dispatches `MARK_DEAD` or `REMOVE_COMBATANT` to take the hazard out of initiative. GM authority for the actual removal stays intact.
 
 ### 4.4 Initiative
 
@@ -272,42 +310,9 @@ No new commands needed for either path.
 
 ### 5.1 Hazards Without AC
 
-Some complex hazards can't be targeted by attacks — they have no AC. In PF2e this is represented as "AC —" in the statblock.
+Some complex hazards can't be targeted by attacks — "AC —" in the statblock. On the `Hazard` template, `ac?: number` (optional). The factory maps `undefined → null` into `HazardBaseStats.ac`. `deriveStats()` omits the `ac` entry from `ComputedStats`. UI renders "—".
 
-Handle the same way as missing saves: make AC nullable on `Hazard`.
-
-```typescript
-interface Hazard {
-  // ...
-  ac?: number                         // undefined = can't be targeted by attacks
-  // ...
-}
-```
-
-`CreatureBaseStats.ac` stays required (`number`). If a hazard lacks AC, the factory sets it to... actually, this is a problem. `deriveStats()` expects `ac: number`.
-
-**Resolution:** Make `CreatureBaseStats.ac` nullable too: `ac: number | null`. Same treatment as saves. `deriveStats()` skips null AC. The UI displays "—". This is a rare edge case (most complex hazards have AC) but the type system should handle it cleanly.
-
-Updated `CreatureBaseStats`:
-
-```typescript
-interface CreatureBaseStats {
-  ac: number | null                  // null for hazards that can't be targeted
-  fortitude: number | null
-  reflex: number | null
-  will: number | null
-  perception: number
-  hp: number
-  hardness?: number
-  skills: Record<string, number>
-  speed?: Record<string, number>
-  resistances?: { type: string; value: number }[]
-  weaknesses?: { type: string; value: number }[]
-  immunities?: string[]
-}
-```
-
-**For creatures, party members, and companions:** factories always set AC and saves to numbers. The `null` path only activates for hazards. Existing code that reads `baseStats.ac` needs a null check — but since this stat is consumed in exactly one place (`deriveStats`), the blast radius is small.
+`CreatureBaseStats.ac` stays required `number`. The null path lives entirely on `HazardBaseStats`. See §2.2 for the full type shapes.
 
 ### 5.2 Hazards With Multiple HP Pools
 
@@ -350,7 +355,6 @@ id: poisoned-dart-gallery
 name: Poisoned Dart Gallery
 level: 8
 traits: [mechanical, trap]
-complexity: complex
 rarity: common
 
 stealth: 28
@@ -407,9 +411,9 @@ tags: [extinction-curse]
 
 ---
 
-## 7. No New Commands
+## 7. Command Vocabulary
 
-Complex hazards use the existing command vocabulary entirely:
+Complex hazards reuse the existing command vocabulary plus one new command for disable tracking:
 
 | Action | Command |
 |---|---|
@@ -420,9 +424,9 @@ Complex hazards use the existing command vocabulary entirely:
 | Advance turn | END_TURN |
 | Destroy | MARK_DEAD |
 | Remove from encounter | REMOVE_COMBATANT |
-| Track disable progress | Orchestrator-level mutation (not a domain command) |
+| Track disable progress | **RECORD_DISABLE_PROGRESS** (see §4.3) |
 
-No new domain commands. No new domain events.
+The 0.1 draft proposed orchestrator-level mutation for disable tracking. The implemented design adds one domain command and two events (`disable-progress-recorded`, `hazard-disabled`) to keep disable attempts within the command-sourced model and surface them in the combat log.
 
 ---
 
@@ -432,20 +436,25 @@ No new domain commands. No new domain events.
 
 | Type | Location | Purpose |
 |---|---|---|
-| `Hazard` | `domain/types/hazard.ts` | Library template for complex hazards |
-| `DisableCheck` | `domain/types/hazard.ts` | Skill + DC + required successes to disable |
-| `HazardRoutine` | `domain/types/hazard.ts` | Fixed actions per turn with description |
-| `DisableProgress` | `domain/types/hazard.ts` | Mutable encounter tracking for disable checks |
+| `Hazard` | `domain/types.ts` | Library template for complex hazards |
+| `HazardBaseStats` | `domain/types.ts` | Defensive stats for hazard combatants (nullable AC/saves, stealth) |
+| `DisableCheck` | `domain/types.ts` | Skill + DC + required successes to disable |
+| `HazardRoutine` | `domain/types.ts` | Fixed actions per turn with description |
+| `DisableProgress` | `domain/types.ts` | Mutable encounter tracking for disable checks |
+| `HazardData` | `domain/types.ts` | Bag carrying routine + disable checks + progress on `CombatantState` |
 
 ### 8.2 Modified Types
 
 | Type | Change |
 |---|---|
-| `CombatantState.sourceType` | Add `"hazard"` to union |
-| `CombatantState` | Add optional `hazardData?` field |
-| `CreatureBaseStats` | Add `hardness?`. Make `ac`, `fortitude`, `reflex`, `will` nullable (`number \| null`). |
+| `CombatantState.sourceType` | Already had `"hazard"` in union (verified) |
+| `CombatantState.baseStats` | Now `CreatureBaseStats \| HazardBaseStats` (discriminated by `sourceType`) |
+| `CombatantState` | Add optional `hazardData?: HazardData` field |
+| `CreatureBaseStats` | Add `hardness?`. Saves stay required `number`. |
 | `ComputedStats` | Make `ac`, `fortitude`, `reflex`, `will` entries optional. |
 | `Creature` | Add optional `hardness?` field. |
+| `Command` | Add `RECORD_DISABLE_PROGRESS` variant. |
+| `DomainEvent` | Add `disable-progress-recorded` and `hazard-disabled` variants. |
 
 ### 8.3 New IndexedDB Store
 
@@ -453,20 +462,23 @@ No new domain commands. No new domain events.
 
 ### 8.4 New Factory Function
 
-`createCombatantFromHazard(hazard: Hazard): CombatantState` — in `domain/creatures/` or new `domain/hazards/`.
+`createCombatantFromHazard(input: { hazard, combatantId, name? })` — implemented at `domain/hazards/factory.ts`. Mirrors `createCombatantFromCreature` shape.
 
-### 8.5 No New Commands
+### 8.5 New Command
 
-Zero. Existing command vocabulary handles all hazard interactions.
+`RECORD_DISABLE_PROGRESS` (see §4.3). Two new events: `disable-progress-recorded`, `hazard-disabled`.
 
 ### 8.6 Orchestrator Logic
 
-- Disable progress tracking: orchestrator-level mutation, not domain command
-- Hazard factory invocation on "Add Hazard" UI action
+- Hazard factory invocation on "Add Hazard" UI action (via `makeHazardCombatant` in `src/lib/encounter-app.ts`).
+- `isHazardCombatant(combatant)` type guard narrows for UI sites that need hazard-specific fields.
+- Initiative roll uses `baseStats.stealth` when `sourceType === 'hazard'`, otherwise computed perception.
 
 ### 8.7 Test Priority
 
-1. **CreatureBaseStats nullability** — `deriveStats()` with null AC, null saves. Verify modifiers targeting null stats are skipped, ComputedStats entries omitted.
-2. **Hardness display** — verify it appears in the stat display and isn't consumed by any automated logic.
-3. **Hazard factory** — produces correct CombatantState from Hazard library entry. Handles missing AC, missing saves, missing HP.
-4. **Disable progress** — initialization from DisableCheck[], decrement, full-disable detection.
+1. **Nullable AC/saves** — `deriveStats()` with `HazardBaseStats` and null fields. ComputedStats entries omitted; modifiers targeting null stats fall on the floor.
+2. **Hardness display** — chip on the card and dd in the details panel for any combatant with `baseStats.hardness !== undefined`. Not consumed by automated damage logic.
+3. **Hazard factory** — produces correct CombatantState. Handles missing AC, missing saves, missing HP, stealth note.
+4. **Disable progress** — initialization from `DisableCheck[]`, decrement clamps at 0, undo clamps at `requiredSuccesses`, `hazard-disabled` fires exactly once on transition.
+5. **YAML import** — round-trip the poisoned-dart-gallery fixture; reject missing required fields (`routine`, `disableChecks`).
+6. **IDB store** — load/add/remove with fake-indexeddb; v4 → v5 migration preserves prior records.

--- a/pf2e-tracker-v2-architecture-spec.md
+++ b/pf2e-tracker-v2-architecture-spec.md
@@ -358,11 +358,14 @@ The derivation pipeline per stat:
 
 ```typescript
 interface ComputedStats {
-  // Each stat includes final value + breakdown for UI display
-  ac: { final: number; base: number; modifiers: AppliedModifier[] }
-  fortitude: { final: number; base: number; modifiers: AppliedModifier[] }
-  reflex: { final: number; base: number; modifiers: AppliedModifier[] }
-  will: { final: number; base: number; modifiers: AppliedModifier[] }
+  // Each stat includes final value + breakdown for UI display.
+  // AC and saves are optional: hazards may lack one or more (PF2e "AC —" or no
+  // Fortitude save, etc.). Hazard base stats hold `number | null` for these
+  // fields; null entries are omitted from ComputedStats and the UI renders "—".
+  ac?: { final: number; base: number; modifiers: AppliedModifier[] }
+  fortitude?: { final: number; base: number; modifiers: AppliedModifier[] }
+  reflex?: { final: number; base: number; modifiers: AppliedModifier[] }
+  will?: { final: number; base: number; modifiers: AppliedModifier[] }
   perception: { final: number; base: number; modifiers: AppliedModifier[] }
   attackRolls: { total: number; modifiers: AppliedModifier[] }
   damageRolls: { total: number; modifiers: AppliedModifier[] }
@@ -371,6 +374,11 @@ interface ComputedStats {
   spellAttacks: { total: number; modifiers: AppliedModifier[] }
   skills: Record<string, { final: number; base: number; modifiers: AppliedModifier[] }>
 }
+
+// `CombatantState.baseStats` is a discriminated union narrowed by `sourceType`:
+//   - 'creature' | 'partyMember' | 'companion' → CreatureBaseStats (all stats required)
+//   - 'hazard' → HazardBaseStats (ac/fortitude/reflex/will: number | null, plus stealth)
+// See pf2e-hazards-spec.md for the hazard branch.
 
 interface AppliedModifier {
   value: number                     // resolved numeric value

--- a/src/components/CombatantCard.svelte
+++ b/src/components/CombatantCard.svelte
@@ -6,6 +6,7 @@
     combatantVisualState,
     computeCombatantStats,
     formatStatTooltip,
+    isHazardCombatant,
     resolveApplyChoice,
     type AppliedEffectView,
     type ApplyConditionChoice,
@@ -178,7 +179,7 @@
   function rollInitiative() {
     if (!onSetInitiative) return;
     const die = Math.floor(Math.random() * 20) + 1;
-    onSetInitiative(combatant.id, die + computed.perception.final);
+    onSetInitiative(combatant.id, die + initiativeMod);
   }
 
   let pickerOpen = false;
@@ -290,26 +291,36 @@
       : 'Revive is unavailable in this phase';
 
   $: computed = computeCombatantStats(combatant);
-  $: acTooltip = formatStatTooltip(computed.ac.base, computed.ac.final, computed.ac.modifiers);
-  $: fortTooltip = formatStatTooltip(
-    computed.fortitude.base,
-    computed.fortitude.final,
-    computed.fortitude.modifiers
-  );
-  $: refTooltip = formatStatTooltip(
-    computed.reflex.base,
-    computed.reflex.final,
-    computed.reflex.modifiers
-  );
-  $: willTooltip = formatStatTooltip(
-    computed.will.base,
-    computed.will.final,
-    computed.will.modifiers
-  );
+  $: hazard = isHazardCombatant(combatant) ? combatant : null;
+  $: initiativeMod = hazard ? hazard.baseStats.stealth : computed.perception.final;
+  $: initiativeLabel = hazard ? 'Stealth' : 'Perception';
+  $: hardness = hazard ? hazard.baseStats.hardness : undefined;
+  $: acTooltip = computed.ac
+    ? formatStatTooltip(computed.ac.base, computed.ac.final, computed.ac.modifiers)
+    : '';
+  $: fortTooltip = computed.fortitude
+    ? formatStatTooltip(
+        computed.fortitude.base,
+        computed.fortitude.final,
+        computed.fortitude.modifiers
+      )
+    : '';
+  $: refTooltip = computed.reflex
+    ? formatStatTooltip(computed.reflex.base, computed.reflex.final, computed.reflex.modifiers)
+    : '';
+  $: willTooltip = computed.will
+    ? formatStatTooltip(computed.will.base, computed.will.final, computed.will.modifiers)
+    : '';
 
-  $: fortAriaLabel = `Roll ${combatant.name} Fortitude save (${formatModifier(computed.fortitude.final)})`;
-  $: refAriaLabel = `Roll ${combatant.name} Reflex save (${formatModifier(computed.reflex.final)})`;
-  $: willAriaLabel = `Roll ${combatant.name} Will save (${formatModifier(computed.will.final)})`;
+  $: fortAriaLabel = computed.fortitude
+    ? `Roll ${combatant.name} Fortitude save (${formatModifier(computed.fortitude.final)})`
+    : `${combatant.name} has no Fortitude save`;
+  $: refAriaLabel = computed.reflex
+    ? `Roll ${combatant.name} Reflex save (${formatModifier(computed.reflex.final)})`
+    : `${combatant.name} has no Reflex save`;
+  $: willAriaLabel = computed.will
+    ? `Roll ${combatant.name} Will save (${formatModifier(computed.will.final)})`
+    : `${combatant.name} has no Will save`;
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -383,6 +394,13 @@
     </div>
   </div>
 
+  {#if isCurrent && hazard}
+    <div class="routine-banner" role="note" aria-label="Routine">
+      <span class="routine-banner__label">Routine · {hazard.hazardData.routine.actions} action{hazard.hazardData.routine.actions === 1 ? '' : 's'}</span>
+      <span class="routine-banner__body">{hazard.hazardData.routine.description}</span>
+    </div>
+  {/if}
+
   {#if phase === 'PREPARING' && onSetInitiative}
     <div class="card-initiative-row" aria-label="Initiative">
       <SectionLabel>Init</SectionLabel>
@@ -403,14 +421,16 @@
       >Roll</Button>
       <span
         class="card-initiative__hint"
-        class:modified={computed.perception.final !== computed.perception.base}
-        title={formatStatTooltip(
-          computed.perception.base,
-          computed.perception.final,
-          computed.perception.modifiers
-        )}
-        aria-label={`Perception modifier ${computed.perception.final >= 0 ? '+' : ''}${computed.perception.final}`}
-      >({computed.perception.final >= 0 ? '+' : ''}{computed.perception.final} Perception)</span>
+        class:modified={!hazard && computed.perception.final !== computed.perception.base}
+        title={hazard
+          ? ''
+          : formatStatTooltip(
+              computed.perception.base,
+              computed.perception.final,
+              computed.perception.modifiers
+            )}
+        aria-label={`${initiativeLabel} modifier ${initiativeMod >= 0 ? '+' : ''}${initiativeMod}`}
+      >({initiativeMod >= 0 ? '+' : ''}{initiativeMod} {initiativeLabel})</span>
     </div>
   {/if}
 
@@ -451,41 +471,61 @@
       <div
         class="stat-readout"
         title={acTooltip}
-        aria-label={`Armor Class ${computed.ac.final}${computed.ac.final !== computed.ac.base ? ` (base ${computed.ac.base})` : ''}`}
+        aria-label={computed.ac
+          ? `Armor Class ${computed.ac.final}${computed.ac.final !== computed.ac.base ? ` (base ${computed.ac.base})` : ''}`
+          : `${combatant.name} has no Armor Class`}
       >
         <span class="stat-readout__label">AC</span>
         <span
           class="stat-readout__value"
-          class:modified={computed.ac.final !== computed.ac.base}
-        >{computed.ac.final}</span>
+          class:modified={computed.ac ? computed.ac.final !== computed.ac.base : false}
+        >{computed.ac ? computed.ac.final : '—'}</span>
       </div>
-      <StatRollButton
-        label="Fort"
-        modifier={computed.fortitude.final}
-        tone="save"
-        ariaLabel={fortAriaLabel}
-        breakdownTitle={fortTooltip}
-        modified={computed.fortitude.final !== computed.fortitude.base}
-        onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
-      />
-      <StatRollButton
-        label="Ref"
-        modifier={computed.reflex.final}
-        tone="save"
-        ariaLabel={refAriaLabel}
-        breakdownTitle={refTooltip}
-        modified={computed.reflex.final !== computed.reflex.base}
-        onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
-      />
-      <StatRollButton
-        label="Will"
-        modifier={computed.will.final}
-        tone="save"
-        ariaLabel={willAriaLabel}
-        breakdownTitle={willTooltip}
-        modified={computed.will.final !== computed.will.base}
-        onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
-      />
+      {#if hardness !== undefined}
+        <div class="stat-readout" aria-label={`Hardness ${hardness}`}>
+          <span class="stat-readout__label">Hard</span>
+          <span class="stat-readout__value">{hardness}</span>
+        </div>
+      {/if}
+      {#if computed.fortitude}
+        <StatRollButton
+          label="Fort"
+          modifier={computed.fortitude.final}
+          tone="save"
+          ariaLabel={fortAriaLabel}
+          breakdownTitle={fortTooltip}
+          modified={computed.fortitude.final !== computed.fortitude.base}
+          onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
+        />
+      {:else}
+        <span class="save-placeholder" aria-label={fortAriaLabel}>Fort —</span>
+      {/if}
+      {#if computed.reflex}
+        <StatRollButton
+          label="Ref"
+          modifier={computed.reflex.final}
+          tone="save"
+          ariaLabel={refAriaLabel}
+          breakdownTitle={refTooltip}
+          modified={computed.reflex.final !== computed.reflex.base}
+          onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
+        />
+      {:else}
+        <span class="save-placeholder" aria-label={refAriaLabel}>Ref —</span>
+      {/if}
+      {#if computed.will}
+        <StatRollButton
+          label="Will"
+          modifier={computed.will.final}
+          tone="save"
+          ariaLabel={willAriaLabel}
+          breakdownTitle={willTooltip}
+          modified={computed.will.final !== computed.will.base}
+          onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
+        />
+      {:else}
+        <span class="save-placeholder" aria-label={willAriaLabel}>Will —</span>
+      {/if}
     </div>
   </div>
 
@@ -890,6 +930,46 @@
     font-size: var(--text-base);
     font-weight: 700;
     color: var(--color-ink);
+  }
+
+  .routine-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: var(--space-2) 0 0;
+    padding: var(--space-2) var(--space-3);
+    border-radius: 4px;
+    border: 1px solid var(--effect-cond);
+    background: var(--effect-cond-soft);
+    color: var(--color-ink);
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    white-space: pre-line;
+  }
+
+  .routine-banner__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--effect-cond);
+  }
+
+  .save-placeholder {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    border: 1px dashed var(--color-rule);
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
   }
 
   .stat-readout__value.modified {

--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import type { Ability, Attack, CombatantState, ComputedStats } from '../domain';
+  import type { Ability, Attack, CombatantState, ComputedStat, ComputedStats } from '../domain';
   import { templateLabel } from '$lib/template-label';
   import { formatModifier } from '$lib/abilities/format-damage';
   import {
     computeCombatantStats,
     formatModifierBreakdown,
-    formatStatTooltip
+    formatStatTooltip,
+    isHazardCombatant
   } from '$lib/encounter-app';
   import type { MapVariant } from '$lib/dice/map';
   import Chip from './ui/Chip.svelte';
@@ -14,6 +15,7 @@
   import StatRollButton from './ui/StatRollButton.svelte';
   import AbilityCard from './details/AbilityCard.svelte';
   import AttackRow from './details/AttackRow.svelte';
+  import HazardSection from './details/HazardSection.svelte';
   import SpellcastingBlockView from './details/SpellcastingBlockView.svelte';
 
   type SaveKey = 'fortitude' | 'reflex' | 'will';
@@ -42,6 +44,11 @@
   export let onRestoreFocusPoint: (combatantId: string, blockId: string) => void = () => {};
   export let onUseInnateSpell: (combatantId: string, blockId: string, spellSlug: string) => void = () => {};
   export let onRestoreInnateSpell: (combatantId: string, blockId: string, spellSlug: string) => void = () => {};
+  export let onRecordDisableProgress: (
+    combatantId: string,
+    checkIndex: number,
+    delta: number
+  ) => void = () => {};
 
   function templateChipVariant(adjustment: 'elite' | 'weak' | undefined) {
     if (adjustment === 'elite') return 'warning';
@@ -60,8 +67,11 @@
     : '';
 
   $: computed = combatant ? computeCombatantStats(combatant) : null;
+  $: hazard = combatant && isHazardCombatant(combatant) ? combatant : null;
+  $: hardness = hazard ? hazard.baseStats.hardness : undefined;
 
-  function statTooltip(stat: ComputedStats['ac']): string {
+  function statTooltip(stat: ComputedStat | undefined): string {
+    if (!stat) return '';
     return formatStatTooltip(stat.base, stat.final, stat.modifiers);
   }
 
@@ -96,8 +106,8 @@
           <SectionLabel>AC</SectionLabel>
           <dd
             title={computed ? statTooltip(computed.ac) : ''}
-            class:modified={computed && computed.ac.final !== computed.ac.base}
-          >{computed ? computed.ac.final : combatant.baseStats.ac}</dd>
+            class:modified={!!computed?.ac && computed.ac.final !== computed.ac.base}
+          >{computed?.ac ? computed.ac.final : '—'}</dd>
         </div>
         <div class="stat">
           <SectionLabel>HP</SectionLabel>
@@ -107,47 +117,71 @@
           </dd>
         </div>
         <div class="stat">
-          <SectionLabel>Perception</SectionLabel>
+          <SectionLabel>{hazard ? 'Stealth' : 'Perception'}</SectionLabel>
           <dd
-            title={computed ? statTooltip(computed.perception) : ''}
-            class:modified={computed && computed.perception.final !== computed.perception.base}
-          >{formatModifier(computed ? computed.perception.final : combatant.baseStats.perception)}</dd>
+            title={hazard ? hazard.baseStats.stealthNote ?? '' : statTooltip(computed?.perception)}
+            class:modified={!hazard && !!computed && computed.perception.final !== computed.perception.base}
+          >{hazard
+            ? formatModifier(hazard.baseStats.stealth)
+            : formatModifier(computed ? computed.perception.final : combatant.baseStats.perception)}</dd>
         </div>
         <div class="stat">
           <SectionLabel>Speed</SectionLabel>
           <dd>{combatant.baseStats.speed} ft</dd>
         </div>
+        {#if hardness !== undefined}
+          <div class="stat">
+            <SectionLabel>Hardness</SectionLabel>
+            <dd>{hardness}</dd>
+          </div>
+        {/if}
       </dl>
       <div class="saves-grid">
-        <StatRollButton
-          label="Fort"
-          modifier={computed ? computed.fortitude.final : combatant.baseStats.fortitude}
-          tone="save"
-          ariaLabel={`Roll ${combatant.name} Fortitude save (${formatModifier(computed ? computed.fortitude.final : combatant.baseStats.fortitude)})`}
-          breakdownTitle={computed ? statTooltip(computed.fortitude) : undefined}
-          modified={!!computed && computed.fortitude.final !== computed.fortitude.base}
-          onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
-        />
-        <StatRollButton
-          label="Ref"
-          modifier={computed ? computed.reflex.final : combatant.baseStats.reflex}
-          tone="save"
-          ariaLabel={`Roll ${combatant.name} Reflex save (${formatModifier(computed ? computed.reflex.final : combatant.baseStats.reflex)})`}
-          breakdownTitle={computed ? statTooltip(computed.reflex) : undefined}
-          modified={!!computed && computed.reflex.final !== computed.reflex.base}
-          onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
-        />
-        <StatRollButton
-          label="Will"
-          modifier={computed ? computed.will.final : combatant.baseStats.will}
-          tone="save"
-          ariaLabel={`Roll ${combatant.name} Will save (${formatModifier(computed ? computed.will.final : combatant.baseStats.will)})`}
-          breakdownTitle={computed ? statTooltip(computed.will) : undefined}
-          modified={!!computed && computed.will.final !== computed.will.base}
-          onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
-        />
+        {#if computed?.fortitude}
+          <StatRollButton
+            label="Fort"
+            modifier={computed.fortitude.final}
+            tone="save"
+            ariaLabel={`Roll ${combatant.name} Fortitude save (${formatModifier(computed.fortitude.final)})`}
+            breakdownTitle={statTooltip(computed.fortitude)}
+            modified={computed.fortitude.final !== computed.fortitude.base}
+            onRoll={(origin) => onRollSave(combatant.id, 'fortitude', origin)}
+          />
+        {:else}
+          <span class="save-placeholder" aria-label={`${combatant.name} has no Fortitude save`}>Fort —</span>
+        {/if}
+        {#if computed?.reflex}
+          <StatRollButton
+            label="Ref"
+            modifier={computed.reflex.final}
+            tone="save"
+            ariaLabel={`Roll ${combatant.name} Reflex save (${formatModifier(computed.reflex.final)})`}
+            breakdownTitle={statTooltip(computed.reflex)}
+            modified={computed.reflex.final !== computed.reflex.base}
+            onRoll={(origin) => onRollSave(combatant.id, 'reflex', origin)}
+          />
+        {:else}
+          <span class="save-placeholder" aria-label={`${combatant.name} has no Reflex save`}>Ref —</span>
+        {/if}
+        {#if computed?.will}
+          <StatRollButton
+            label="Will"
+            modifier={computed.will.final}
+            tone="save"
+            ariaLabel={`Roll ${combatant.name} Will save (${formatModifier(computed.will.final)})`}
+            breakdownTitle={statTooltip(computed.will)}
+            modified={computed.will.final !== computed.will.base}
+            onRoll={(origin) => onRollSave(combatant.id, 'will', origin)}
+          />
+        {:else}
+          <span class="save-placeholder" aria-label={`${combatant.name} has no Will save`}>Will —</span>
+        {/if}
       </div>
     </section>
+
+    {#if hazard}
+      <HazardSection combatant={hazard} {onRecordDisableProgress} />
+    {/if}
 
     {#if combatant.passiveAbilities.length > 0}
       <section class="details__section" aria-label="Passive Abilities">
@@ -379,5 +413,20 @@
   .spellcasting-stack {
     display: grid;
     gap: var(--space-3);
+  }
+
+  .save-placeholder {
+    display: inline-flex;
+    align-items: baseline;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    border: 1px dashed var(--color-rule);
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
   }
 </style>

--- a/src/components/HazardsSection.svelte
+++ b/src/components/HazardsSection.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import type { Hazard } from '../domain';
+  import Button from './ui/Button.svelte';
+  import IconButton from './ui/IconButton.svelte';
+  import Input from './ui/Input.svelte';
+  import SectionLabel from './ui/SectionLabel.svelte';
+
+  export let hazards: Hazard[];
+  export let encounterCounts: Record<string, number> = {};
+  export let onAddToEncounter: (hazard: Hazard) => void;
+  export let onRemoveOneFromEncounter: (hazardId: string) => void;
+  export let onImportYamlFiles: ((files: File[]) => void) | undefined = undefined;
+  export let onRemoveHazard: ((id: string) => void) | undefined = undefined;
+
+  let query = '';
+  let fileInput: HTMLInputElement | undefined;
+
+  $: needle = query.trim().toLowerCase();
+  $: filtered = needle
+    ? hazards.filter((h) => {
+        if (h.name.toLowerCase().includes(needle)) return true;
+        return h.traits.some((t) => t.toLowerCase().includes(needle));
+      })
+    : hazards;
+
+  function handleFileChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    if (files.length > 0) {
+      onImportYamlFiles?.(files);
+    }
+    input.value = '';
+  }
+</script>
+
+<section class="hazards" aria-labelledby="hazards-label">
+  <header class="hazards__header">
+    <SectionLabel as="h3" id="hazards-label">Hazards</SectionLabel>
+    <span class="count">{hazards.length}</span>
+  </header>
+
+  <div class="hazards__actions">
+    {#if onImportYamlFiles}
+      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept=".yaml,.yml,application/yaml,text/yaml"
+        multiple
+        hidden
+        onchange={handleFileChange}
+      />
+    {/if}
+  </div>
+
+  <div class="hazards__search">
+    <Input
+      ariaLabel="Search hazards"
+      type="search"
+      placeholder="Search…"
+      bind:value={query}
+    >
+      <span slot="leading" aria-hidden="true">⌕</span>
+    </Input>
+  </div>
+
+  {#if filtered.length === 0}
+    <p class="hazards__empty">{hazards.length === 0 ? 'No hazards in library. Import a YAML.' : 'No matches.'}</p>
+  {:else}
+    <ul class="hazards__list" role="list">
+      {#each filtered as hazard (hazard.id)}
+        {@const count = encounterCounts[hazard.id] ?? 0}
+        <li class="hazards__row">
+          <div class="hazards__main">
+            <span class="hazards__name">{hazard.name}</span>
+            <span class="hazards__meta">L{hazard.level} · {hazard.traits.join(', ')}</span>
+          </div>
+          <div class="hazards__controls">
+            {#if count > 0}
+              <span class="hazards__count" aria-label={`${count} in encounter`}>×{count}</span>
+              <IconButton
+                ariaLabel={`Remove one ${hazard.name} from encounter`}
+                title="Remove one from encounter"
+                size={22}
+                onclick={() => onRemoveOneFromEncounter(hazard.id)}
+              >−</IconButton>
+            {/if}
+            <Button size="sm" onclick={() => onAddToEncounter(hazard)}>Add</Button>
+            {#if onRemoveHazard}
+              <IconButton
+                ariaLabel={`Delete ${hazard.name} from library`}
+                title="Delete from library"
+                size={22}
+                onclick={() => onRemoveHazard?.(hazard.id)}
+              >🗑</IconButton>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .hazards {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-top: var(--border-thin);
+  }
+
+  .hazards__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+
+  .count {
+    color: var(--color-ink-mute);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .hazards__actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .hazards__empty {
+    margin: 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-sm);
+    font-style: italic;
+  }
+
+  .hazards__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: var(--space-1);
+    max-height: 280px;
+    overflow-y: auto;
+  }
+
+  .hazards__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 4px 6px;
+    border-radius: 4px;
+  }
+
+  .hazards__row:hover {
+    background: var(--color-panel-2);
+  }
+
+  .hazards__main {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .hazards__name {
+    font-family: var(--font-serif);
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .hazards__meta {
+    color: var(--color-ink-soft);
+    font-size: var(--text-xs);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .hazards__controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .hazards__count {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-ink-mute);
+  }
+</style>

--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import type { Creature, PartyMember } from '../domain';
+  import type { Creature, Hazard, PartyMember } from '../domain';
   import type {
     ConditionOption,
     ManualCombatantInput,
     TemplateAdjustmentChoice
   } from '$lib/encounter-app';
   import BestiarySection from './BestiarySection.svelte';
+  import HazardsSection from './HazardsSection.svelte';
   import LibraryManageModal from './LibraryManageModal.svelte';
   import PartySection from './PartySection.svelte';
   import SetupPanel from './SetupPanel.svelte';
@@ -13,6 +14,7 @@
   export let canStart: boolean;
   export let creatures: Creature[];
   export let partyMembers: PartyMember[];
+  export let hazards: Hazard[];
   export let conditionOptions: ConditionOption[];
   export let encounterCounts: Record<string, number>;
   export let onAddOneFromBestiary: (creature: Creature, adjustment: TemplateAdjustmentChoice) => void;
@@ -24,6 +26,10 @@
   export let onRemovePartyMember: (id: string) => void;
   export let onSavePartyMember: (partyMember: PartyMember) => void;
   export let onImportPartyMemberYamlFiles: (files: File[]) => void;
+  export let onAddHazardToEncounter: (hazard: Hazard) => void;
+  export let onRemoveOneHazardFromEncounter: (hazardId: string) => void;
+  export let onImportHazardYamlFiles: (files: File[]) => void;
+  export let onRemoveHazard: (id: string) => void;
   export let onStart: () => void;
   export let onReset: () => void;
 
@@ -57,6 +63,14 @@
     {onRemovePartyMember}
     {onSavePartyMember}
     {onImportPartyMemberYamlFiles}
+  />
+  <HazardsSection
+    {hazards}
+    {encounterCounts}
+    onAddToEncounter={onAddHazardToEncounter}
+    onRemoveOneFromEncounter={onRemoveOneHazardFromEncounter}
+    onImportYamlFiles={onImportHazardYamlFiles}
+    {onRemoveHazard}
   />
   <div class="library__configure">
     <SetupPanel {canStart} {onAddManual} {onStart} {onReset} />

--- a/src/components/details/HazardSection.svelte
+++ b/src/components/details/HazardSection.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import type { CombatantState, HazardBaseStats, HazardData } from '../../domain';
+  import Chip from '../ui/Chip.svelte';
+  import SectionLabel from '../ui/SectionLabel.svelte';
+
+  export let combatant: CombatantState & { hazardData: HazardData; baseStats: HazardBaseStats };
+  export let onRecordDisableProgress: (
+    combatantId: string,
+    checkIndex: number,
+    delta: number
+  ) => void = () => {};
+
+  $: data = combatant.hazardData;
+  $: fullyDisabled = data.disableProgress.every((p) => p.successesRemaining === 0);
+  $: immunities = combatant.baseStats.immunities ?? [];
+
+  function titleCase(value: string): string {
+    return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1);
+  }
+</script>
+
+<section class="details__section" aria-label="Hazard">
+  <SectionLabel as="h3">Hazard</SectionLabel>
+
+  <div class="hazard-routine" role="note" aria-label="Routine">
+    <span class="hazard-routine__label">Routine · {data.routine.actions} action{data.routine.actions === 1 ? '' : 's'}</span>
+    <span class="hazard-routine__body">{data.routine.description}</span>
+  </div>
+
+  <div class="hazard-disable">
+    <div class="hazard-disable__head">
+      <SectionLabel>Disable checks</SectionLabel>
+      {#if fullyDisabled}
+        <Chip variant="success">Fully disabled</Chip>
+      {/if}
+    </div>
+    <ul class="hazard-checks">
+      {#each data.disableChecks as check, i (i)}
+        {@const progress = data.disableProgress[i]?.successesRemaining ?? check.requiredSuccesses}
+        {@const done = progress === 0}
+        <li class="hazard-check" class:hazard-check--done={done}>
+          <div class="hazard-check__head">
+            <span class="hazard-check__skill">{titleCase(check.skill)}</span>
+            <span class="hazard-check__dc">DC {check.dc}</span>
+            <span class="hazard-check__count">{check.requiredSuccesses - progress}/{check.requiredSuccesses}</span>
+          </div>
+          {#if check.note}
+            <div class="hazard-check__note">{check.note}</div>
+          {/if}
+          <div class="hazard-check__actions">
+            <button
+              type="button"
+              class="hazard-btn hazard-btn--success"
+              disabled={done}
+              aria-label={`Record success on ${titleCase(check.skill)} disable check`}
+              onclick={() => onRecordDisableProgress(combatant.id, i, -1)}
+            >+ Success</button>
+            <button
+              type="button"
+              class="hazard-btn hazard-btn--undo"
+              disabled={progress === check.requiredSuccesses}
+              aria-label={`Undo a success on ${titleCase(check.skill)} disable check`}
+              onclick={() => onRecordDisableProgress(combatant.id, i, 1)}
+            >Undo</button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+
+  {#if immunities.length > 0}
+    <div class="hazard-immunities">
+      <SectionLabel>Immunities</SectionLabel>
+      <div class="immunity-list">
+        {#each immunities as imm (imm)}
+          <Chip>{imm}</Chip>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .hazard-routine {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: var(--space-2) 0 var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-radius: 4px;
+    border: 1px solid var(--effect-cond);
+    background: var(--effect-cond-soft);
+    color: var(--color-ink);
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    white-space: pre-line;
+  }
+
+  .hazard-routine__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--effect-cond);
+  }
+
+  .hazard-disable {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .hazard-disable__head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .hazard-checks {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .hazard-check {
+    border-top: 1px dashed var(--color-rule);
+    padding-top: var(--space-2);
+    display: grid;
+    gap: 4px;
+  }
+
+  .hazard-check:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .hazard-check__head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .hazard-check__skill {
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+  }
+
+  .hazard-check__dc {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-ink-soft);
+  }
+
+  .hazard-check__count {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-ink-mute);
+  }
+
+  .hazard-check__note {
+    color: var(--color-ink-soft);
+    font-size: var(--text-sm);
+    font-style: italic;
+  }
+
+  .hazard-check__actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .hazard-btn {
+    padding: 3px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--color-rule);
+    background: var(--color-panel-2);
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+  }
+
+  .hazard-btn:hover:not(:disabled) {
+    background: var(--color-panel);
+    border-color: var(--color-ink);
+  }
+
+  .hazard-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .hazard-btn--success {
+    color: var(--roll-sav);
+    border-color: var(--roll-sav);
+  }
+
+  .hazard-check--done .hazard-check__skill,
+  .hazard-check--done .hazard-check__dc {
+    color: var(--color-ink-mute);
+    text-decoration: line-through;
+  }
+
+  .hazard-immunities {
+    margin-top: var(--space-3);
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .immunity-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+</style>

--- a/src/domain/effects/derivation.test.ts
+++ b/src/domain/effects/derivation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { deriveStats } from './derivation';
 import { effectLibrary } from './library';
-import type { AppliedEffect, CreatureBaseStats, EffectLibrary } from '../types';
+import type {
+  AppliedEffect,
+  CreatureBaseStats,
+  EffectLibrary,
+  HazardBaseStats
+} from '../types';
 
 const baseStats: CreatureBaseStats = {
   hp: 20,
@@ -196,8 +201,8 @@ describe('deriveStats', () => {
   test('keeps only the worse same-type status penalty from Frightened and Sickened', () => {
     const computed = deriveStats(baseStats, [applied('frightened', 1), applied('sickened', 2)], effectLibrary);
 
-    expect(computed.ac.final).toBe(16);
-    expect(computed.ac.modifiers).toEqual([
+    expect(computed.ac!.final).toBe(16);
+    expect(computed.ac!.modifiers).toEqual([
       expect.objectContaining({ effectId: 'frightened', value: -1, suppressed: true }),
       expect.objectContaining({ effectId: 'sickened', value: -2, suppressed: false })
     ]);
@@ -206,8 +211,8 @@ describe('deriveStats', () => {
   test('stacks Frightened status penalty and Off-Guard circumstance penalty on AC', () => {
     const computed = deriveStats(baseStats, [applied('frightened', 1), applied('off-guard')], effectLibrary);
 
-    expect(computed.ac.final).toBe(15);
-    expect(computed.ac.modifiers).toEqual([
+    expect(computed.ac!.final).toBe(15);
+    expect(computed.ac!.modifiers).toEqual([
       expect.objectContaining({ effectId: 'frightened', bonusType: 'status', value: -1, suppressed: false }),
       expect.objectContaining({ effectId: 'off-guard', bonusType: 'circumstance', value: -2, suppressed: false })
     ]);
@@ -216,8 +221,8 @@ describe('deriveStats', () => {
   test('suppresses the lower duplicate Frightened value', () => {
     const computed = deriveStats(baseStats, [applied('frightened', 1, 'frightened-low'), applied('frightened', 3, 'frightened-high')], effectLibrary);
 
-    expect(computed.will.final).toBe(4);
-    expect(computed.will.modifiers).toEqual([
+    expect(computed.will!.final).toBe(4);
+    expect(computed.will!.modifiers).toEqual([
       expect.objectContaining({ instanceId: 'frightened-low', value: -1, suppressed: true }),
       expect.objectContaining({ instanceId: 'frightened-high', value: -3, suppressed: false })
     ]);
@@ -235,8 +240,8 @@ describe('deriveStats', () => {
       customLibrary
     );
 
-    expect(computed.ac.final).toBe(17);
-    expect(computed.ac.modifiers).toEqual([
+    expect(computed.ac!.final).toBe(17);
+    expect(computed.ac!.modifiers).toEqual([
       expect.objectContaining({ effectId: 'untypedPenaltyA', value: -1, suppressed: false }),
       expect.objectContaining({ effectId: 'untypedPenaltyB', value: -2, suppressed: false }),
       expect.objectContaining({ effectId: 'lowerUntypedBoost', value: 1, suppressed: true }),
@@ -251,8 +256,8 @@ describe('deriveStats', () => {
       { ...customLibrary, frightened: effectLibrary.frightened }
     );
 
-    expect(computed.ac.final).toBe(20);
-    expect(computed.ac.modifiers).toEqual([
+    expect(computed.ac!.final).toBe(20);
+    expect(computed.ac!.modifiers).toEqual([
       expect.objectContaining({ effectId: 'lowerStatusBoost', value: 1, suppressed: true }),
       expect.objectContaining({ effectId: 'higherStatusBoost', value: 3, suppressed: false }),
       expect.objectContaining({ effectId: 'frightened', value: -1, suppressed: false })
@@ -264,9 +269,9 @@ describe('deriveStats', () => {
     const abilityComputed = deriveStats(baseStats, [applied('abilityMetaPenalty')], customLibrary);
     const mentalComputed = deriveStats(baseStats, [applied('mentalPenalty')], customLibrary);
 
-    expect(allComputed.fortitude.final).toBe(8);
-    expect(allComputed.reflex.final).toBe(7);
-    expect(allComputed.will.final).toBe(6);
+    expect(allComputed.fortitude!.final).toBe(8);
+    expect(allComputed.reflex!.final).toBe(7);
+    expect(allComputed.will!.final).toBe(6);
     expect(allComputed.skills.stealth.final).toBe(10);
     expect(allComputed.skills.warfareLore.final).toBe(11);
 
@@ -359,9 +364,56 @@ describe('deriveStats', () => {
   test('applies standalone custom allSaves modifier to all saves', () => {
     const computed = deriveStats(baseStats, [applied('savePenalty')], customLibrary);
 
-    expect(computed.fortitude.final).toBe(7);
-    expect(computed.reflex.final).toBe(6);
-    expect(computed.will.final).toBe(5);
-    expect(computed.ac.final).toBe(18);
+    expect(computed.fortitude!.final).toBe(7);
+    expect(computed.reflex!.final).toBe(6);
+    expect(computed.will!.final).toBe(5);
+    expect(computed.ac!.final).toBe(18);
+  });
+
+  test('hazard base stats: null AC and null fortitude omit those entries; remaining stats still derive', () => {
+    const hazardBase: HazardBaseStats = {
+      hp: 0,
+      ac: null,
+      fortitude: null,
+      reflex: 17,
+      will: null,
+      perception: 0,
+      stealth: 28,
+      speed: 0,
+      skills: {}
+    };
+
+    const computed = deriveStats(hazardBase, [applied('frightened', 2)], effectLibrary);
+
+    expect(computed.ac).toBeUndefined();
+    expect(computed.fortitude).toBeUndefined();
+    expect(computed.will).toBeUndefined();
+    expect(computed.reflex).toBeDefined();
+    expect(computed.reflex!.final).toBe(15);
+    expect(computed.perception.final).toBe(-2);
+    expect(computed.attackRolls.total).toBe(-2);
+  });
+
+  test('hazard with all defenses null: only perception/buckets populate; modifiers fall on the floor', () => {
+    const hazardBase: HazardBaseStats = {
+      hp: 0,
+      ac: null,
+      fortitude: null,
+      reflex: null,
+      will: null,
+      perception: 0,
+      stealth: 30,
+      speed: 0,
+      skills: {}
+    };
+
+    const computed = deriveStats(hazardBase, [applied('off-guard')], effectLibrary);
+
+    expect(computed.ac).toBeUndefined();
+    expect(computed.fortitude).toBeUndefined();
+    expect(computed.reflex).toBeUndefined();
+    expect(computed.will).toBeUndefined();
+    expect(computed.perception).toEqual({ base: 0, final: 0, modifiers: [] });
+    expect(computed.attackRolls).toEqual({ total: 0, modifiers: [] });
   });
 });

--- a/src/domain/effects/derivation.ts
+++ b/src/domain/effects/derivation.ts
@@ -8,9 +8,12 @@ import type {
   CreatureBaseStats,
   EffectDefinition,
   EffectLibrary,
+  HazardBaseStats,
   Modifier,
   StatTarget
 } from '../types';
+
+export type DerivableBaseStats = CreatureBaseStats | HazardBaseStats;
 
 type BaseStatKey = 'ac' | 'fortitude' | 'reflex' | 'will' | 'perception';
 type BucketKey = 'attackRolls' | 'damageRolls' | 'allDCs' | 'spellDcs' | 'spellAttacks';
@@ -32,17 +35,13 @@ const skillMetaTargets: Record<'strSkills' | 'dexSkills' | 'intSkills' | 'wisSki
 };
 
 export function deriveStats(
-  baseStats: CreatureBaseStats,
+  baseStats: DerivableBaseStats,
   appliedEffects: AppliedEffect[],
   effectLibrary: EffectLibrary
 ): ComputedStats {
   const modifiersByTarget = collectModifiers(baseStats, appliedEffects, effectLibrary);
 
-  return {
-    ac: computeBaseStat(baseStats.ac, modifiersByTarget.ac),
-    fortitude: computeBaseStat(baseStats.fortitude, modifiersByTarget.fortitude),
-    reflex: computeBaseStat(baseStats.reflex, modifiersByTarget.reflex),
-    will: computeBaseStat(baseStats.will, modifiersByTarget.will),
+  const computed: ComputedStats = {
     perception: computeBaseStat(baseStats.perception, modifiersByTarget.perception),
     skills: computeSkills(baseStats.skills, modifiersByTarget.skills),
     attackRolls: computeBucket(modifiersByTarget.attackRolls),
@@ -51,10 +50,25 @@ export function deriveStats(
     spellDcs: computeBucket(modifiersByTarget.spellDcs),
     spellAttacks: computeBucket(modifiersByTarget.spellAttacks)
   };
+
+  if (baseStats.ac !== null) {
+    computed.ac = computeBaseStat(baseStats.ac, modifiersByTarget.ac);
+  }
+  if (baseStats.fortitude !== null) {
+    computed.fortitude = computeBaseStat(baseStats.fortitude, modifiersByTarget.fortitude);
+  }
+  if (baseStats.reflex !== null) {
+    computed.reflex = computeBaseStat(baseStats.reflex, modifiersByTarget.reflex);
+  }
+  if (baseStats.will !== null) {
+    computed.will = computeBaseStat(baseStats.will, modifiersByTarget.will);
+  }
+
+  return computed;
 }
 
 function collectModifiers(
-  baseStats: CreatureBaseStats,
+  baseStats: DerivableBaseStats,
   appliedEffects: AppliedEffect[],
   effectLibrary: EffectLibrary
 ): {

--- a/src/domain/effects/library.test.ts
+++ b/src/domain/effects/library.test.ts
@@ -166,7 +166,7 @@ describe('effectLibrary', () => {
 
     expect(computed.spellDcs.total).toBe(-2);
     expect(computed.spellAttacks.total).toBe(-2);
-    expect(computed.will.final).toBe(7);
+    expect(computed.will!.final).toBe(7);
     expect(computed.skills.arcana.final).toBe(8);
   });
 
@@ -222,10 +222,10 @@ describe('effectLibrary', () => {
 
     const computed = deriveStats(baseStats, [applied], effectLibrary);
 
-    expect(computed.ac.final).toBe(19);
-    expect(computed.fortitude.final).toBe(8);
-    expect(computed.reflex.final).toBe(8);
-    expect(computed.will.final).toBe(8);
+    expect(computed.ac!.final).toBe(19);
+    expect(computed.fortitude!.final).toBe(8);
+    expect(computed.reflex!.final).toBe(8);
+    expect(computed.will!.final).toBe(8);
   });
 
   test('wires Mage Armor to AC as item bonus', () => {
@@ -243,8 +243,8 @@ describe('effectLibrary', () => {
 
     const computed = deriveStats(baseStats, [applied], effectLibrary);
 
-    expect(computed.ac.final).toBe(19);
-    expect(computed.ac.modifiers[0]?.bonusType).toBe('item');
+    expect(computed.ac!.final).toBe(19);
+    expect(computed.ac!.modifiers[0]?.bonusType).toBe('item');
   });
 
   test('models persistent damage as note-driven prompt definitions', () => {

--- a/src/domain/hazards/factory.test.ts
+++ b/src/domain/hazards/factory.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+import { createCombatantFromHazard } from './factory';
+import type { Hazard, HazardBaseStats } from '../types';
+
+function baseHazard(overrides: Partial<Hazard> = {}): Hazard {
+  return {
+    id: 'dart-gallery',
+    name: 'Poisoned Dart Gallery',
+    level: 8,
+    traits: ['mechanical', 'trap'],
+    rarity: 'common',
+    ac: 27,
+    fortitude: 13,
+    reflex: 17,
+    hp: 100,
+    hardness: 10,
+    stealth: 28,
+    stealthNote: 'expert',
+    immunities: ['critical-hits'],
+    resistances: [],
+    weaknesses: [],
+    disableChecks: [
+      { skill: 'thievery', dc: 26, requiredSuccesses: 3 },
+      { skill: 'athletics', dc: 22, requiredSuccesses: 1 }
+    ],
+    routine: { actions: 2, description: 'Fires darts.' },
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    attacks: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+describe('createCombatantFromHazard', () => {
+  test('builds a hazard combatant with HazardBaseStats and hazardData', () => {
+    const c = createCombatantFromHazard({ hazard: baseHazard(), combatantId: 'trap-1' });
+
+    expect(c.id).toBe('trap-1');
+    expect(c.sourceType).toBe('hazard');
+    expect(c.sourceId).toBe('dart-gallery');
+    expect(c.name).toBe('Poisoned Dart Gallery');
+    expect(c.isAlive).toBe(true);
+    expect(c.currentHp).toBe(100);
+
+    const stats = c.baseStats as HazardBaseStats;
+    expect(stats.ac).toBe(27);
+    expect(stats.fortitude).toBe(13);
+    expect(stats.reflex).toBe(17);
+    expect(stats.will).toBeNull();
+    expect(stats.hardness).toBe(10);
+    expect(stats.stealth).toBe(28);
+    expect(stats.stealthNote).toBe('expert');
+    expect(stats.immunities).toEqual(['critical-hits']);
+
+    expect(c.hazardData?.routine.actions).toBe(2);
+    expect(c.hazardData?.disableChecks).toHaveLength(2);
+    expect(c.hazardData?.disableProgress).toEqual([
+      { checkIndex: 0, successesRemaining: 3 },
+      { checkIndex: 1, successesRemaining: 1 }
+    ]);
+  });
+
+  test('null AC and saves when hazard fields are absent', () => {
+    const c = createCombatantFromHazard({
+      hazard: baseHazard({ ac: undefined, fortitude: undefined, reflex: undefined, will: undefined }),
+      combatantId: 'trap-2'
+    });
+    const stats = c.baseStats as HazardBaseStats;
+    expect(stats.ac).toBeNull();
+    expect(stats.fortitude).toBeNull();
+    expect(stats.reflex).toBeNull();
+    expect(stats.will).toBeNull();
+  });
+
+  test('indestructible hazard: hp undefined → 0, isAlive: true', () => {
+    const c = createCombatantFromHazard({
+      hazard: baseHazard({ hp: undefined }),
+      combatantId: 'trap-3'
+    });
+    expect(c.currentHp).toBe(0);
+    expect((c.baseStats as HazardBaseStats).hp).toBe(0);
+    expect(c.isAlive).toBe(true);
+  });
+
+  test('omits hardness when absent', () => {
+    const c = createCombatantFromHazard({
+      hazard: baseHazard({ hardness: undefined }),
+      combatantId: 'trap-4'
+    });
+    expect((c.baseStats as HazardBaseStats).hardness).toBeUndefined();
+  });
+
+  test('result is JSON-serializable', () => {
+    const c = createCombatantFromHazard({ hazard: baseHazard(), combatantId: 'trap-5' });
+    expect(JSON.parse(JSON.stringify(c))).toEqual(c);
+  });
+
+  test('name override wins', () => {
+    const c = createCombatantFromHazard({
+      hazard: baseHazard(),
+      combatantId: 'trap-6',
+      name: 'Custom Name'
+    });
+    expect(c.name).toBe('Custom Name');
+  });
+});

--- a/src/domain/hazards/factory.ts
+++ b/src/domain/hazards/factory.ts
@@ -1,0 +1,72 @@
+import type { CombatantState, Hazard, HazardBaseStats } from '../types';
+
+export interface CreateCombatantFromHazardInput {
+  hazard: Hazard;
+  combatantId: string;
+  name?: string;
+}
+
+export function createCombatantFromHazard({
+  hazard,
+  combatantId,
+  name
+}: CreateCombatantFromHazardInput): CombatantState {
+  const hp = hazard.hp ?? 0;
+  const baseStats: HazardBaseStats = {
+    hp,
+    ac: hazard.ac ?? null,
+    fortitude: hazard.fortitude ?? null,
+    reflex: hazard.reflex ?? null,
+    will: hazard.will ?? null,
+    perception: hazard.perception ?? 0,
+    stealth: hazard.stealth,
+    speed: 0,
+    skills: {}
+  };
+  if (hazard.stealthNote !== undefined) {
+    baseStats.stealthNote = hazard.stealthNote;
+  }
+  if (hazard.hardness !== undefined) {
+    baseStats.hardness = hazard.hardness;
+  }
+  if (hazard.immunities.length > 0) {
+    baseStats.immunities = cloneValue(hazard.immunities);
+  }
+  if (hazard.resistances.length > 0) {
+    baseStats.resistances = cloneValue(hazard.resistances);
+  }
+  if (hazard.weaknesses.length > 0) {
+    baseStats.weaknesses = cloneValue(hazard.weaknesses);
+  }
+
+  return {
+    id: combatantId,
+    sourceId: hazard.id,
+    name: name ?? hazard.name,
+    sourceType: 'hazard',
+    baseStats,
+    currentHp: hp,
+    tempHp: 0,
+    appliedEffects: [],
+    reactionUsedThisRound: false,
+    isAlive: true,
+    attacks: cloneValue(hazard.attacks),
+    passiveAbilities: cloneValue(hazard.passiveAbilities),
+    reactiveAbilities: cloneValue(hazard.reactiveAbilities),
+    activeAbilities: cloneValue(hazard.activeAbilities),
+    traits: cloneValue(hazard.traits),
+    level: hazard.level,
+    hazardData: {
+      routine: cloneValue(hazard.routine),
+      disableChecks: cloneValue(hazard.disableChecks),
+      disableProgress: hazard.disableChecks.map((check, i) => ({
+        checkIndex: i,
+        successesRemaining: check.requiredSuccesses
+      }))
+    }
+  };
+}
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,5 +1,6 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
+export { createCombatantFromHazard } from './hazards/factory';
 export { createCombatantFromPartyMember } from './party/factory';
 export { applyEliteWeak, adjustedLevel } from './creatures/templates';
 export { effectLibrary } from './effects/library';
@@ -40,6 +41,8 @@ export type {
   CreatureRarity,
   CreatureSize,
   DamageComponent,
+  DisableCheck,
+  DisableProgress,
   DomainEvent,
   Duration,
   EffectCategory,
@@ -47,6 +50,10 @@ export type {
   EffectLibrary,
   EncounterPhase,
   EncounterState,
+  Hazard,
+  HazardBaseStats,
+  HazardData,
+  HazardRoutine,
   InitiativeState,
   LogEntry,
   LogEntryTone,
@@ -56,6 +63,7 @@ export type {
   Prompt,
   PromptBoundary,
   PromptResolution,
+  RecordDisableProgressPayload,
   RemoveEffectPayload,
   ResolvePromptPayload,
   SetEffectDurationPayload,

--- a/src/domain/reducer.test.ts
+++ b/src/domain/reducer.test.ts
@@ -2993,3 +2993,129 @@ describe('spellcasting commands', () => {
     expectSerializable(result.newState);
   });
 });
+
+describe('applyCommand RECORD_DISABLE_PROGRESS', () => {
+  function hazardEncounter() {
+    const trap = combatant('trap-1', {
+      sourceType: 'hazard',
+      name: 'Dart Gallery',
+      hazardData: {
+        routine: { actions: 2, description: 'Fires darts.' },
+        disableChecks: [
+          { skill: 'thievery', dc: 22, requiredSuccesses: 3 },
+          { skill: 'athletics', dc: 18, requiredSuccesses: 1 }
+        ],
+        disableProgress: [
+          { checkIndex: 0, successesRemaining: 3 },
+          { checkIndex: 1, successesRemaining: 1 }
+        ]
+      }
+    });
+    return encounter({
+      combatants: { [trap.id]: trap },
+      initiative: { order: [trap.id], currentIndex: -1, delaying: [], scores: {} }
+    });
+  }
+
+  test('decrements successesRemaining on a success', () => {
+    const result = applyCommand(
+      hazardEncounter(),
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: -1 }),
+      emptyEffects
+    );
+    expect(result.newState.combatants['trap-1'].hazardData!.disableProgress[0].successesRemaining).toBe(2);
+    expectEvents(result, [
+      {
+        type: 'disable-progress-recorded',
+        combatantId: 'trap-1',
+        checkIndex: 0,
+        previous: 3,
+        next: 2
+      }
+    ]);
+  });
+
+  test('clamps at 0 and rejects no-op decrement when already disabled', () => {
+    const start = hazardEncounter();
+    let next = start;
+    next = applyCommand(
+      next,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: -3 }),
+      emptyEffects
+    ).newState;
+    next = applyCommand(
+      next,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 1, delta: -1 }),
+      emptyEffects
+    ).newState;
+
+    // both should be at 0 now
+    expect(next.combatants['trap-1'].hazardData!.disableProgress[0].successesRemaining).toBe(0);
+    expect(next.combatants['trap-1'].hazardData!.disableProgress[1].successesRemaining).toBe(0);
+
+    const noop = applyCommand(
+      next,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: -1 }),
+      emptyEffects
+    );
+    expectRejected(noop, 'RECORD_DISABLE_PROGRESS', 'No change to disable progress');
+  });
+
+  test('emits hazard-disabled exactly once when crossing all-zero', () => {
+    const start = hazardEncounter();
+    const first = applyCommand(
+      start,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: -3 }),
+      emptyEffects
+    );
+    expect(first.events.some((e) => e.type === 'disable-progress-recorded')).toBe(true);
+    expect(first.events.some((e) => e.type === 'hazard-disabled')).toBe(false);
+
+    const second = applyCommand(
+      first.newState,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 1, delta: -1 }),
+      emptyEffects
+    );
+    expect(second.events.some((e) => e.type === 'hazard-disabled')).toBe(true);
+  });
+
+  test('rejects on non-hazard target', () => {
+    const fighter = combatant('fighter-1', { sourceType: 'partyMember' });
+    const state = encounter({
+      combatants: { [fighter.id]: fighter },
+      initiative: { order: [fighter.id], currentIndex: -1, delaying: [], scores: {} }
+    });
+    const result = applyCommand(
+      state,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'fighter-1', checkIndex: 0, delta: -1 }),
+      emptyEffects
+    );
+    expectRejected(result, 'RECORD_DISABLE_PROGRESS', 'Combatant fighter-1 is not a hazard');
+  });
+
+  test('rejects on out-of-range checkIndex', () => {
+    const result = applyCommand(
+      hazardEncounter(),
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 9, delta: -1 }),
+      emptyEffects
+    );
+    expectRejected(result, 'RECORD_DISABLE_PROGRESS', 'Disable check index 9 is out of range');
+  });
+
+  test('positive delta undoes successes and clamps at requiredSuccesses', () => {
+    const start = hazardEncounter();
+    const reduced = applyCommand(
+      start,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: -2 }),
+      emptyEffects
+    );
+    expect(reduced.newState.combatants['trap-1'].hazardData!.disableProgress[0].successesRemaining).toBe(1);
+
+    const undone = applyCommand(
+      reduced.newState,
+      command('RECORD_DISABLE_PROGRESS', { combatantId: 'trap-1', checkIndex: 0, delta: 99 }),
+      emptyEffects
+    );
+    expect(undone.newState.combatants['trap-1'].hazardData!.disableProgress[0].successesRemaining).toBe(3);
+  });
+});

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -59,7 +59,8 @@ const allowedPhases: Record<CommandType, EncounterPhase[]> = {
   RESET_REACTION: ['ACTIVE', 'RESOLVING'],
   SET_NOTE: ['PREPARING', 'ACTIVE', 'RESOLVING'],
   MARK_DEAD: ['PREPARING', 'ACTIVE', 'RESOLVING'],
-  REVIVE: ['PREPARING', 'ACTIVE', 'RESOLVING']
+  REVIVE: ['PREPARING', 'ACTIVE', 'RESOLVING'],
+  RECORD_DISABLE_PROGRESS: ['PREPARING', 'ACTIVE', 'RESOLVING']
 };
 
 export function applyCommand(state: EncounterState, command: Command, effectLibrary: EffectLibrary): CommandResult {
@@ -137,6 +138,8 @@ export function applyCommand(state: EncounterState, command: Command, effectLibr
       return useInnateSpell(state, command.payload);
     case 'RESTORE_INNATE_SPELL':
       return restoreInnateSpell(state, command.payload);
+    case 'RECORD_DISABLE_PROGRESS':
+      return recordDisableProgress(state, command.payload);
     default:
       return reject(state, command.type, `${command.type} is not implemented in the first domain slice`);
   }
@@ -1687,6 +1690,82 @@ function revive(state: EncounterState, combatantId: CombatantId): CommandResult 
   }
 
   return updateCombatant(state, { ...combatant, isAlive: true }, [{ type: 'combatant-revived', combatantId }]);
+}
+
+function recordDisableProgress(
+  state: EncounterState,
+  payload: { combatantId: CombatantId; checkIndex: number; delta: number }
+): CommandResult {
+  const combatant = state.combatants[payload.combatantId];
+  if (!combatant) {
+    return reject(state, 'RECORD_DISABLE_PROGRESS', `Combatant ${payload.combatantId} not found`);
+  }
+
+  if (combatant.sourceType !== 'hazard' || !combatant.hazardData) {
+    return reject(
+      state,
+      'RECORD_DISABLE_PROGRESS',
+      `Combatant ${payload.combatantId} is not a hazard`
+    );
+  }
+
+  const checks = combatant.hazardData.disableChecks;
+  const progress = combatant.hazardData.disableProgress;
+  if (payload.checkIndex < 0 || payload.checkIndex >= checks.length) {
+    return reject(
+      state,
+      'RECORD_DISABLE_PROGRESS',
+      `Disable check index ${payload.checkIndex} is out of range`
+    );
+  }
+
+  const check = checks[payload.checkIndex];
+  const entry = progress[payload.checkIndex] ?? {
+    checkIndex: payload.checkIndex,
+    successesRemaining: check.requiredSuccesses
+  };
+  const max = check.requiredSuccesses;
+  const previous = entry.successesRemaining;
+  const next = clampInteger(previous + payload.delta, 0, max);
+
+  if (next === previous) {
+    return reject(state, 'RECORD_DISABLE_PROGRESS', 'No change to disable progress');
+  }
+
+  const wasFullyDisabled = progress.every((p) => p.successesRemaining === 0);
+  const newProgress = progress.map((p, i) =>
+    i === payload.checkIndex ? { ...p, successesRemaining: next } : p
+  );
+  const nowFullyDisabled = newProgress.every((p) => p.successesRemaining === 0);
+
+  const updated: CombatantState = {
+    ...combatant,
+    hazardData: {
+      ...combatant.hazardData,
+      disableProgress: newProgress
+    }
+  };
+
+  const events: DomainEvent[] = [
+    {
+      type: 'disable-progress-recorded',
+      combatantId: payload.combatantId,
+      checkIndex: payload.checkIndex,
+      previous,
+      next
+    }
+  ];
+
+  if (!wasFullyDisabled && nowFullyDisabled) {
+    events.push({ type: 'hazard-disabled', combatantId: payload.combatantId });
+  }
+
+  return updateCombatant(state, updated, events);
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
 }
 
 interface SpellLookup {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -18,6 +18,82 @@ export interface CreatureBaseStats {
   perception: number;
   speed: number;
   skills: Record<string, number>;
+  hardness?: number;
+}
+
+/**
+ * Defensive stats for a complex hazard. Hazards may lack some saves or AC
+ * entirely (PF2e prints "—"). Stealth replaces Perception as the initiative
+ * modifier; Perception is kept as a number but is unused for hazards.
+ */
+export interface HazardBaseStats {
+  hp: number;
+  ac: number | null;
+  fortitude: number | null;
+  reflex: number | null;
+  will: number | null;
+  perception: number;
+  stealth: number;
+  stealthNote?: string;
+  speed: number;
+  skills: Record<string, number>;
+  hardness?: number;
+  immunities?: string[];
+  resistances?: { type: string; value: number }[];
+  weaknesses?: { type: string; value: number }[];
+}
+
+export interface DisableCheck {
+  skill: string;
+  dc: number;
+  requiredSuccesses: number;
+  note?: string;
+}
+
+export interface DisableProgress {
+  checkIndex: number;
+  successesRemaining: number;
+}
+
+export interface HazardRoutine {
+  actions: number;
+  description: string;
+}
+
+export interface HazardData {
+  routine: HazardRoutine;
+  disableChecks: DisableCheck[];
+  disableProgress: DisableProgress[];
+}
+
+export interface Hazard {
+  id: string;
+  name: string;
+  level: number;
+  traits: string[];
+  rarity: CreatureRarity;
+  ac?: number;
+  fortitude?: number;
+  reflex?: number;
+  will?: number;
+  perception?: number;
+  hp?: number;
+  hardness?: number;
+  stealth: number;
+  stealthNote?: string;
+  immunities: string[];
+  resistances: { type: string; value: number }[];
+  weaknesses: { type: string; value: number }[];
+  disableChecks: DisableCheck[];
+  routine: HazardRoutine;
+  passiveAbilities: Ability[];
+  reactiveAbilities: Ability[];
+  activeAbilities: Ability[];
+  attacks: Attack[];
+  description?: string;
+  source?: string;
+  tags: string[];
+  notes?: string;
 }
 
 export type SourceType = 'creature' | 'partyMember' | 'companion' | 'hazard';
@@ -105,6 +181,7 @@ export interface Creature {
   will: number;
   perception: number;
   hp: number;
+  hardness?: number;
   immunities: string[];
   resistances: { type: string; value: number }[];
   weaknesses: { type: string; value: number }[];
@@ -172,7 +249,7 @@ export interface CombatantState {
   name: string;
   sourceType: SourceType;
   masterId?: CombatantId;
-  baseStats: CreatureBaseStats;
+  baseStats: CreatureBaseStats | HazardBaseStats;
   currentHp: number;
   tempHp: number;
   appliedEffects: AppliedEffect[];
@@ -188,6 +265,7 @@ export interface CombatantState {
   size?: CreatureSize;
   level?: number;
   templateAdjustment?: 'elite' | 'weak';
+  hazardData?: HazardData;
 }
 
 export type PromptBoundary = { type: 'turnStart' | 'turnEnd'; ownerId: CombatantId };
@@ -294,6 +372,17 @@ export interface InnateSpellPayload {
   spellSlug: string;
 }
 
+export interface RecordDisableProgressPayload {
+  combatantId: CombatantId;
+  checkIndex: number;
+  /**
+   * Successes to apply, signed: negative decrements successesRemaining
+   * (representing GM-confirmed successful disable check), positive undoes.
+   * Crit success = -2, crit fail / undo = +1, etc.
+   */
+  delta: number;
+}
+
 export type PromptResolution =
   | { type: 'accept' }
   | { type: 'setValue'; value: number }
@@ -347,7 +436,8 @@ export type Command =
   | BaseCommand<'RESET_REACTION', { combatantId: CombatantId }>
   | BaseCommand<'SET_NOTE', { combatantId: CombatantId; note: string | null }>
   | BaseCommand<'MARK_DEAD', { combatantId: CombatantId }>
-  | BaseCommand<'REVIVE', { combatantId: CombatantId }>;
+  | BaseCommand<'REVIVE', { combatantId: CombatantId }>
+  | BaseCommand<'RECORD_DISABLE_PROGRESS', RecordDisableProgressPayload>;
 
 export type CommandType =
   | 'START_ENCOUNTER'
@@ -386,7 +476,8 @@ export type CommandType =
   | 'RESET_REACTION'
   | 'SET_NOTE'
   | 'MARK_DEAD'
-  | 'REVIVE';
+  | 'REVIVE'
+  | 'RECORD_DISABLE_PROGRESS';
 
 export type DomainEvent =
   | { type: 'encounter-started' }
@@ -477,6 +568,14 @@ export type DomainEvent =
       spellSlug?: string;
       spellName?: string;
     }
+  | {
+      type: 'disable-progress-recorded';
+      combatantId: CombatantId;
+      checkIndex: number;
+      previous: number;
+      next: number;
+    }
+  | { type: 'hazard-disabled'; combatantId: CombatantId }
   | { type: 'command-rejected'; commandType: CommandType; reason: string };
 
 export type EffectCategory = 'condition' | 'spell' | 'affliction' | 'persistent-damage' | 'custom';
@@ -533,10 +632,12 @@ export interface ComputedModifierBucket {
 }
 
 export interface ComputedStats {
-  ac: ComputedStat;
-  fortitude: ComputedStat;
-  reflex: ComputedStat;
-  will: ComputedStat;
+  /** Absent for hazards that lack AC (PF2e "AC —"). */
+  ac?: ComputedStat;
+  /** Absent for hazards that lack the save. */
+  fortitude?: ComputedStat;
+  reflex?: ComputedStat;
+  will?: ComputedStat;
   perception: ComputedStat;
   skills: Record<string, ComputedStat>;
   attackRolls: ComputedModifierBucket;

--- a/src/lib/combat-log/format.ts
+++ b/src/lib/combat-log/format.ts
@@ -140,9 +140,32 @@ export function formatEvent(event: DomainEvent, options: FormatOptions): LogEntr
       return entry(id, `${nameOf(state, event.combatantId)} dropped to 0 HP.`, 'danger');
     case 'spell-usage-changed':
       return entry(id, formatSpellUsage(state, event), 'info');
+    case 'disable-progress-recorded':
+      return entry(id, formatDisableProgress(state, event), 'info');
+    case 'hazard-disabled':
+      return entry(id, `${nameOf(state, event.combatantId)} is fully disabled.`, 'success');
     case 'command-rejected':
       return entry(id, `${event.commandType} rejected: ${event.reason}.`, 'danger');
   }
+}
+
+function formatDisableProgress(
+  state: EncounterState,
+  event: Extract<DomainEvent, { type: 'disable-progress-recorded' }>
+): string {
+  const target = nameOf(state, event.combatantId);
+  const combatant = state.combatants[event.combatantId];
+  const check = combatant?.hazardData?.disableChecks[event.checkIndex];
+  const label = check ? `${capitalize(check.skill)} DC ${check.dc}` : `check #${event.checkIndex + 1}`;
+  const direction = event.next < event.previous ? 'success' : 'undone';
+  const remaining = check
+    ? ` (${event.next}/${check.requiredSuccesses} remaining)`
+    : '';
+  return `${target} disable — ${label} ${direction}${remaining}.`;
+}
+
+function capitalize(value: string): string {
+  return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1);
 }
 
 function formatSpellUsage(

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -1,6 +1,7 @@
 import {
   applyCommand,
   createCombatantFromCreature,
+  createCombatantFromHazard,
   createCombatantFromPartyMember,
   deriveStats,
   effectLibrary
@@ -18,6 +19,8 @@ import type {
   Duration,
   EffectDefinition,
   EncounterState,
+  Hazard,
+  HazardBaseStats,
   LogEntry,
   PartyMember
 } from '../domain';
@@ -127,6 +130,26 @@ export function makePartyMemberCombatant(input: PartyMemberCombatantInput): Comb
     combatantId: input.combatantId,
     name: input.name
   });
+}
+
+export interface HazardCombatantInput {
+  hazard: Hazard;
+  combatantId: string;
+  name?: string;
+}
+
+export function makeHazardCombatant(input: HazardCombatantInput): CombatantState {
+  return createCombatantFromHazard({
+    hazard: input.hazard,
+    combatantId: input.combatantId,
+    name: input.name
+  });
+}
+
+export function isHazardCombatant(
+  combatant: CombatantState
+): combatant is CombatantState & { baseStats: HazardBaseStats; hazardData: NonNullable<CombatantState['hazardData']> } {
+  return combatant.sourceType === 'hazard' && combatant.hazardData !== undefined;
 }
 
 export function toCommand<T extends CommandType>(

--- a/src/lib/storage/db.test.ts
+++ b/src/lib/storage/db.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIVE_ENCOUNTER_STORE,
   CREATURE_LIBRARY_STORE,
   DB_NAME,
+  HAZARD_LIBRARY_STORE,
   PARTY_MEMBER_STORE,
   SETTINGS_STORE
 } from './db';
@@ -52,7 +53,7 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE, HAZARD_LIBRARY_STORE].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v1-data'
@@ -77,7 +78,7 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE, HAZARD_LIBRARY_STORE].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v3-active'
@@ -104,7 +105,7 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE, HAZARD_LIBRARY_STORE].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v2-active'
@@ -113,12 +114,39 @@ describe('IndexedDB schema migration', () => {
     expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([]);
   });
 
-  it('creates all three stores on a fresh install (no prior database)', async () => {
+  it('preserves prior records when upgrading from v4 to v5 and adds the hazardLibrary store', async () => {
+    const v4 = await openDB(DB_NAME, 4, {
+      upgrade(db) {
+        db.createObjectStore(ACTIVE_ENCOUNTER_STORE);
+        db.createObjectStore(SETTINGS_STORE);
+        db.createObjectStore(CREATURE_LIBRARY_STORE);
+        db.createObjectStore(PARTY_MEMBER_STORE);
+      }
+    });
+    await v4.put(ACTIVE_ENCOUNTER_STORE, { sentinel: 'v4-active' }, 'current');
+    await v4.put(CREATURE_LIBRARY_STORE, { id: 'goblin', name: 'Goblin' }, 'goblin');
+    v4.close();
+
+    const { getDb } = await import('./db');
+    const db = await getDb()!;
+    openConnections.push(db);
+
+    expect(Array.from(db.objectStoreNames).sort()).toEqual(
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE, HAZARD_LIBRARY_STORE].sort()
+    );
+    expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
+      sentinel: 'v4-active'
+    });
+    expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([{ id: 'goblin', name: 'Goblin' }]);
+    expect(await db.getAll(HAZARD_LIBRARY_STORE)).toEqual([]);
+  });
+
+  it('creates all five stores on a fresh install (no prior database)', async () => {
     const { getDb } = await import('./db');
     const db = await getDb()!;
     openConnections.push(db);
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE, HAZARD_LIBRARY_STORE].sort()
     );
   });
 });

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,11 +1,12 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 export const DB_NAME = 'pf2e-tracker-v2';
-export const DB_VERSION = 4;
+export const DB_VERSION = 5;
 export const ACTIVE_ENCOUNTER_STORE = 'activeEncounter';
 export const SETTINGS_STORE = 'settings';
 export const CREATURE_LIBRARY_STORE = 'creatureLibrary';
 export const PARTY_MEMBER_STORE = 'partyMembers';
+export const HAZARD_LIBRARY_STORE = 'hazardLibrary';
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -32,6 +33,9 @@ export function getDb(): Promise<IDBPDatabase> | null {
         }
         if (!db.objectStoreNames.contains(PARTY_MEMBER_STORE)) {
           db.createObjectStore(PARTY_MEMBER_STORE);
+        }
+        if (!db.objectStoreNames.contains(HAZARD_LIBRARY_STORE)) {
+          db.createObjectStore(HAZARD_LIBRARY_STORE);
         }
       }
     }).catch((err) => {

--- a/src/lib/storage/hazard-library.test.ts
+++ b/src/lib/storage/hazard-library.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Hazard } from '../../domain';
+import {
+  addHazards,
+  clearHazards,
+  loadHazards,
+  removeHazard
+} from './hazard-library';
+
+function makeHazard(overrides: Partial<Hazard> = {}): Hazard {
+  return {
+    id: 'test-hazard',
+    name: 'Test Hazard',
+    level: 1,
+    traits: ['mechanical', 'trap'],
+    rarity: 'common',
+    ac: 15,
+    fortitude: 5,
+    reflex: 8,
+    hp: 30,
+    stealth: 12,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    disableChecks: [{ skill: 'thievery', dc: 18, requiredSuccesses: 1 }],
+    routine: { actions: 1, description: 'Spins.' },
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    attacks: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+async function loadOrThrow(): Promise<Hazard[]> {
+  const result = await loadHazards();
+  if (!result.ok) throw new Error(`loadHazards failed: ${result.reason}`);
+  return result.hazards;
+}
+
+beforeEach(async () => {
+  await clearHazards();
+});
+
+afterEach(async () => {
+  await clearHazards();
+});
+
+describe('hazard library storage', () => {
+  it('returns an empty list when nothing has been imported', async () => {
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('round-trips an imported hazard', async () => {
+    const trap = makeHazard({ id: 'pit', name: 'Spiked Pit' });
+    const result = await addHazards([trap]);
+    expect(result).toEqual({ ok: true, added: [trap], rejected: [] });
+    expect(await loadOrThrow()).toEqual([trap]);
+  });
+
+  it('rejects hazards whose id is already present', async () => {
+    const original = makeHazard({ id: 'pit', name: 'Original' });
+    await addHazards([original]);
+
+    const collision = makeHazard({ id: 'pit', name: 'Different' });
+    const fresh = makeHazard({ id: 'dart', name: 'Dart Trap' });
+    const result = await addHazards([collision, fresh]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.added).toEqual([fresh]);
+      expect(result.rejected).toEqual([collision]);
+    }
+
+    const stored = await loadOrThrow();
+    expect(stored.find((h) => h.id === 'pit')?.name).toBe('Original');
+  });
+
+  it('removeHazard deletes a single record', async () => {
+    await addHazards([makeHazard({ id: 'a' }), makeHazard({ id: 'b' })]);
+    expect(await removeHazard('a')).toEqual({ ok: true, existed: true });
+    const stored = await loadOrThrow();
+    expect(stored.map((h) => h.id)).toEqual(['b']);
+  });
+
+  it('removeHazard reports existed: false for unknown ids', async () => {
+    expect(await removeHazard('missing')).toEqual({ ok: true, existed: false });
+  });
+
+  it('persists hazards across a simulated reload', async () => {
+    const trap = makeHazard({ id: 'pit', name: 'Spiked Pit' });
+    await addHazards([trap]);
+
+    vi.resetModules();
+    const { loadHazards: load } = await import('./hazard-library');
+    const result = await load();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.hazards.map((h) => h.id)).toEqual(['pit']);
+    }
+  });
+});
+
+describe('hazard library when indexedDB is unavailable', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loadHazards returns ok: false / unavailable', async () => {
+    const { loadHazards: load } = await import('./hazard-library');
+    expect(await load()).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('addHazards returns ok: false / unavailable', async () => {
+    const { addHazards: add } = await import('./hazard-library');
+    expect(await add([makeHazard({ id: 'x' })])).toEqual({
+      ok: false,
+      reason: 'unavailable'
+    });
+  });
+});

--- a/src/lib/storage/hazard-library.ts
+++ b/src/lib/storage/hazard-library.ts
@@ -1,0 +1,78 @@
+import type { Hazard } from '../../domain';
+import { dedupeNewHazards } from '../yaml';
+import { getDb, HAZARD_LIBRARY_STORE } from './db';
+
+export type StorageFailureReason = 'unavailable' | 'failed';
+
+export type LoadHazardsResult =
+  | { ok: true; hazards: Hazard[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type AddHazardsResult =
+  | { ok: true; added: Hazard[]; rejected: Hazard[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type RemoveHazardResult =
+  | { ok: true; existed: boolean }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type ClearHazardsResult =
+  | { ok: true }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export async function loadHazards(): Promise<LoadHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const stored = (await db.getAll(HAZARD_LIBRARY_STORE)) as Hazard[];
+    return { ok: true, hazards: stored };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function addHazards(hazards: readonly Hazard[]): Promise<AddHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const tx = db.transaction(HAZARD_LIBRARY_STORE, 'readwrite');
+    const existingIds = new Set((await tx.store.getAllKeys()) as string[]);
+    const { accepted, rejected } = dedupeNewHazards(existingIds, hazards);
+    for (const hazard of accepted) {
+      tx.store.put(hazard, hazard.id);
+    }
+    await tx.done;
+    return { ok: true, added: accepted, rejected };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function removeHazard(id: string): Promise<RemoveHazardResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const tx = db.transaction(HAZARD_LIBRARY_STORE, 'readwrite');
+    const existed = (await tx.store.getKey(id)) !== undefined;
+    await tx.store.delete(id);
+    await tx.done;
+    return { ok: true, existed };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function clearHazards(): Promise<ClearHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    await db.clear(HAZARD_LIBRARY_STORE);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}

--- a/src/lib/yaml/hazard-validator.test.ts
+++ b/src/lib/yaml/hazard-validator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'vitest';
+import { importHazardYaml, dedupeNewHazards } from './index';
+
+const POISONED_DART_GALLERY_YAML = `kind: hazard
+schemaVersion: 1
+data:
+  id: poisoned-dart-gallery
+  name: Poisoned Dart Gallery
+  level: 8
+  traits: [mechanical, trap]
+  rarity: common
+
+  stealth: 28
+  stealthNote: expert
+
+  ac: 27
+  fortitude: 13
+  reflex: 17
+  hp: 100
+  hardness: 10
+  immunities: [critical-hits, object-immunities, precision]
+  resistances: []
+  weaknesses: []
+
+  disableChecks:
+    - skill: thievery
+      dc: 26
+      requiredSuccesses: 3
+      note: "at a control panel on the far wall"
+    - skill: athletics
+      dc: 22
+      requiredSuccesses: 1
+      note: "to jam a single dart launcher"
+
+  routine:
+    actions: 2
+    description: |
+      The trap fires a volley of poisoned darts.
+
+  attacks:
+    - name: poisoned dart
+      type: ranged
+      modifier: 21
+      traits: [range-60]
+      damage:
+        - dice: 3
+          dieSize: 4
+          bonus: 2
+          type: piercing
+
+  passiveAbilities: []
+  reactiveAbilities: []
+  activeAbilities: []
+  tags: [extinction-curse]
+  source: "Extinction Curse #3"
+`;
+
+describe('importHazardYaml', () => {
+  test('round-trips the poisoned dart gallery fixture', () => {
+    const result = importHazardYaml(POISONED_DART_GALLERY_YAML);
+    expect(result.issues).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.hazards).toHaveLength(1);
+
+    const h = result.hazards[0];
+    expect(h.id).toBe('poisoned-dart-gallery');
+    expect(h.name).toBe('Poisoned Dart Gallery');
+    expect(h.level).toBe(8);
+    expect(h.ac).toBe(27);
+    expect(h.fortitude).toBe(13);
+    expect(h.reflex).toBe(17);
+    expect(h.will).toBeUndefined();
+    expect(h.hardness).toBe(10);
+    expect(h.stealth).toBe(28);
+    expect(h.stealthNote).toBe('expert');
+    expect(h.immunities).toEqual(['critical-hits', 'object-immunities', 'precision']);
+    expect(h.disableChecks).toHaveLength(2);
+    expect(h.disableChecks[0].requiredSuccesses).toBe(3);
+    expect(h.routine.actions).toBe(2);
+    expect(h.attacks).toHaveLength(1);
+  });
+
+  test('rejects when required fields are missing', () => {
+    const bad = `kind: hazard
+schemaVersion: 1
+data:
+  id: incomplete
+  name: Incomplete
+  level: 1
+  traits: []
+  rarity: common
+  stealth: 10
+  immunities: []
+  resistances: []
+  weaknesses: []
+  disableChecks: []
+  routine:
+    actions: 1
+    description: noop
+  attacks: []
+  passiveAbilities: []
+  reactiveAbilities: []
+  activeAbilities: []
+  tags: []
+`;
+    const result = importHazardYaml(bad);
+    expect(result.hazards).toHaveLength(0);
+    expect(result.issues.some((i) => i.path === 'disableChecks')).toBe(true);
+  });
+
+  test('skips non-hazard envelopes', () => {
+    const yaml = `kind: creature
+schemaVersion: 1
+data:
+  id: goblin
+  name: Goblin
+`;
+    const result = importHazardYaml(yaml);
+    expect(result.hazards).toHaveLength(0);
+    expect(result.skipped).toEqual([{ documentIndex: 0, kind: 'creature' }]);
+  });
+});
+
+describe('dedupeNewHazards', () => {
+  function fakeHazard(id: string, name = id): import('../../domain').Hazard {
+    return {
+      id,
+      name,
+      level: 1,
+      traits: [],
+      rarity: 'common',
+      stealth: 10,
+      immunities: [],
+      resistances: [],
+      weaknesses: [],
+      disableChecks: [{ skill: 'thievery', dc: 10, requiredSuccesses: 1 }],
+      routine: { actions: 1, description: 'noop' },
+      passiveAbilities: [],
+      reactiveAbilities: [],
+      activeAbilities: [],
+      attacks: [],
+      tags: []
+    };
+  }
+
+  test('accepts ids not in the existing set', () => {
+    const result = dedupeNewHazards(new Set(['pit']), [fakeHazard('dart')]);
+    expect(result.accepted.map((h) => h.id)).toEqual(['dart']);
+    expect(result.rejected).toEqual([]);
+  });
+
+  test('rejects ids already present', () => {
+    const result = dedupeNewHazards(new Set(['pit']), [fakeHazard('pit')]);
+    expect(result.accepted).toEqual([]);
+    expect(result.rejected.map((h) => h.id)).toEqual(['pit']);
+  });
+
+  test('rejects duplicates within an import batch', () => {
+    const result = dedupeNewHazards(new Set(), [fakeHazard('a'), fakeHazard('a', 'A2')]);
+    expect(result.accepted.map((h) => h.name)).toEqual(['a']);
+    expect(result.rejected.map((h) => h.name)).toEqual(['A2']);
+  });
+});

--- a/src/lib/yaml/hazard-validator.ts
+++ b/src/lib/yaml/hazard-validator.ts
@@ -1,0 +1,492 @@
+import type {
+  Ability,
+  ActionCost,
+  Attack,
+  AttackType,
+  CreatureRarity,
+  DamageComponent,
+  DisableCheck,
+  Hazard,
+  HazardRoutine
+} from '../../domain';
+import type { ValidationIssue } from './envelope';
+
+const RARITIES: ReadonlySet<CreatureRarity> = new Set(['common', 'uncommon', 'rare', 'unique']);
+const ATTACK_TYPES: ReadonlySet<AttackType> = new Set(['melee', 'ranged']);
+const ACTION_COSTS = new Set<ActionCost>([1, 2, 3, 'free', 'reaction']);
+
+export type ParseOutcome<T> =
+  | { ok: true; value: T; issues: ValidationIssue[] }
+  | { ok: false; issues: ValidationIssue[] };
+
+class IssueBag {
+  readonly issues: ValidationIssue[] = [];
+  constructor(private readonly documentIndex: number) {}
+
+  add(path: string, message: string): void {
+    this.issues.push({ documentIndex: this.documentIndex, path, message });
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function requireNumber(bag: IssueBag, path: string, value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    bag.add(path, 'must be a finite number');
+    return null;
+  }
+  return value;
+}
+
+function requirePositiveInteger(bag: IssueBag, path: string, value: unknown): number | null {
+  const n = requireNumber(bag, path, value);
+  if (n === null) return null;
+  if (!Number.isInteger(n) || n < 1) {
+    bag.add(path, 'must be a positive integer');
+    return null;
+  }
+  return n;
+}
+
+function requireString(bag: IssueBag, path: string, value: unknown): string | null {
+  if (typeof value !== 'string') {
+    bag.add(path, 'must be a string');
+    return null;
+  }
+  return value;
+}
+
+function requireStringArray(bag: IssueBag, path: string, value: unknown): string[] | null {
+  if (!isStringArray(value)) {
+    bag.add(path, 'must be an array of strings');
+    return null;
+  }
+  return value;
+}
+
+function requireArray(bag: IssueBag, path: string, value: unknown): unknown[] | null {
+  if (!Array.isArray(value)) {
+    bag.add(path, 'must be an array');
+    return null;
+  }
+  return value;
+}
+
+function requireObject(bag: IssueBag, path: string, value: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    bag.add(path, 'must be a mapping (object)');
+    return null;
+  }
+  return value;
+}
+
+function validateDamageType(
+  bag: IssueBag,
+  path: string,
+  raw: unknown
+): { type: string; value: number } | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  const type = requireString(bag, `${path}.type`, obj.type);
+  const value = requireNumber(bag, `${path}.value`, obj.value);
+  if (type === null || value === null) return null;
+  return { type, value };
+}
+
+function validateDamageComponent(bag: IssueBag, path: string, raw: unknown): DamageComponent | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const type = requireString(bag, `${path}.type`, obj.type);
+  if (type === null) ok = false;
+
+  let dice: number | undefined;
+  if (obj.dice !== undefined) {
+    const n = requireNumber(bag, `${path}.dice`, obj.dice);
+    if (n === null) ok = false;
+    else dice = n;
+  }
+  let dieSize: number | undefined;
+  if (obj.dieSize !== undefined) {
+    const n = requireNumber(bag, `${path}.dieSize`, obj.dieSize);
+    if (n === null) ok = false;
+    else dieSize = n;
+  }
+  let bonus: number | undefined;
+  if (obj.bonus !== undefined) {
+    const n = requireNumber(bag, `${path}.bonus`, obj.bonus);
+    if (n === null) ok = false;
+    else bonus = n;
+  }
+  let persistent: boolean | undefined;
+  if (obj.persistent !== undefined) {
+    if (typeof obj.persistent !== 'boolean') {
+      bag.add(`${path}.persistent`, 'must be a boolean');
+      ok = false;
+    } else persistent = obj.persistent;
+  }
+
+  if (!ok || type === null) return null;
+  const out: DamageComponent = { type };
+  if (dice !== undefined) out.dice = dice;
+  if (dieSize !== undefined) out.dieSize = dieSize;
+  if (bonus !== undefined) out.bonus = bonus;
+  if (persistent !== undefined) out.persistent = persistent;
+  return out;
+}
+
+function validateAttack(bag: IssueBag, path: string, raw: unknown): Attack | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const name = requireString(bag, `${path}.name`, obj.name);
+  if (name === null) ok = false;
+
+  let type: AttackType | null = null;
+  if (typeof obj.type !== 'string' || !ATTACK_TYPES.has(obj.type as AttackType)) {
+    bag.add(`${path}.type`, 'must be one of: melee, ranged');
+    ok = false;
+  } else type = obj.type as AttackType;
+
+  const modifier = requireNumber(bag, `${path}.modifier`, obj.modifier);
+  if (modifier === null) ok = false;
+  const traits = requireStringArray(bag, `${path}.traits`, obj.traits);
+  if (traits === null) ok = false;
+
+  const damageRaw = requireArray(bag, `${path}.damage`, obj.damage);
+  const damage: DamageComponent[] = [];
+  if (damageRaw === null) ok = false;
+  else {
+    for (let i = 0; i < damageRaw.length; i++) {
+      const d = validateDamageComponent(bag, `${path}.damage[${i}]`, damageRaw[i]);
+      if (d === null) ok = false;
+      else damage.push(d);
+    }
+  }
+
+  let effects: string[] | undefined;
+  if (obj.effects !== undefined) {
+    const e = requireStringArray(bag, `${path}.effects`, obj.effects);
+    if (e === null) ok = false;
+    else effects = e;
+  }
+
+  if (!ok || name === null || type === null || modifier === null || traits === null) return null;
+  return {
+    name,
+    type,
+    modifier,
+    traits,
+    damage,
+    ...(effects !== undefined ? { effects } : {})
+  };
+}
+
+function validateAbility(bag: IssueBag, path: string, raw: unknown): Ability | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const name = requireString(bag, `${path}.name`, obj.name);
+  if (name === null) ok = false;
+  const description = requireString(bag, `${path}.description`, obj.description);
+  if (description === null) ok = false;
+
+  let actions: ActionCost | undefined;
+  if (obj.actions !== undefined) {
+    if (!ACTION_COSTS.has(obj.actions as ActionCost)) {
+      bag.add(`${path}.actions`, 'must be 1, 2, 3, "free", or "reaction"');
+      ok = false;
+    } else actions = obj.actions as ActionCost;
+  }
+  let traits: string[] | undefined;
+  if (obj.traits !== undefined) {
+    const t = requireStringArray(bag, `${path}.traits`, obj.traits);
+    if (t === null) ok = false;
+    else traits = t;
+  }
+  const optStrings: Record<'trigger' | 'frequency' | 'requirements', string | undefined> = {
+    trigger: undefined,
+    frequency: undefined,
+    requirements: undefined
+  };
+  for (const key of ['trigger', 'frequency', 'requirements'] as const) {
+    if (obj[key] !== undefined) {
+      const s = requireString(bag, `${path}.${key}`, obj[key]);
+      if (s === null) ok = false;
+      else optStrings[key] = s;
+    }
+  }
+
+  if (!ok || name === null || description === null) return null;
+  const out: Ability = { name, description };
+  if (actions !== undefined) out.actions = actions;
+  if (traits !== undefined) out.traits = traits;
+  if (optStrings.trigger !== undefined) out.trigger = optStrings.trigger;
+  if (optStrings.frequency !== undefined) out.frequency = optStrings.frequency;
+  if (optStrings.requirements !== undefined) out.requirements = optStrings.requirements;
+  return out;
+}
+
+function validateAbilityArray(bag: IssueBag, path: string, raw: unknown): Ability[] | null {
+  const arr = requireArray(bag, path, raw);
+  if (arr === null) return null;
+  const out: Ability[] = [];
+  let ok = true;
+  for (let i = 0; i < arr.length; i++) {
+    const a = validateAbility(bag, `${path}[${i}]`, arr[i]);
+    if (a === null) ok = false;
+    else out.push(a);
+  }
+  return ok ? out : null;
+}
+
+function validateDisableCheck(bag: IssueBag, path: string, raw: unknown): DisableCheck | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const skill = requireString(bag, `${path}.skill`, obj.skill);
+  if (skill === null) ok = false;
+  const dc = requireNumber(bag, `${path}.dc`, obj.dc);
+  if (dc === null) ok = false;
+  const requiredSuccesses = requirePositiveInteger(
+    bag,
+    `${path}.requiredSuccesses`,
+    obj.requiredSuccesses
+  );
+  if (requiredSuccesses === null) ok = false;
+
+  let note: string | undefined;
+  if (obj.note !== undefined) {
+    const s = requireString(bag, `${path}.note`, obj.note);
+    if (s === null) ok = false;
+    else note = s;
+  }
+
+  if (!ok || skill === null || dc === null || requiredSuccesses === null) return null;
+  return { skill, dc, requiredSuccesses, ...(note !== undefined ? { note } : {}) };
+}
+
+function validateRoutine(bag: IssueBag, path: string, raw: unknown): HazardRoutine | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const actions = requirePositiveInteger(bag, `${path}.actions`, obj.actions);
+  if (actions === null) ok = false;
+  const description = requireString(bag, `${path}.description`, obj.description);
+  if (description === null) ok = false;
+  if (!ok || actions === null || description === null) return null;
+  return { actions, description };
+}
+
+export function validateHazard(raw: unknown, documentIndex: number): ParseOutcome<Hazard> {
+  const bag = new IssueBag(documentIndex);
+
+  const obj = requireObject(bag, '', raw);
+  if (!obj) return { ok: false, issues: bag.issues };
+
+  let ok = true;
+
+  const id = requireString(bag, 'id', obj.id);
+  if (id === null) ok = false;
+  const name = requireString(bag, 'name', obj.name);
+  if (name === null) ok = false;
+  const level = requireNumber(bag, 'level', obj.level);
+  if (level === null) ok = false;
+  const traits = requireStringArray(bag, 'traits', obj.traits);
+  if (traits === null) ok = false;
+
+  let rarity: CreatureRarity | null = null;
+  if (typeof obj.rarity !== 'string' || !RARITIES.has(obj.rarity as CreatureRarity)) {
+    bag.add('rarity', 'must be one of: common, uncommon, rare, unique');
+    ok = false;
+  } else rarity = obj.rarity as CreatureRarity;
+
+  const stealth = requireNumber(bag, 'stealth', obj.stealth);
+  if (stealth === null) ok = false;
+  let stealthNote: string | undefined;
+  if (obj.stealthNote !== undefined) {
+    const s = requireString(bag, 'stealthNote', obj.stealthNote);
+    if (s === null) ok = false;
+    else stealthNote = s;
+  }
+
+  let ac: number | undefined;
+  if (obj.ac !== undefined) {
+    const n = requireNumber(bag, 'ac', obj.ac);
+    if (n === null) ok = false;
+    else ac = n;
+  }
+  let fortitude: number | undefined;
+  if (obj.fortitude !== undefined) {
+    const n = requireNumber(bag, 'fortitude', obj.fortitude);
+    if (n === null) ok = false;
+    else fortitude = n;
+  }
+  let reflex: number | undefined;
+  if (obj.reflex !== undefined) {
+    const n = requireNumber(bag, 'reflex', obj.reflex);
+    if (n === null) ok = false;
+    else reflex = n;
+  }
+  let will: number | undefined;
+  if (obj.will !== undefined) {
+    const n = requireNumber(bag, 'will', obj.will);
+    if (n === null) ok = false;
+    else will = n;
+  }
+  let perception: number | undefined;
+  if (obj.perception !== undefined) {
+    const n = requireNumber(bag, 'perception', obj.perception);
+    if (n === null) ok = false;
+    else perception = n;
+  }
+  let hp: number | undefined;
+  if (obj.hp !== undefined) {
+    const n = requireNumber(bag, 'hp', obj.hp);
+    if (n === null) ok = false;
+    else hp = n;
+  }
+  let hardness: number | undefined;
+  if (obj.hardness !== undefined) {
+    const n = requireNumber(bag, 'hardness', obj.hardness);
+    if (n === null) ok = false;
+    else hardness = n;
+  }
+
+  const immunities = requireStringArray(bag, 'immunities', obj.immunities);
+  if (immunities === null) ok = false;
+
+  const resistancesRaw = requireArray(bag, 'resistances', obj.resistances);
+  const resistances: { type: string; value: number }[] = [];
+  if (resistancesRaw === null) ok = false;
+  else {
+    for (let i = 0; i < resistancesRaw.length; i++) {
+      const r = validateDamageType(bag, `resistances[${i}]`, resistancesRaw[i]);
+      if (r === null) ok = false;
+      else resistances.push(r);
+    }
+  }
+  const weaknessesRaw = requireArray(bag, 'weaknesses', obj.weaknesses);
+  const weaknesses: { type: string; value: number }[] = [];
+  if (weaknessesRaw === null) ok = false;
+  else {
+    for (let i = 0; i < weaknessesRaw.length; i++) {
+      const w = validateDamageType(bag, `weaknesses[${i}]`, weaknessesRaw[i]);
+      if (w === null) ok = false;
+      else weaknesses.push(w);
+    }
+  }
+
+  const disableChecksRaw = requireArray(bag, 'disableChecks', obj.disableChecks);
+  const disableChecks: DisableCheck[] = [];
+  if (disableChecksRaw === null) {
+    ok = false;
+  } else if (disableChecksRaw.length === 0) {
+    bag.add('disableChecks', 'must be a non-empty array');
+    ok = false;
+  } else {
+    for (let i = 0; i < disableChecksRaw.length; i++) {
+      const c = validateDisableCheck(bag, `disableChecks[${i}]`, disableChecksRaw[i]);
+      if (c === null) ok = false;
+      else disableChecks.push(c);
+    }
+  }
+
+  const routine = validateRoutine(bag, 'routine', obj.routine);
+  if (routine === null) ok = false;
+
+  const attacksRaw = requireArray(bag, 'attacks', obj.attacks);
+  const attacks: Attack[] = [];
+  if (attacksRaw === null) ok = false;
+  else {
+    for (let i = 0; i < attacksRaw.length; i++) {
+      const a = validateAttack(bag, `attacks[${i}]`, attacksRaw[i]);
+      if (a === null) ok = false;
+      else attacks.push(a);
+    }
+  }
+
+  const passive = validateAbilityArray(bag, 'passiveAbilities', obj.passiveAbilities);
+  if (passive === null) ok = false;
+  const reactive = validateAbilityArray(bag, 'reactiveAbilities', obj.reactiveAbilities);
+  if (reactive === null) ok = false;
+  const active = validateAbilityArray(bag, 'activeAbilities', obj.activeAbilities);
+  if (active === null) ok = false;
+
+  const tags = requireStringArray(bag, 'tags', obj.tags);
+  if (tags === null) ok = false;
+
+  let source: string | undefined;
+  if (obj.source !== undefined) {
+    const s = requireString(bag, 'source', obj.source);
+    if (s === null) ok = false;
+    else source = s;
+  }
+  let notes: string | undefined;
+  if (obj.notes !== undefined) {
+    const s = requireString(bag, 'notes', obj.notes);
+    if (s === null) ok = false;
+    else notes = s;
+  }
+  let description: string | undefined;
+  if (obj.description !== undefined) {
+    const s = requireString(bag, 'description', obj.description);
+    if (s === null) ok = false;
+    else description = s;
+  }
+
+  if (
+    !ok ||
+    id === null ||
+    name === null ||
+    level === null ||
+    traits === null ||
+    rarity === null ||
+    stealth === null ||
+    immunities === null ||
+    passive === null ||
+    reactive === null ||
+    active === null ||
+    tags === null ||
+    routine === null
+  ) {
+    return { ok: false, issues: bag.issues };
+  }
+
+  const hazard: Hazard = {
+    id,
+    name,
+    level,
+    traits,
+    rarity,
+    stealth,
+    immunities,
+    resistances,
+    weaknesses,
+    disableChecks,
+    routine,
+    passiveAbilities: passive,
+    reactiveAbilities: reactive,
+    activeAbilities: active,
+    attacks,
+    tags,
+    ...(stealthNote !== undefined ? { stealthNote } : {}),
+    ...(ac !== undefined ? { ac } : {}),
+    ...(fortitude !== undefined ? { fortitude } : {}),
+    ...(reflex !== undefined ? { reflex } : {}),
+    ...(will !== undefined ? { will } : {}),
+    ...(perception !== undefined ? { perception } : {}),
+    ...(hp !== undefined ? { hp } : {}),
+    ...(hardness !== undefined ? { hardness } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...(notes !== undefined ? { notes } : {})
+  };
+  return { ok: true, value: hazard, issues: bag.issues };
+}

--- a/src/lib/yaml/index.ts
+++ b/src/lib/yaml/index.ts
@@ -1,6 +1,7 @@
-import type { Creature } from '../../domain';
+import type { Creature, Hazard } from '../../domain';
 import { parseYamlEnvelopes, type ValidationIssue, type YamlDocumentKind } from './envelope';
 import { validateCreature } from './creature-validator';
+import { validateHazard } from './hazard-validator';
 
 export type { ValidationIssue } from './envelope';
 export type { ParseOutcome } from './creature-validator';
@@ -61,6 +62,59 @@ export function dedupeNewCreatures(
     } else {
       seen.add(creature.id);
       accepted.push(creature);
+    }
+  }
+  return { accepted, rejected };
+}
+
+export interface HazardSkippedDocument {
+  documentIndex: number;
+  kind: Exclude<YamlDocumentKind, 'hazard'>;
+}
+
+export interface HazardImportResult {
+  hazards: Hazard[];
+  issues: ValidationIssue[];
+  skipped: HazardSkippedDocument[];
+}
+
+export function importHazardYaml(text: string): HazardImportResult {
+  const { envelopes, issues } = parseYamlEnvelopes(text);
+  const hazards: Hazard[] = [];
+  const skipped: HazardSkippedDocument[] = [];
+  const allIssues: ValidationIssue[] = [...issues];
+
+  for (const envelope of envelopes) {
+    if (envelope.kind !== 'hazard') {
+      skipped.push({ documentIndex: envelope.documentIndex, kind: envelope.kind });
+      continue;
+    }
+    const result = validateHazard(envelope.data, envelope.documentIndex);
+    if (result.ok) hazards.push(result.value);
+    allIssues.push(...result.issues);
+  }
+
+  return { hazards, issues: allIssues, skipped };
+}
+
+export interface HazardDedupeResult {
+  accepted: Hazard[];
+  rejected: Hazard[];
+}
+
+export function dedupeNewHazards(
+  existingIds: ReadonlySet<string>,
+  incoming: readonly Hazard[]
+): HazardDedupeResult {
+  const accepted: Hazard[] = [];
+  const rejected: Hazard[] = [];
+  const seen = new Set(existingIds);
+  for (const hazard of incoming) {
+    if (seen.has(hazard.id)) {
+      rejected.push(hazard);
+    } else {
+      seen.add(hazard.id);
+      accepted.push(hazard);
     }
   }
   return { accepted, rejected };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Command, CombatantState, Creature, Duration, LogEntry, PartyMember, PromptResolution } from '../domain';
+  import type { Command, CombatantState, Creature, Duration, Hazard, LogEntry, PartyMember, PromptResolution } from '../domain';
   import { computeEncounterXP } from '../domain';
   import EncounterDifficultyMeter from '../components/EncounterDifficultyMeter.svelte';
   import TopBar from '../components/TopBar.svelte';
@@ -19,6 +19,7 @@
     dispatchEncounterCommand,
     formatModifierBreakdown,
     groupConditionsByCategory,
+    isHazardCombatant,
     listAfflictionOptions,
     listConditionOptions,
     listConditionWedgeCounts,
@@ -28,6 +29,7 @@
     listSpellEffectOptions,
     makeCombatant,
     makeCreatureCombatant,
+    makeHazardCombatant,
     makePartyMemberCombatant,
     newEncounterState,
     toCommand,
@@ -65,13 +67,18 @@
     removeCreature
   } from '$lib/storage/creature-library';
   import {
+    addHazards,
+    loadHazards,
+    removeHazard
+  } from '$lib/storage/hazard-library';
+  import {
     addPartyMembers,
     loadPartyMembers,
     removePartyMember,
     savePartyMember
   } from '$lib/storage/party-members';
   import { createPersistenceController } from '$lib/storage/persistence-controller';
-  import { importCreatureYaml, importPartyMemberYaml } from '$lib/yaml';
+  import { importCreatureYaml, importHazardYaml, importPartyMemberYaml } from '$lib/yaml';
 
   const conditionOptions = listConditionOptions();
   const conditionGroups = groupConditionsByCategory();
@@ -94,6 +101,7 @@
   let selection: Selection = emptySelection;
   let storedCreatures: Creature[] = [];
   let storedPartyMembers: PartyMember[] = [];
+  let storedHazards: Hazard[] = [];
 
   $: availableCreatures = storedCreatures;
 
@@ -174,10 +182,11 @@
   }
 
   onMount(async () => {
-    const [restored, loadResult, partyResult] = await Promise.all([
+    const [restored, loadResult, partyResult, hazardResult] = await Promise.all([
       persistence.restore(),
       loadCreatures(),
-      loadPartyMembers()
+      loadPartyMembers(),
+      loadHazards()
     ]);
     if (restored) {
       encounter = { ...restored, combatLog: dedupeLogById(restored.combatLog) };
@@ -202,6 +211,16 @@
         partyResult.reason === 'unavailable'
           ? 'Could not load your party members: storage is unavailable. Imports this session will not survive a reload.'
           : 'Could not load your party members from storage. Try reloading the page; if it persists, your saved data may be inaccessible.'
+      );
+    }
+    if (hazardResult.ok) {
+      storedHazards = hazardResult.hazards;
+    } else {
+      appendFeedback(
+        nextFeedbackId('hazard-load-fail'),
+        hazardResult.reason === 'unavailable'
+          ? 'Could not load your hazard library: storage is unavailable. Imports this session will not survive a reload.'
+          : 'Could not load your hazard library from storage. Try reloading the page; if it persists, your saved data may be inaccessible.'
       );
     }
   });
@@ -520,6 +539,132 @@
       : [...storedPartyMembers, member];
   }
 
+  function handleAddHazardToEncounter(hazard: Hazard) {
+    const existing = encounterCounts[hazard.id] ?? 0;
+    const name = existing > 0 ? `${hazard.name} ${existing + 1}` : hazard.name;
+    const combatant = makeHazardCombatant({
+      hazard,
+      combatantId: `${hazard.id}-${combatantCounter++}`,
+      name
+    });
+    addCombatant(combatant);
+  }
+
+  function handleRemoveOneHazardFromEncounter(hazardId: string) {
+    let target: CombatantState | undefined;
+    for (const id of [...encounter.initiative.order].reverse()) {
+      const c = encounter.combatants[id];
+      if (c && c.sourceType === 'hazard' && c.sourceId === hazardId) {
+        target = c;
+        break;
+      }
+    }
+    if (!target) {
+      for (const c of Object.values(encounter.combatants)) {
+        if (c.sourceType === 'hazard' && c.sourceId === hazardId) {
+          target = c;
+          break;
+        }
+      }
+    }
+    if (!target) return;
+    runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
+  }
+
+  async function handleImportHazardYamlFiles(files: File[]) {
+    for (const file of files) {
+      let text: string;
+      try {
+        text = await file.text();
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-read-fail'),
+          `Could not read "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      let hazards: Hazard[];
+      let issues: ReturnType<typeof importHazardYaml>['issues'];
+      let skipped: ReturnType<typeof importHazardYaml>['skipped'];
+      try {
+        ({ hazards, issues, skipped } = importHazardYaml(text));
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-fail'),
+          `Could not import "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      const persistResult = await addHazards(hazards);
+      if (!persistResult.ok) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-persist-fail'),
+          persistResult.reason === 'unavailable'
+            ? `Could not save hazards from "${file.name}": storage is unavailable.`
+            : `Could not save hazards from "${file.name}": storage write failed.`
+        );
+        continue;
+      }
+      for (const h of persistResult.rejected) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-dup'),
+          `Skipped "${h.name}" from "${file.name}": id "${h.id}" is already in your library.`
+        );
+      }
+      if (persistResult.added.length > 0) {
+        storedHazards = [...storedHazards, ...persistResult.added];
+        appendFeedback(
+          nextFeedbackId('hazard-import-ok'),
+          `Imported ${persistResult.added.length} hazard${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
+          'success'
+        );
+      }
+      for (const skip of skipped) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-skip'),
+          `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not yet imported by this build.`,
+          'info'
+        );
+      }
+      for (const issue of issues) {
+        const where = issue.path ? ` at "${issue.path}"` : '';
+        const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
+        appendFeedback(
+          nextFeedbackId('hazard-import-issue'),
+          `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
+        );
+      }
+      if (
+        persistResult.added.length === 0 &&
+        persistResult.rejected.length === 0 &&
+        issues.length === 0 &&
+        skipped.length === 0 &&
+        hazards.length === 0
+      ) {
+        appendFeedback(
+          nextFeedbackId('hazard-import-empty'),
+          `"${file.name}" contained no hazard documents.`
+        );
+      }
+    }
+  }
+
+  async function handleRemoveHazard(id: string) {
+    const result = await removeHazard(id);
+    if (!result.ok) {
+      appendFeedback(
+        nextFeedbackId('hazard-remove-fail'),
+        result.reason === 'unavailable'
+          ? 'Could not remove hazard: storage is unavailable.'
+          : 'Could not remove hazard: storage write failed.'
+      );
+      return;
+    }
+    storedHazards = storedHazards.filter((h) => h.id !== id);
+  }
+
   function handleAddManual(input: Omit<ManualCombatantInput, 'id'>) {
     const slug = input.name
       .trim()
@@ -560,10 +705,15 @@
       const c = encounter.combatants[id];
       if (!c) continue;
       const die = Math.floor(Math.random() * 20) + 1;
-      patch[id] = die + computeCombatantStats(c).perception.final;
+      patch[id] = die + initiativeModifier(c);
     }
     if (Object.keys(patch).length === 0) return;
     runCommand(toCommand('SET_INITIATIVE_SCORES', { scores: patch }, nextCommandId()));
+  }
+
+  function initiativeModifier(c: CombatantState): number {
+    if (isHazardCombatant(c)) return c.baseStats.stealth;
+    return computeCombatantStats(c).perception.final;
   }
 
   function applyHpEdit(combatantId: string, field: HpEditField, parsed: CommittableEdit) {
@@ -767,6 +917,7 @@
     if (!c) return;
     const stats = computeCombatantStats(c);
     const stat = stats[save];
+    if (!stat) return;
     const mod = stat.final;
     const result = rollAttackDice(mod);
     const isCrit = result.d20 === 20;
@@ -826,6 +977,11 @@
   function useSpellSlot(combatantId: string, blockId: string, rank: number) {
     runCommand(toCommand('USE_SPELL_SLOT', { combatantId, blockId, rank }, nextCommandId()));
   }
+  function recordDisableProgress(combatantId: string, checkIndex: number, delta: number) {
+    runCommand(
+      toCommand('RECORD_DISABLE_PROGRESS', { combatantId, checkIndex, delta }, nextCommandId())
+    );
+  }
   function restoreSpellSlot(combatantId: string, blockId: string, rank: number) {
     runCommand(toCommand('RESTORE_SPELL_SLOT', { combatantId, blockId, rank }, nextCommandId()));
   }
@@ -881,6 +1037,7 @@
         {canStart}
         creatures={availableCreatures}
         partyMembers={storedPartyMembers}
+        hazards={storedHazards}
         {conditionOptions}
         {encounterCounts}
         onAddOneFromBestiary={handleAddOneFromBestiary}
@@ -892,6 +1049,10 @@
         onRemovePartyMember={handleRemovePartyMember}
         onSavePartyMember={handleSavePartyMember}
         onImportPartyMemberYamlFiles={handleImportPartyMemberYamlFiles}
+        onAddHazardToEncounter={handleAddHazardToEncounter}
+        onRemoveOneHazardFromEncounter={handleRemoveOneHazardFromEncounter}
+        onImportHazardYamlFiles={handleImportHazardYamlFiles}
+        onRemoveHazard={handleRemoveHazard}
         onStart={startEncounter}
         onReset={resetLocal}
       />
@@ -965,6 +1126,7 @@
         onRestoreFocusPoint={restoreFocusPoint}
         onUseInnateSpell={useInnateSpell}
         onRestoreInnateSpell={restoreInnateSpell}
+        onRecordDisableProgress={recordDisableProgress}
       />
     </aside>
 


### PR DESCRIPTION
**Stacks on top of #110** (conditions-affect-stats). Once #110 merges to master, this branch will be rebased and re-targeted at master.

## Summary

- PF2e complex hazards are now first-class combatants. The encounter tracker can import a hazard from YAML, persist it in an IndexedDB hazard library, add it to encounters, roll its Stealth for initiative, surface its routine on the active card, and record disable progress through a domain-sourced command path.
- New types: \`Hazard\`, \`HazardBaseStats\`, \`HazardData\`, \`HazardRoutine\`, \`DisableCheck\`, \`DisableProgress\`. New command \`RECORD_DISABLE_PROGRESS\` with \`disable-progress-recorded\` + \`hazard-disabled\` events. New factory \`createCombatantFromHazard\`. New IDB store \`hazardLibrary\` (schema v4 → v5). New YAML validator + import (\`importHazardYaml\`). New UI: \`HazardsSection\` (library tab), \`HazardSection\` (details panel — routine + disable checks + immunities), inline routine banner on the active card when a hazard's turn is current.

## Design choices (diverge from pf2e-hazards-spec.md 0.1)

1. **Discriminated \`baseStats\`** instead of nullable \`CreatureBaseStats\`. \`CreatureBaseStats\` stays strict (numbers everywhere). New \`HazardBaseStats\` carries \`ac/fortitude/reflex/will: number | null\` + \`stealth: number\`. \`CombatantState.baseStats\` is the union, narrowed by \`sourceType\`. Creature/PC code paths keep their guarantees; only hazard derivations skip stats.
2. **Split hazard fields**: \`stealth\`/\`stealthNote\` on \`HazardBaseStats\` (parallel to \`perception\`). \`routine\` + \`disableChecks\` + \`disableProgress\` in a small \`hazardData?\` bag.
3. **Disable tracking is a domain command**, not orchestrator mutation. Mirrors the rest of the codebase's command-sourced model and surfaces disable attempts in the combat log.

Plus minor: dropped \`complexity: \"complex\"\` literal field; hazards auto-roll Stealth for initiative; hardness stays display-only.

\`pf2e-hazards-spec.md\` bumped to 0.2 with the decisions reflected in §2.2, §4.2, §4.3. Architecture spec §9.4 documents optional AC/saves on \`ComputedStats\`. ROADMAP marks hazards shipped.

## Test plan

- [x] \`npm run check\` — svelte-check + tsc on domain.
- [x] \`npm run test:run\` — 731 tests pass across 55 files. New coverage:
  - \`derivation.test.ts\`: null AC + null saves omit ComputedStats entries; modifiers targeting null fall on the floor.
  - \`reducer.test.ts\`: RECORD_DISABLE_PROGRESS happy/clamp/undo/reject-non-hazard/out-of-range/hazard-disabled-exactly-once.
  - \`hazards/factory.test.ts\`: full Hazard → CombatantState, missing AC/saves/HP, JSON round-trip, name override.
  - \`hazard-validator.test.ts\`: poisoned-dart-gallery YAML round-trip, rejection on missing required fields, non-hazard envelopes skipped.
  - \`hazard-library.test.ts\`: load/add/remove/dedupe with fake-indexeddb, persistence across simulated reload.
  - \`db.test.ts\`: v4 → v5 migration preserves prior records and adds \`hazardLibrary\` store.
- [x] \`npm run audit\` — 3 low only (cookie via @sveltejs/kit). Moderate gate passes.
- [x] \`npm run build\` — static Cloudflare output produced.
- [ ] Manual via \`npm run dev\`: import a hazard YAML; appears in Hazards tab; add it to encounter; \`Roll\` uses its Stealth modifier; start encounter; routine banner shows on its turn; details panel disable checks count down on \`+ Success\` and \`Undo\` restores; immunities and hardness display; null-AC hazard shows \"—\" in card + details without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)