### PR TITLE
Fix combatant details not refreshing on selection change (each_key_duplicate crash)

### DIFF
--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -211,7 +211,7 @@
       <section class="details__section" aria-label="Spellcasting">
         <SectionLabel as="h3">Spellcasting</SectionLabel>
         <div class="spellcasting-stack">
-          {#each combatant.spellcasting as block (block.blockId)}
+          {#each combatant.spellcasting as block, i (i)}
             <SpellcastingBlockView
               {block}
               dcBonus={computed ? computed.spellDcs.total : 0}

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -244,6 +244,37 @@ describe('CombatantDetailsPanel', () => {
     expect(onUseSpellSlot).toHaveBeenCalledWith('yaashka', 'b1', 3);
   });
 
+  test('renders innate spellcasting with a repeated spell slug and stays in sync on rerender', async () => {
+    // PF2e creatures can list the same innate spell at more than one rank (heightened
+    // separately). Keying the spell list by slug used to throw `each_key_duplicate`,
+    // which aborted the rest of the panel update and left stale content (e.g. the name).
+    const caster = combatant('archmage', {
+      name: 'Archmage',
+      spellcasting: [
+        {
+          blockId: 'arcane-innate',
+          name: 'Arcane Innate',
+          tradition: 'arcane',
+          type: 'innate',
+          dc: 30,
+          attackModifier: 22,
+          entries: [
+            { spellSlug: 'charm', name: 'Charm', level: 5, frequency: { type: 'atWill' } },
+            { spellSlug: 'charm', name: 'Charm', level: 4, frequency: { type: 'atWill' } }
+          ]
+        }
+      ]
+    });
+
+    const { rerender } = renderPanel(caster);
+    expect(screen.getByRole('heading', { level: 2, name: 'Archmage' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Spellcasting')).toHaveTextContent('Charm');
+
+    await rerender({ combatant: combatant('goblin-1', { name: 'Goblin Sneak' }), onSetNote: vi.fn() });
+    expect(screen.getByRole('heading', { level: 2, name: 'Goblin Sneak' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Spellcasting')).not.toBeInTheDocument();
+  });
+
   test('renders existing notes inside the Notes section', () => {
     renderPanel(combatant('goblin-1', { notes: 'Hiding behind the cart.' }));
     const notes = screen.getByLabelText('Notes');

--- a/src/components/details/SpellcastingBlockView.svelte
+++ b/src/components/details/SpellcastingBlockView.svelte
@@ -91,7 +91,7 @@
           </div>
           {#if rank.entries.length > 0}
             <ul class="spell-list">
-              {#each rank.entries as entry (entry.spellSlug)}
+              {#each rank.entries as entry, i (i)}
                 <li>{entry.name}{entry.count > 1 ? ` (×${entry.count})` : ''}</li>
               {/each}
             </ul>
@@ -131,7 +131,7 @@
           </div>
           {#if rank.entries.length > 0}
             <ul class="spell-list">
-              {#each rank.entries as entry (entry.spellSlug)}
+              {#each rank.entries as entry, i (i)}
                 <li>{entry.name}</li>
               {/each}
             </ul>
@@ -169,7 +169,7 @@
       </div>
       {#if view.entries.length > 0}
         <ul class="spell-list">
-          {#each view.entries as entry (entry.spellSlug)}
+          {#each view.entries as entry, i (i)}
             <li>{entry.name} <span class="muted">({ordinal(entry.level)})</span></li>
           {/each}
         </ul>
@@ -178,7 +178,7 @@
   {:else}
     {#if view.entries.length > 0}
       <ul class="innate-list">
-        {#each view.entries as entry (entry.spellSlug)}
+        {#each view.entries as entry, i (i)}
           <li class="innate-row">
             <span class="innate-name">{entry.name} <span class="muted">({ordinal(entry.level)})</span></span>
             {#if entry.interactive && entry.max !== undefined}


### PR DESCRIPTION
## Problem

Selecting one combatant in the details panel and then selecting another (repro: pick a PC, then pick an enemy) left stale content — the `<h2>` heading kept showing the previous combatant's name. The browser console showed:

```
Uncaught Error: https://svelte.dev/e/each_key_duplicate
```

## Root cause

The `{#each}` blocks over spell entries in `SpellcastingBlockView.svelte` (and the spellcasting-block list in `CombatantDetailsPanel.svelte`) used `spellSlug` as the key. PF2e creatures legitimately list the same innate spell at more than one rank (heightened separately), so the list can contain duplicate slugs. Svelte throws `each_key_duplicate` during the update flush, which aborts the rest of the `CombatantDetailsPanel` DOM update — so everything else in the panel (including the name) is left un-updated.

## Fix

Key the spell-entry lists and the spellcasting-block list by index. These rows hold no local state, and index keys match the existing convention in `SpellcastingBlockView.svelte` (the slot pips) and `CombatantDetailsPanel.svelte` (ability lists).

## Tests

Added a regression test in `CombatantDetailsPanel.test.ts`: renders a combatant with an innate block that repeats a spell slug (asserting no crash), then rerenders with a different combatant and asserts the heading and sections update. Fails before the fix (`each_key_duplicate`), passes after.

Pre-PR gate: `npm run check && npm run test:run && npm run audit && npm run build` — all pass (703 tests).

## Follow-up (out of scope)

Innate spell *use* tracking is also keyed by `spellSlug` (`usedEntries`, `USE_INNATE_SPELL` / `RESTORE_INNATE_SPELL`). If a creature has the same innate spell slug at two ranks, using one affects the pip display of the other. Fixing that properly is a domain-layer change (entry identity = slug + rank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)