### PR TITLE
Foundry pf2e JSON → Bestiary importer

### DIFF
--- a/docs/creature-schema-backlog.md
+++ b/docs/creature-schema-backlog.md
@@ -9,34 +9,27 @@ Closing a section means: add the field to the schema spec and validator,
 update the `Creature` type and sample creatures, then migrate affected files
 out of `notes` into the new structured field.
 
-## Senses
+## Senses — closed
 
-PF2e creatures often have senses like `darkvision`, `low-light vision`,
-`scent (imprecise) 30 feet`, `tremorsense (precise) 60 feet`. Currently dumped
-into `notes:`.
+Added in the Foundry JSON importer pass. The `Creature.senses?: Sense[]` field
+is now structured as `{ type: string; acuity?: 'precise' | 'imprecise' | 'vague'; range?: number }`,
+matching the Foundry pf2e source schema. Mapper populates it from
+`system.perception.senses[]`.
 
-Suggested encoding: top-level `senses: string[]` for the simple case, or
-`senses: { name: string; range?: number; precision?: 'precise' | 'imprecise' }[]`
-if range and precision matter for the runtime (e.g. for concealment / hidden
-checks).
+## Ability score modifiers — closed
 
-Triggered by:
-- basilisk
-
-## Ability score modifiers
-
-Statblocks list `Str +X, Dex +Y, Con +Z, Int +W, Wis +V, Cha +U`. Currently
-dumped into `notes:`. Useful for skill-check resolution and any ability-score-
-based DC the runtime might compute.
-
-Suggested encoding: top-level `abilityModifiers: { str, dex, con, int, wis, cha: number }`.
-
-Triggered by:
-- basilisk
+Added in the Foundry JSON importer pass. The `Creature.abilities?: AbilityScores`
+field is now structured as `{ str, dex, con, int, wis, cha: number }`. Mapper
+populates it from `system.abilities.<key>.mod`.
 
 ## Immunity classification
 
-Current `immunities: string[]` collapses three semantically distinct
+Note: the Foundry JSON importer pass migrated the wire shape to
+`immunities: { type: string; exceptions?: string[] }[]` — symmetric with
+`resistances` and `weaknesses`. The semantic classification below is still
+open: a single `type` string still collapses three distinct categories.
+
+Current `immunities: CreatureImmunity[]` collapses three semantically distinct
 categories:
 
 - **Condition immunities** (e.g. `petrified`, `paralyzed`, `unconscious`) —
@@ -49,11 +42,34 @@ categories:
 The runtime will need to tell these apart once it starts enforcing immunity
 checks (today the field is informational only).
 
-Suggested encoding: either three arrays
-(`conditionImmunities`, `traitImmunities`, `damageImmunities`) or tagged
-objects
-(`immunities: { kind: 'condition' | 'trait' | 'damage'; name: string }[]`).
-The three-array form is friendlier for hand-editing.
+Suggested encoding: add a `kind: 'condition' | 'trait' | 'damage'` field to
+`CreatureImmunity`, or derive it from a curated list at validation time
+since Foundry already publishes well-formed type strings.
 
 Triggered by:
 - basilisk
+
+## Languages — closed
+
+Added in the Foundry JSON importer pass. The `Creature.languages?: Languages`
+field is now structured as `{ value: string[]; details?: string }`, matching
+the Foundry pf2e source schema. The `details` string carries special
+communication notes like `telepathy 100 feet`.
+
+## Items
+
+Statblocks list an `Items` line (e.g. `religious symbol of Zevgavizeb,
++1 striking spiked gauntlet`, `breastplate, longsword, key`). Currently
+dumped into `notes:`. Mostly flavor and loot tracking; mechanical effects
+(weapon enhancement, armor) are already baked into the published AC,
+attack modifiers, and damage, so this is primarily display data.
+
+Suggested encoding: top-level `items: string[]` (free-form names) for V1.
+A future enhancement could model linkage to a treasure/item index, but
+that is well beyond the encounter-tracker scope.
+
+Triggered by:
+- yaashka
+- xulgath-leader
+- xulgath-spinesnapper
+- gluttondark-babau

--- a/docs/sample-creatures.yaml
+++ b/docs/sample-creatures.yaml
@@ -76,12 +76,12 @@ data:
   perception: 6
   hp: 20
   immunities:
-    - death effects
-    - disease
-    - mental
-    - paralyzed
-    - poison
-    - unconscious
+    - type: death effects
+    - type: disease
+    - type: mental
+    - type: paralyzed
+    - type: poison
+    - type: unconscious
   resistances:
     - type: piercing
       value: 5

--- a/src/components/BestiarySection.svelte
+++ b/src/components/BestiarySection.svelte
@@ -10,7 +10,7 @@
   export let encounterCounts: Record<string, number> = {};
   export let onAddToEncounter: (creature: Creature, adjustment: TemplateAdjustmentChoice) => void;
   export let onRemoveOneFromEncounter: (creatureId: string) => void;
-  export let onImportYamlFiles: ((files: File[]) => void) | undefined = undefined;
+  export let onImportCreatureFiles: ((files: File[]) => void) | undefined = undefined;
   export let onOpenManageLibrary: (() => void) | undefined = undefined;
 
   let query = '';
@@ -32,7 +32,7 @@
     const input = event.currentTarget as HTMLInputElement;
     const files = input.files ? Array.from(input.files) : [];
     if (files.length > 0) {
-      onImportYamlFiles?.(files);
+      onImportCreatureFiles?.(files);
     }
     input.value = '';
   }
@@ -45,12 +45,12 @@
   </header>
 
   <div class="bestiary__actions">
-    {#if onImportYamlFiles}
-      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import YAML…</Button>
+    {#if onImportCreatureFiles}
+      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import…</Button>
       <input
         bind:this={fileInput}
         type="file"
-        accept=".yaml,.yml,application/yaml,text/yaml"
+        accept=".yaml,.yml,.json,application/yaml,text/yaml,application/json"
         multiple
         hidden
         onchange={handleFileChange}
@@ -100,7 +100,7 @@
   </fieldset>
 
   {#if creatures.length === 0}
-    <p class="empty">Import a YAML file to add creatures.</p>
+    <p class="empty">Import a YAML or Foundry JSON file to add creatures.</p>
   {:else if filtered.length === 0}
     <p class="empty">No matching creatures.</p>
   {:else}

--- a/src/components/BestiarySection.test.ts
+++ b/src/components/BestiarySection.test.ts
@@ -108,7 +108,7 @@ describe('BestiarySection', () => {
   test('renders the empty-library message when the library is empty', () => {
     render(BestiarySection, { props: defaultProps() });
     expect(
-      screen.getByText('Import a YAML file to add creatures.')
+      screen.getByText('Import a YAML or Foundry JSON file to add creatures.')
     ).toBeInTheDocument();
     expect(screen.queryByText('No matching creatures.')).not.toBeInTheDocument();
   });

--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -18,7 +18,7 @@
   export let onAddOneFromBestiary: (creature: Creature, adjustment: TemplateAdjustmentChoice) => void;
   export let onRemoveOneFromBestiaryCount: (creatureId: string) => void;
   export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
-  export let onImportYamlFiles: (files: File[]) => void;
+  export let onImportCreatureFiles: (files: File[]) => void;
   export let onRemoveCreature: (id: string) => void;
   export let onAddPartyMemberToEncounter: (partyMember: PartyMember) => void;
   export let onRemovePartyMember: (id: string) => void;
@@ -47,7 +47,7 @@
     {encounterCounts}
     onAddToEncounter={onAddOneFromBestiary}
     onRemoveOneFromEncounter={onRemoveOneFromBestiaryCount}
-    {onImportYamlFiles}
+    {onImportCreatureFiles}
     onOpenManageLibrary={openManage}
   />
   <PartySection

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -19,6 +19,7 @@ export type {
 } from './encounter-xp';
 export type {
   Ability,
+  AbilityScores,
   AppliedModifier,
   AppliedEffect,
   Attack,
@@ -37,6 +38,7 @@ export type {
   ComputedStats,
   Creature,
   CreatureBaseStats,
+  CreatureImmunity,
   CreatureRarity,
   CreatureSize,
   DamageComponent,
@@ -48,6 +50,7 @@ export type {
   EncounterPhase,
   EncounterState,
   InitiativeState,
+  Languages,
   LogEntry,
   LogEntryTone,
   Modifier,
@@ -58,6 +61,8 @@ export type {
   PromptResolution,
   RemoveEffectPayload,
   ResolvePromptPayload,
+  Sense,
+  SenseAcuity,
   SetEffectDurationPayload,
   SetEffectValuePayload,
   SourceType,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -91,6 +91,33 @@ export interface CombatantSpellcasting extends SpellcastingBlock {
   usedEntries?: Record<string, number>;
 }
 
+export type SenseAcuity = 'precise' | 'imprecise' | 'vague';
+
+export interface Sense {
+  type: string;
+  acuity?: SenseAcuity;
+  range?: number;
+}
+
+export interface AbilityScores {
+  str: number;
+  dex: number;
+  con: number;
+  int: number;
+  wis: number;
+  cha: number;
+}
+
+export interface CreatureImmunity {
+  type: string;
+  exceptions?: string[];
+}
+
+export interface Languages {
+  value: string[];
+  details?: string;
+}
+
 export interface Creature {
   id: string;
   name: string;
@@ -105,7 +132,7 @@ export interface Creature {
   will: number;
   perception: number;
   hp: number;
-  immunities: string[];
+  immunities: CreatureImmunity[];
   resistances: { type: string; value: number }[];
   weaknesses: { type: string; value: number }[];
   speed: Record<string, number>;
@@ -115,6 +142,9 @@ export interface Creature {
   reactiveAbilities: Ability[];
   activeAbilities: Ability[];
   skills: Record<string, number>;
+  senses?: Sense[];
+  abilities?: AbilityScores;
+  languages?: Languages;
   source?: string;
   tags: string[];
   notes?: string;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -169,6 +169,11 @@ export interface PartyMember {
   skills?: Record<string, number>;
   resistances?: { type: string; value: number }[];
   weaknesses?: { type: string; value: number }[];
+  /**
+   * Party members are authored manually (no importer), so their immunities
+   * stay as a flat string[] — they don't need the exceptions shape that
+   * Creature.immunities carries.
+   */
   immunities?: string[];
 
   persistentEffects: AppliedEffect[];

--- a/src/lib/foundry/fixtures/aasimar-redeemer.json
+++ b/src/lib/foundry/fixtures/aasimar-redeemer.json
@@ -1,0 +1,1006 @@
+{
+    "_id": "gDMPUL0UiOHrUUd3",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "bthV65bmBiFxafJ6",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Divine Innate Spells",
+            "sort": 100000,
+            "system": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "prepared": {
+                    "flexible": false,
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "slots": {},
+                "slug": null,
+                "spelldc": {
+                    "dc": 20,
+                    "mod": 0,
+                    "value": 12
+                },
+                "tradition": {
+                    "value": "divine"
+                }
+            },
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "HPknnMADVjl3vadK",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Champion Devotion Spells",
+            "sort": 200000,
+            "system": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "prepared": {
+                    "flexible": false,
+                    "value": "focus"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slots": {},
+                "slug": null,
+                "spelldc": {
+                    "dc": 20,
+                    "mod": 0,
+                    "value": 12
+                },
+                "tradition": {
+                    "value": "divine"
+                }
+            },
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "tRnTQnTcF5F4xbQy",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.zNN9212H2FGfM7VS"
+            },
+            "img": "systems/pf2e/icons/spells/lay-on-hands.webp",
+            "name": "Lay on Hands",
+            "sort": 300000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>Your hands become infused with vitality energy, healing a living creature or damaging an undead creature with a touch.</p>\n<p>If you use lay on hands on a willing living target, you restore 6 Hit Points; if the target is one of your allies, they also gain a +2 status bonus to AC for 1 round.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lay on Hands]</p>\n<p>Against an undead target, you deal 1d6 damage and it must attempt a basic Fortitude save; if it fails, it also takes a -2 status penalty to AC for 1 round.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by 6, and the damage to an undead target increases by 1d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "HPknnMADVjl3vadK"
+                },
+                "overlays": {
+                    "a33QUFoKgoOprovO": {
+                        "name": "Lay on Hands (Vs. Undead)",
+                        "overlayType": "override",
+                        "sort": 2,
+                        "system": {
+                            "damage": {
+                                "37YW4ZGhxx7Y2mdI": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "1d6",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "vitality"
+                                }
+                            },
+                            "defense": {
+                                "save": {
+                                    "basic": true,
+                                    "statistic": "fortitude"
+                                }
+                            },
+                            "heightening": {
+                                "damage": {
+                                    "37YW4ZGhxx7Y2mdI": "1d6"
+                                },
+                                "interval": 1,
+                                "type": "interval"
+                            }
+                        }
+                    },
+                    "uLuOg62dVyxvbW66": {
+                        "name": "Lay on Hands (Healing)",
+                        "overlayType": "override",
+                        "sort": 1,
+                        "system": {
+                            "damage": {
+                                "b39tbePoPlJSzLku": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "6",
+                                    "kinds": [
+                                        "healing"
+                                    ],
+                                    "materials": [],
+                                    "type": "vitality"
+                                }
+                            },
+                            "heightening": {
+                                "damage": {
+                                    "b39tbePoPlJSzLku": "6"
+                                },
+                                "interval": 1,
+                                "type": "interval"
+                            }
+                        }
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "lay-on-hands",
+                "target": {
+                    "value": "1 willing living creature or 1 undead creature"
+                },
+                "time": {
+                    "value": "1"
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "traditions": [],
+                    "value": [
+                        "champion",
+                        "focus",
+                        "healing",
+                        "manipulate",
+                        "vitality"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "U59fpo1i5VNRYsAw",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.WBmvzNDfpwka3qT4"
+            },
+            "img": "systems/pf2e/icons/spells/light.webp",
+            "name": "Light",
+            "sort": 400000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>The object glows, casting bright light in a 20-foot radius (and dim light for the next 20 feet) like a torch. If you cast this spell again on a second object, the light spell on the first object ends.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Light]</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The object sheds bright light in a 60-foot radius (and dim light for the next 60 feet).</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": "until the next time you make your daily preparations"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "bthV65bmBiFxafJ6"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "light",
+                "target": {
+                    "value": "1 object of 1 Bulk or less, either unattended or possessed by you or a willing ally"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ],
+                    "value": [
+                        "cantrip",
+                        "concentrate",
+                        "light",
+                        "manipulate"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "nfdWoB41XOLrTNiM",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.62nnVQvGhoVLLl2K"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/crossbow.webp",
+            "name": "Crossbow",
+            "sort": 500000,
+            "system": {
+                "ammo": {
+                    "baseType": "bolts",
+                    "builtIn": false,
+                    "capacity": 1
+                },
+                "baseItem": "crossbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 1
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d8"
+                },
+                "description": {
+                    "value": "<p>This ranged weapon has a bow-like assembly mounted on a handled frame called a tiller. The tiller has a mechanism to lock the bowstring in place, attached to a trigger mechanism that releases the tension and launches a bolt.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "expend": 1,
+                "group": "crossbow",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "quantity": 1,
+                "range": 120,
+                "reload": {
+                    "value": "1"
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "crossbow",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "R8PqwEDXMvBIfZBm",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.LJdbVTOZog39EEbi"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
+            "name": "Longsword",
+            "sort": 600000,
+            "system": {
+                "baseItem": "longsword",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 1
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d8"
+                },
+                "description": {
+                    "value": "<p>Longswords can be one-edged or two-edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 1
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "longsword",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "versatile-p"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "QMkRnJwQcgCRQXvU",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.Yr9yCuJiAlFh3QEB"
+            },
+            "img": "icons/equipment/shield/heater-steel-boss-red.webp",
+            "name": "Steel Shield",
+            "sort": 700000,
+            "system": {
+                "acBonus": 2,
+                "baseItem": "steel-shield",
+                "bulk": {
+                    "value": 1
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>Like wooden shields, steel shields come in a variety of shapes and sizes. Though more expensive than wooden shields, they are much more durable.</p>\n<table class=\"pf2e\">\n<thead>\n<tr>\n<th>Hardness</th>\n<th>HP</th>\n<th>BT</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>5</td>\n<td>20</td>\n<td>10</td>\n</tr>\n</tbody>\n</table>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "hardness": 5,
+                "hp": {
+                    "max": 20,
+                    "value": 20
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 2
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "quantity": 1,
+                "rules": [],
+                "runes": {
+                    "reinforcing": 0
+                },
+                "size": "med",
+                "slug": "steel-shield",
+                "speedPenalty": 0,
+                "traits": {
+                    "integrated": null,
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "shield"
+        },
+        {
+            "_id": "Zkt8u4uKBMDGmBZH",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.pRoikbRo5HFW6YUB"
+            },
+            "img": "icons/equipment/chest/breastplate-gorget-steel-white.webp",
+            "name": "Half Plate",
+            "sort": 800000,
+            "system": {
+                "acBonus": 5,
+                "baseItem": "half-plate",
+                "bulk": {
+                    "value": 3
+                },
+                "category": "heavy",
+                "checkPenalty": -3,
+                "containerId": null,
+                "description": {
+                    "value": "<p>Half plate consists of most of the upper body plates used in full plate, with lighter or sparser steel plate protection for the arms and legs. This provides some of the protection of full plate with greater flexibility and speed. A suit of this armor comes with an undercoat of padded armor and a pair of gauntlets.</p>"
+                },
+                "dexCap": 1,
+                "equipped": {
+                    "carryType": "worn",
+                    "inSlot": true,
+                    "invested": null
+                },
+                "group": "plate",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 1
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 18
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "quantity": 1,
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "resilient": 0
+                },
+                "size": "med",
+                "slug": "half-plate",
+                "speedPenalty": -10,
+                "strength": 3,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "armor"
+        },
+        {
+            "_id": "W8eb6gjymXLSenUe",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
+            "name": "Bolts",
+            "sort": 900000,
+            "system": {
+                "baseItem": "bolts",
+                "bulk": {
+                    "value": 0.1
+                },
+                "containerId": null,
+                "craftableAs": null,
+                "description": {
+                    "value": "<p>Shorter than traditional arrows but similar in construction, bolts are the ammunition used by crossbows.</p>"
+                },
+                "level": {
+                    "value": 0
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "quantity": 10,
+                "rules": [],
+                "size": "med",
+                "slug": "bolts",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "consumable"
+                    ]
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "max": 1,
+                    "value": 1
+                }
+            },
+            "type": "ammo"
+        },
+        {
+            "_id": "uXbNGzD4guadWLp9",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "R8PqwEDXMvBIfZBm"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Longsword",
+            "sort": 1000000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 15
+                },
+                "damageRolls": {
+                    "mjadst6lj09xzqchu9ct": {
+                        "damage": "1d8+7",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "versatile-p"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "i7ekQiw5lntgdpAT",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "nfdWoB41XOLrTNiM"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Crossbow",
+            "sort": 1100000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 12
+                },
+                "damageRolls": {
+                    "bdv8bdbc088q7et3d5g8": {
+                        "damage": "1d8+3",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": {
+                    "increment": 120,
+                    "max": null
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "reload-1"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "gPoK6Dl5m43T6mpg",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.kquBnQ0kObZztnBc"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "+1 Status to All Saves vs. Disease",
+            "sort": 1200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p>Against diseases, critical failures become failures.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "disease"
+                        ],
+                        "selector": "saving-throw",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "adjustment": {
+                            "criticalFailure": "one-degree-better"
+                        },
+                        "key": "AdjustDegreeOfSuccess",
+                        "predicate": [
+                            "disease"
+                        ],
+                        "selector": "saving-throw",
+                        "type": "save"
+                    }
+                ],
+                "slug": "1-status-to-all-saves-vs-magic",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "ITkyellSfoRYxVGk",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Divine Grace",
+            "sort": 1300000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> The angelkin is targeted by a spell that allows a saving throw.</p>\n<hr />\n<p><strong>Effect</strong> The scion gains a +2 circumstance bonus to the saving throw.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "domain": "saving-throw",
+                        "key": "RollOption",
+                        "option": "divine-grace",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "divine-grace"
+                        ],
+                        "selector": "saving-throw",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "eOj1lBtBYURSS36K",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Glimpse of Redemption",
+            "sort": 1400000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> An enemy damages one of the angelkin's allies. Both the enemy and ally must be within 15 feet of the angelkin.</p>\n<hr />\n<p><strong>Effect</strong> The angelkin causes its foe to hesitate under the weight of its sins as visions of possible redemption play out in its mind's eye. The foe chooses one of two options:</p>\n<ul>\n<li>The ally is completely unharmed by the triggering damage.</li>\n<li>The ally gains resistance 7 to all damage against the triggering damage. After the damaging effect resolves, the enemy becomes @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 2} until the end of its next turn.</li>\n</ul>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": "glimpse-of-redemption",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "XgwBNbRPKr9hX8NS",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.m4HQ2o5aPxjXf2kY"
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Shield Block",
+            "sort": 1500000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ShieldBlock]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [],
+                "slug": "shield-block",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        }
+    ],
+    "name": "Aasimar Redeemer",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 3
+            },
+            "con": {
+                "mod": 3
+            },
+            "dex": {
+                "mod": 1
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 4
+            },
+            "wis": {
+                "mod": 2
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "(25 with shield raised)",
+                "value": 23
+            },
+            "allSaves": {
+                "value": "+1 status to all saves vs. disease (critical failures become failures against diseases)"
+            },
+            "hp": {
+                "details": "",
+                "max": 73,
+                "temp": 0,
+                "value": 73
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": 20
+            }
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "",
+                "value": [
+                    "common",
+                    "empyrean"
+                ]
+            },
+            "level": {
+                "value": 5
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Mortals whose ancestry has been influenced by celestials are known as aasimars, and angelkin, who have blood of angels coursing through their veins, are among the most common type of them. Many angelkin seek adventure as a means of doing good in the world.</p>\n<hr />\n<p>Many immortals dwell upon the other planes of the Great Beyond. Some are benevolent and kindly, like angels. Others are cruel and destructive, like demons. And some fit roles outside of morality, like psychopomps. It's far from unheard of that mortals and immortals alike become entangled romantically, and the children of such engagements carry a supernatural element in their bloodlines for generations to follow. After the first generation, this otherworldly influence usually lies dormant, but now and then, the influence can manifest strongly in descendants many years later. These inheritors of extraplanar legacies are known collectively as planar scions.</p>",
+            "publication": {
+                "license": "OGL",
+                "remaster": false,
+                "title": "Pathfinder Bestiary"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 11,
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 12
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 8
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 11
+            }
+        },
+        "skills": {
+            "athletics": {
+                "base": 11
+            },
+            "diplomacy": {
+                "base": 12
+            },
+            "medicine": {
+                "base": 9
+            },
+            "religion": {
+                "base": 11
+            },
+            "society": {
+                "base": 7
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "good",
+                "human",
+                "humanoid",
+                "nephilim"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/fixtures/air-mephit.json
+++ b/src/lib/foundry/fixtures/air-mephit.json
@@ -1,0 +1,427 @@
+{
+    "_id": "KDRlxdIUADWHI6Vr",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "UsE3E2jD964UvWQw",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Arcane Innate Spells",
+            "sort": 100000,
+            "system": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "prepared": {
+                    "flexible": false,
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "slots": {},
+                "slug": null,
+                "spelldc": {
+                    "dc": 17,
+                    "mod": 0,
+                    "value": 9
+                },
+                "tradition": {
+                    "value": "arcane"
+                }
+            },
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "4wYhc5wemRSq5zYN",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.3JG1t3T4mWn6vTke"
+            },
+            "img": "systems/pf2e/icons/spells/blur.webp",
+            "name": "Blur",
+            "sort": 200000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>The target's form appears blurry. It becomes @UUID[Compendium.pf2e.conditionitems.Item.Concealed]. As the nature of this effect still leaves the target's location obvious, the target can't use this concealment to Hide or Sneak.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": "1 minute"
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "UsE3E2jD964UvWQw"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "blur",
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "illusion",
+                        "manipulate",
+                        "visual"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "IJfc0yjvz9bWboon",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.g8QqHpv2CWDwmIm1"
+            },
+            "img": "systems/pf2e/icons/spells/gust-of-wind.webp",
+            "name": "Gust of Wind",
+            "sort": 300000,
+            "system": {
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>A violent wind issues forth from your palm, blowing from the point where you are when you cast the spell to the line's opposite end. The wind extinguishes small non-magical fires, disperses fog and mist, blows objects of light Bulk or less around, and pushes larger objects. Large or smaller creatures in the area must attempt a Fortitude save. Large or smaller creatures that later move into the gust must attempt the save on entering.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature can't move against the wind.</p>\n<p><strong>Failure</strong> The creature is knocked @UUID[Compendium.pf2e.conditionitems.Item.Prone]. If it was flying, it suffers the effects of critical failure instead.</p>\n<p><strong>Critical Failure</strong> The creature is pushed 30 feet in the wind's direction, knocked Prone, and takes 2d6 bludgeoning damage.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": "until the start of your next turn"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 1,
+                    "value": "UsE3E2jD964UvWQw"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "gust-of-wind",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "primal"
+                    ],
+                    "value": [
+                        "air",
+                        "concentrate",
+                        "manipulate"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "Bie1u5IuxXpAhbC7",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Claw",
+            "sort": 400000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "gn46d6t3xy5xubspjs62": {
+                        "damage": "1d6+1",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "finesse",
+                        "unarmed"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "OG9zHmjCiir50sUt",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.fJSNOw4zHGbIm4bZ"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Fast Healing 2 (In Open Air)",
+            "sort": 500000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.FastHealing]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [
+                    {
+                        "key": "FastHealing",
+                        "type": "fast-healing",
+                        "value": 2
+                    }
+                ],
+                "slug": "fast-healing",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "5Rd1LNWiczurzj0C",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Breath Weapon",
+            "sort": 600000,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>The air mephit breathes sand and grit in a @Template[cone|distance:15] that deals @Damage[2d6[slashing]|options:area-damage] damage to each creature within the area (@Check[reflex|dc:17|basic|options:area-effect] save).</p>\n<p>The air mephit can't use Breath Weapon again for [[/gmr 1d4 #Recharge Breath Weapon]]{1d4 rounds}.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "air",
+                        "arcane"
+                    ]
+                }
+            },
+            "type": "action"
+        }
+    ],
+    "name": "Air Mephit",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 0
+            },
+            "con": {
+                "mod": 0
+            },
+            "dex": {
+                "mod": 4
+            },
+            "int": {
+                "mod": -2
+            },
+            "str": {
+                "mod": 1
+            },
+            "wis": {
+                "mod": 0
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 16
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "fast healing 2 (in open air)",
+                "max": 12,
+                "temp": 0,
+                "value": 12
+            },
+            "immunities": [
+                {
+                    "type": "bleed"
+                },
+                {
+                    "type": "paralyzed"
+                },
+                {
+                    "type": "poison"
+                },
+                {
+                    "type": "sleep"
+                }
+            ],
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": 40
+                    }
+                ],
+                "value": 20
+            }
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "",
+                "value": [
+                    "sussuran"
+                ]
+            },
+            "level": {
+                "value": 1
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Air mephits are capricious and flighty relative to their kin; they are as likely to fly blindly into battle as they are to whine in terror at a loud noise. They are pale blue in coloration and have thin wings that trail small puffs of vapor as they fly through the skies.</p>\n<hr />\n<p>Mephits-sometimes known as elemental scamps-are little bipedal critters with bat-like wings who serve stronger elementals on the Elemental Planes or neophyte spellcasters who summon them to the Material Plane. All mephits have an inkling of magical power as well as a breath weapon.</p>",
+            "publication": {
+                "license": "OGL",
+                "remaster": false,
+                "title": "Pathfinder Bestiary"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 3,
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 3
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 19
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 7
+            }
+        },
+        "skills": {
+            "acrobatics": {
+                "base": 7
+            },
+            "stealth": {
+                "base": 7
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "sm"
+            },
+            "value": [
+                "air",
+                "elemental"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/fixtures/bandit.json
+++ b/src/lib/foundry/fixtures/bandit.json
@@ -1,0 +1,865 @@
+{
+    "_id": "FBq4bqtKUBpJUCMU",
+    "folder": "HpWVchvSjucxVHMv",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "2JOmjVrX6zMi3jhW",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.UCH4myuFnokGv0vF"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
+            "name": "Sling",
+            "sort": 100000,
+            "system": {
+                "ammo": {
+                    "baseType": "sling-bullets",
+                    "builtIn": false,
+                    "capacity": 1
+                },
+                "baseItem": "sling",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "bludgeoning",
+                    "dice": 1,
+                    "die": "d6"
+                },
+                "description": {
+                    "value": "<p>Little more than a leather cup attached to a pair of straps, a sling can be used to fling smooth stones or sling bullets at a range.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "expend": 1,
+                "group": "sling",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "quantity": 1,
+                "range": 50,
+                "reload": {
+                    "value": "1"
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "sling",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "propulsive"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "UIXlx0aROWfhPtws",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.O7IZBvVoe7W2XnBa"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/machete.webp",
+            "name": "Machete",
+            "sort": 200000,
+            "system": {
+                "baseItem": "machete",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d6"
+                },
+                "description": {
+                    "value": "<p>This medium-length sword has a wide blade and long grip. Though it is typically used to hack through heavy foliage, the machete can also be used as a deadly weapon.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 7
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Lost Omens Gods & Magic"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "machete",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d8",
+                        "sweep"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "s67Nnro2zsvUm1Io",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.rQWaJhI5Bko5x14Z"
+            },
+            "img": "icons/weapons/daggers/dagger-straight-blue.webp",
+            "name": "Dagger",
+            "sort": 300000,
+            "system": {
+                "baseItem": "dagger",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d4"
+                },
+                "description": {
+                    "value": "<p>This small, bladed weapon is held in one hand and used to stab a creature in close combat. It can also be thrown.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "knife",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 2
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": "-"
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "dagger",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "finesse",
+                        "thrown-10",
+                        "versatile-s"
+                    ]
+                },
+                "usage": {
+                    "canBeAmmo": false,
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "IXm05NQf7mWBHpuu",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.ewQZ0VeL38v3qFnN"
+            },
+            "img": "icons/equipment/chest/breastplate-layered-leather-studded-brown.webp",
+            "name": "Studded Leather Armor",
+            "sort": 400000,
+            "system": {
+                "acBonus": 2,
+                "baseItem": "studded-leather-armor",
+                "bulk": {
+                    "value": 1
+                },
+                "category": "light",
+                "checkPenalty": -1,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This leather armor is reinforced with metal studs and sometimes small metal plates, providing most of the flexibility of leather armor with more robust protection.</p>"
+                },
+                "dexCap": 3,
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": true,
+                    "invested": null
+                },
+                "group": "leather",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "quantity": 1,
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "resilient": 0
+                },
+                "size": "med",
+                "slug": "studded-leather-armor",
+                "speedPenalty": 0,
+                "strength": 1,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "armor"
+        },
+        {
+            "_id": "qJnEVm26X5Flc05Y",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
+            "name": "Sling Bullets",
+            "sort": 500000,
+            "system": {
+                "baseItem": "sling-bullets",
+                "bulk": {
+                    "value": 0.1
+                },
+                "containerId": null,
+                "craftableAs": null,
+                "description": {
+                    "value": "<p>These are small metal balls, typically either iron or lead, designed to be used as ammunition in slings.</p>"
+                },
+                "level": {
+                    "value": 0
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "cp": 1
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "quantity": 10,
+                "rules": [],
+                "size": "med",
+                "slug": "sling-bullets",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "consumable"
+                    ]
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "max": 1,
+                    "value": 1
+                }
+            },
+            "type": "ammo"
+        },
+        {
+            "_id": "HCyqbOwAesUJxAac",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "UIXlx0aROWfhPtws"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Machete",
+            "sort": 600000,
+            "system": {
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "fyZr2QUAVjkLmPVA": {
+                        "damage": "1d6+5",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": "machete",
+                "traits": {
+                    "value": [
+                        "deadly-d8",
+                        "sweep"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "WOzz2GaTFiLGMKlV",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "s67Nnro2zsvUm1Io"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Dagger",
+            "sort": 700000,
+            "system": {
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "6nxj0yVWmNRzBWLH": {
+                        "damage": "1d4+5",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": "dagger",
+                "traits": {
+                    "value": [
+                        "agile",
+                        "versatile-s"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "8qgPSrq5yQ1u9viJ",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "s67Nnro2zsvUm1Io"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Dagger",
+            "sort": 800000,
+            "system": {
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "QZWMXWgOvsx7NbH6": {
+                        "damage": "1d4+5",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": "dagger",
+                "traits": {
+                    "value": [
+                        "agile",
+                        "thrown-10",
+                        "versatile-s"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "R0wrxXewuUSa6TI5",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Fist",
+            "sort": 900000,
+            "system": {
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "6bZpqDGfPOW979x2": {
+                        "damage": "1d4+5",
+                        "damageType": "bludgeoning"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": [
+                        "agile",
+                        "nonlethal",
+                        "unarmed"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "WFByucZQz0Q9slLk",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "2JOmjVrX6zMi3jhW"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Sling",
+            "sort": 1000000,
+            "system": {
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "mlgzwacs5fzwkmfhll2l": {
+                        "damage": "1d6+3",
+                        "damageType": "bludgeoning"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "range": {
+                    "increment": 50,
+                    "max": null
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": [
+                        "propulsive",
+                        "reload-1"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "IEibCXh97z4dVqH9",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Bandit's Ambush",
+            "sort": 1100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>When the bandit rolls initiative using Deception or Stealth, they can attempt to [[/act demoralize]] one creature as a free action.</p>"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "Note",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "check:statistic:base:deception",
+                                    "check:statistic:base:stealth"
+                                ]
+                            }
+                        ],
+                        "selector": "initiative",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "VKwW4ylsv5KU7Nhr",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Dread Striker",
+            "sort": 1200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>@UUID[Compendium.pf2e.conditionitems.Item.Frightened] creatures are @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to the bandit.</p>"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "EphemeralEffect",
+                        "predicate": [
+                            "target:condition:frightened"
+                        ],
+                        "selectors": [
+                            "strike-attack-roll",
+                            "spell-attack-roll",
+                            "strike-damage",
+                            "attack-spell-damage"
+                        ],
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "y9nL7kklEoVqLV06",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Forest Passage",
+            "sort": 1300000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>The bandit ignores any difficult terrain caused by plants, such as bushes, vines, and undergrowth.</p>"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "51OPbUesBItU8rTj",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Forest Lore",
+            "sort": 1400000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 4
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {}
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Bandit",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 1
+            },
+            "con": {
+                "mod": 1
+            },
+            "dex": {
+                "mod": 3
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 3
+            },
+            "wis": {
+                "mod": 2
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 19
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 30,
+                "temp": 0,
+                "value": 30
+            },
+            "speed": {
+                "details": "forest passage",
+                "otherSpeeds": [],
+                "value": 25
+            }
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "",
+                "value": [
+                    "common"
+                ]
+            },
+            "level": {
+                "value": 2
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Bandits waylay travelers and plunder their valuables before disappearing back to their wilderness hideouts. Many bandits seek only to steal and release their victims alive, though a few prefer to leave no witnesses.</p><hr /><p>In the underbelly of society, the lawless reign supreme.</p>",
+            "publication": {
+                "license": "ORC",
+                "remaster": true,
+                "title": "Pathfinder NPC Core"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 6,
+            "senses": []
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 7
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 9
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 6
+            }
+        },
+        "skills": {
+            "athletics": {
+                "base": 6
+            },
+            "deception": {
+                "base": 5
+            },
+            "intimidation": {
+                "base": 6
+            },
+            "stealth": {
+                "base": 8
+            },
+            "survival": {
+                "base": 6
+            },
+            "thievery": {
+                "base": 8
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "human",
+                "humanoid"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/fixtures/barbazu.json
+++ b/src/lib/foundry/fixtures/barbazu.json
@@ -1,0 +1,932 @@
+{
+    "_id": "FIoRPHaHdYUPVKdT",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "6F6RBqJmz0JUvLc3",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Divine Innate Spells",
+            "sort": 100000,
+            "system": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "prepared": {
+                    "flexible": false,
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "slots": {},
+                "slug": null,
+                "spelldc": {
+                    "dc": 19,
+                    "mod": 0,
+                    "value": 11
+                },
+                "tradition": {
+                    "value": "divine"
+                }
+            },
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "Kki4pRY5X5RoDgkd",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.VlNcjmYyu95vOUe8"
+            },
+            "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
+            "name": "Dimension Door",
+            "sort": 200000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "levels": {
+                        "5": {
+                            "range": {
+                                "value": "1 mile"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 5,
+                    "value": "6F6RBqJmz0JUvLc3"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "dimension-door",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "teleportation"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "j5nOoy2JdxGbg96d",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.VlNcjmYyu95vOUe8"
+            },
+            "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
+            "name": "Dimension Door (At Will)",
+            "sort": 300000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "levels": {
+                        "5": {
+                            "range": {
+                                "value": "1 mile"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 4,
+                    "value": "6F6RBqJmz0JUvLc3"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "dimension-door",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "teleportation"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "IbkmAj6qaijmxkBd",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.spells-srd.Item.30BBep9U4BDV0EgQ"
+            },
+            "img": "systems/pf2e/icons/spells/infernal-pact.webp",
+            "name": "Infernal Pact",
+            "sort": 400000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>You make an appeal to a powerful devil, asking it to bind some of its subordinates to your service. If you succeed, the devil sends you its choice of one devil whose level is no more than double <em>infernal pact's</em> rank, two devils whose levels are each at least 2 less than double the spell rank, or three devils whose levels are each at least 3 less than double the spell rank.</p>\n<hr />\n<p><strong>Critical Success</strong> The devils are sent to you and serve you for [[/r 1d4 #weeks]]{1d4 weeks}.</p>\n<p><strong>Success</strong> The devils are sent to you and serve you for [[/r 1d4 #days]]{1d4 days}.</p>\n<p><strong>Failure</strong> Your request is denied.</p>\n<p><strong>Critical Failure</strong> Not only is your request denied, but the powerful devil sends word of its displeasure to your master.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": null
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "ritual": {
+                    "primary": {
+                        "check": "Religion (expert; you must be a devil)"
+                    },
+                    "secondary": {
+                        "casters": 0,
+                        "checks": ""
+                    }
+                },
+                "rules": [],
+                "slug": "infernal-pact",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "1 day"
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "traditions": [],
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "A1xgZ8YYwgXBIYfH",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.vlnzTSsRmWeSkt9O"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/glaive.webp",
+            "name": "Glaive",
+            "sort": 500000,
+            "system": {
+                "baseItem": "glaive",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 2
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d8"
+                },
+                "description": {
+                    "value": "<p>This polearm consists of a long, single-edged blade on the end of a 7-foot pole. It is extremely effective at delivering lethal cuts at a distance.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "polearm",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 2
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "glaive",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d8",
+                        "forceful",
+                        "reach"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "DzJcNWKMqkWqtgAX",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "A1xgZ8YYwgXBIYfH"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Glaive",
+            "sort": 600000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "infernal-wound"
+                    ]
+                },
+                "bonus": {
+                    "value": 15
+                },
+                "damageRolls": {
+                    "21wcxa25samjknoz4t0j": {
+                        "damage": "1d8+7",
+                        "damageType": "slashing"
+                    },
+                    "fmuc3tt84ghiy5gzxfag": {
+                        "damage": "2d6",
+                        "damageType": "spirit"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d8",
+                        "evil",
+                        "forceful",
+                        "magical",
+                        "reach-10",
+                        "unholy"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "99jBJtnLmD48VOSS",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Claw",
+            "sort": 700000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 15
+                },
+                "damageRolls": {
+                    "ekd4zn6q64nd9im5e8tz": {
+                        "damage": "2d6+7",
+                        "damageType": "slashing"
+                    },
+                    "d88d04bcjo8in3h2kok7": {
+                        "damage": "1d6",
+                        "damageType": "spirit"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "magical",
+                        "unarmed",
+                        "unholy"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "kwMV2uj1jCdvIm7J",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Beard",
+            "sort": 800000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "avernal-fever"
+                    ]
+                },
+                "bonus": {
+                    "value": 15
+                },
+                "damageRolls": {
+                    "xigo14gfsr9rb4xoxoxa": {
+                        "damage": "1d6+7",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "magical",
+                        "unholy"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "fOXEVyfWiHQRSyiC",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.4Ho2xMPEC05aSxzr"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Greater Darkvision",
+            "sort": 900000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [],
+                "slug": "greater-darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "fDmw9feXNMKuAci4",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.kdhbPaBMK1d1fpbA"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Telepathy 100 feet",
+            "sort": 1000000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [],
+                "slug": "telepathy",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "magical"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "agqHW8i0ToF0OIyF",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.kquBnQ0kObZztnBc"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "+1 Status to All Saves vs. Magic",
+            "sort": 1100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "item:magical"
+                        ],
+                        "selector": "saving-throw",
+                        "type": "status",
+                        "value": 1
+                    }
+                ],
+                "slug": "1-status-to-all-saves-vs-magic",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "T108hwN1OhACYQdQ",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.hFtNbo1LKYCoDy2O"
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Attack of Opportunity",
+            "sort": 1200000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [],
+                "slug": "attack-of-opportunity",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "GZ55vWFhwaHyhnfM",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Avernal Fever",
+            "sort": 1300000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p><strong>Saving Throw</strong> @Check[fortitude|dc:23]</p>\n<hr />\n<p><strong>Stage 1</strong> carrier with no ill effect (1 day)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 1} (1 day)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 2} (1 day)</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": "avernal-fever",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "disease"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "SNJ0RSCREyP9YYKY",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Infernal Wound",
+            "sort": 1400000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>A bearded devil's glaive Strike also deals @Damage[1d6[bleed]] that resists attempts to heal it.</p>\n<p>The flat check to stop the bleeding starts at @Check[flat|dc:20]. The DC is reduced to @Check[flat|dc:15] only if the bleeding creature or an ally successfully assists with the recovery. The DC to @UUID[Compendium.pf2e.actionspf2e.Item.Administer First Aid] to a creature with an infernal wound is increased by 5.</p>\n<p>A spellcaster or item attempting to use healing magic on a creature suffering from an infernal wound must succeed at a DC 21 counteract check or the magic fails to heal the creature.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Infernal Wound]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "selector": "glaive-damage"
+                    }
+                ],
+                "slug": "infernal-wound",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "divine"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "zQUhdB7kvudfGv5Z",
+            "img": "systems/pf2e/icons/actions/FreeAction.webp",
+            "name": "Reposition",
+            "sort": 1500000,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> The devil hits a creature with a glaive Strike.</p>\n<hr />\n<p><strong>Effect</strong> The devil moves the creature 5 feet in any direction. The destination square must be within reach of the devil's glaive.</p>\n<p>This movement doesn't trigger reactions.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "6zbiPHhWaAV5pJd6",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Wriggling Beard",
+            "sort": 1600000,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per round.</p>\n<hr />\n<p><strong>Effect</strong> The barbazu makes a beard Strike. This Strike ignores their multiple attack penalty and doesn't count toward that penalty.</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "round",
+                    "value": 1
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        }
+    ],
+    "name": "Barbazu",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 1
+            },
+            "con": {
+                "mod": 4
+            },
+            "dex": {
+                "mod": 2
+            },
+            "int": {
+                "mod": -2
+            },
+            "str": {
+                "mod": 4
+            },
+            "wis": {
+                "mod": 2
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 22
+            },
+            "allSaves": {
+                "value": "+1 status to all saves vs. magic"
+            },
+            "hp": {
+                "details": "",
+                "max": 60,
+                "temp": 0,
+                "value": 60
+            },
+            "immunities": [
+                {
+                    "type": "fire"
+                }
+            ],
+            "resistances": [
+                {
+                    "exceptions": [
+                        "silver"
+                    ],
+                    "type": "physical",
+                    "value": 5
+                },
+                {
+                    "type": "poison",
+                    "value": 10
+                }
+            ],
+            "speed": {
+                "otherSpeeds": [],
+                "value": 35
+            },
+            "weaknesses": [
+                {
+                    "type": "holy",
+                    "value": 5
+                }
+            ]
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "telepathy 100 feet",
+                "value": [
+                    "common",
+                    "diabolic",
+                    "draconic",
+                    "empyrean"
+                ]
+            },
+            "level": {
+                "value": 5
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Barbazus, known also as bearded devils or infantry devils, are murderous fiends who satiate their lust for annihilation by serving as the foot soldiers of Hell's armies, often leading hordes of lesser devils such as imps and lemures into battle. Bearded devils wield serrated glaives to inflict jagged gashes that resist healing magic, resulting in tremendous blood loss. When enemies come too close, bearded devils strike with the spines of their wriggling beards to deliver a wretched contagion called Avernal fever, savoring the sight of their victim's strength being slowly devoured from within.</p>\n<p>Barbazus can be found savagely indulging the whims of evil infernal lords from all layers of Hell, rejoicing as they disseminate murder, misery, and anguish as they see fit.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
+            "publication": {
+                "license": "OGL",
+                "remaster": false,
+                "title": "Pathfinder Bestiary"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 13,
+            "senses": [
+                {
+                    "type": "greater-darkvision"
+                }
+            ]
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 15
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 11
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 11
+            }
+        },
+        "skills": {
+            "acrobatics": {
+                "base": 11
+            },
+            "athletics": {
+                "base": 13
+            },
+            "intimidation": {
+                "base": 10
+            },
+            "religion": {
+                "base": 11
+            },
+            "stealth": {
+                "base": 11
+            }
+        },
+        "spellcasting": {
+            "rituals": {
+                "dc": 19
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "devil",
+                "evil",
+                "fiend",
+                "lawful",
+                "unholy"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/fixtures/bloodseeker.json
+++ b/src/lib/foundry/fixtures/bloodseeker.json
@@ -1,0 +1,219 @@
+{
+    "_id": "HpD0BTfid3hnUEWj",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "a9nhBEqNFJ9N1rH5",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Barbed Leg",
+            "sort": 100000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "attach"
+                    ]
+                },
+                "bonus": {
+                    "value": 8
+                },
+                "damageRolls": {},
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "finesse"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "QEvRlTqwOEac04ov",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Attach",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>When a bloodseeker hits a target larger than itself, its barbed legs attach it to that creature. This is similar to grabbing the creature, but the bloodseeker moves with that creature rather than holding it in place.</p>\n<p>The bloodseeker is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] while attached. If the bloodseeker is killed or pushed away while attached to a creature it has drained blood from, that creature takes @Damage[1[bleed]] damage.</p>\n<p>Escaping the attach or removing the bloodseeker in other ways doesn't cause bleed damage.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": "attach",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "YwidZ8QmOJ85iLcw",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Blood Drain",
+            "sort": 300000,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p><strong>Requirements</strong> The bloodseeker is attached to a creature.</p>\n<hr />\n<p><strong>Effect</strong> The bloodseeker uses its proboscis to drain blood from the creature it's attached to. This deals @Damage[1d4[untyped]] damage, and the bloodseeker gains temporary Hit Points equal to the damage dealt.</p>\n<p>A creature that has its blood drained by a bloodseeker is @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1} until it receives healing (of any kind or amount).</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        }
+    ],
+    "name": "Bloodseeker",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": -2
+            },
+            "con": {
+                "mod": 0
+            },
+            "dex": {
+                "mod": 3
+            },
+            "int": {
+                "mod": -5
+            },
+            "str": {
+                "mod": -4
+            },
+            "wis": {
+                "mod": 1
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 16
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 6,
+                "temp": 0,
+                "value": 6
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": 30
+                    }
+                ],
+                "value": 10
+            }
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "",
+                "value": []
+            },
+            "level": {
+                "value": -1
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Scourges of swamps and damp, abandoned places, bloodseekers are ravenous blood drinkers. Farmers curse the creatures for sucking their livestock dry. It is from such beleaguered people that the bloodseeker's regional name \"stirge,\" possibly a corruption of the word \"scourge,\" comes. Folk wisdom holds that the appearance of bloodseekers in a region signals a healthy herd of livestock, but more often it means bogs or old buildings that haven't been properly tended to. Certainly, no amount of folksy parable can assuage a farmer driven to destitution by a bloodseeker infestation. But despite their role as parasites, bloodseekers aren't hated by all villages. In some cases, the inhabitants of remote backwoods thorps even keep the things as pets or use them as doubtful medicinal \"tools\" to drain away unwanted humors or test for evil spirits possessing the blood. Worshippers of gods of pestilence and parasites often view bloodseekers as sacred to their faith and allow the creatures to feed freely from their bodies. In such societies, those who accidentally give too much are considered to have been \"blessed\" by the village's hungry god.</p>\n<p>Bloodseekers seem to be constantly hungry, but they are not inherently malevolent. They can be scared away fairly easily and prefer to swiftly retreat rather than risk death. Some adventurers report that these creatures can be scared away by waving torches at the flying pests. However, bloodseekers are much bolder when encountered in larger numbers, as bringing down one victim lets an entire colony feed. Bloodseeker colonies are called clots, for obvious and disgusting reasons. If a lone bloodseeker finds a likely victim while its clot is nearby, it emits a high-pitched, keening noise to summon reinforcements.</p>\n<p>Most humanoids avoid bloodseekers, but boggards sometimes cultivate bloodseeker nests around the perimeter of their territory. These colonies serve as a deterrent to intruders, and the boggards sometimes check for bloodseeker prey, collecting the hides or bodies of animals killed by the pests. Meals prepared from slain bloodseekers that have gorged on the blood of specific creatures are a staple among certain boggard communities. The boggards not only eat the actual bloodseekers, but they also make a gelled slurry from the drained blood.</p>\n<p>A typical bloodseeker is about a foot long, with mottled, reddish-brown skin and a yellow underbelly. Its four wings resemble bat wings. When gorged with blood, the creature becomes bloated and pink, and it tends to wobble unsteadily in the air as it flies off to digest its meal.</p>",
+            "publication": {
+                "license": "OGL",
+                "remaster": false,
+                "title": "Pathfinder Bestiary"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 6,
+            "senses": [
+                {
+                    "type": "darkvision"
+                },
+                {
+                    "acuity": "imprecise",
+                    "range": 60,
+                    "type": "scent"
+                }
+            ]
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 5
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 8
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 4
+            }
+        },
+        "skills": {
+            "acrobatics": {
+                "base": 6
+            },
+            "stealth": {
+                "base": 6
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "tiny"
+            },
+            "value": [
+                "animal"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/fixtures/sea-devil-scout.json
+++ b/src/lib/foundry/fixtures/sea-devil-scout.json
@@ -1,0 +1,711 @@
+{
+    "_id": "PXru127aJljwKhSy",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "RmRCyTSAEiNPqwE9",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.aXuJh4i8HqSu6NYV"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/longspear.webp",
+            "name": "Longspear",
+            "sort": 100000,
+            "system": {
+                "baseItem": "longspear",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 2
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d8"
+                },
+                "description": {
+                    "value": "<p>This very long spear, sometimes called a pike, is purely for thrusting rather than throwing. Used by many soldiers and city watch for crowd control and defense against charging enemies, it must be wielded with two hands.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "spear",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 5
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "longspear",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "reach"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "SCiAtVb11X3s8Zqx",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.tOhoGvmCMw4JpWcS"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/spear.webp",
+            "name": "Spear",
+            "sort": 200000,
+            "system": {
+                "baseItem": "spear",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 1
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d6"
+                },
+                "description": {
+                    "value": "<p>A long metal shaft ending with a metal spike, a spear can be used one-handed as a melee weapon and can be thrown.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "expend": null,
+                "group": "spear",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": "-"
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "spear",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "thrown-20"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "yrctbhF7nTGEPJSK",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "RmRCyTSAEiNPqwE9"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Longspear",
+            "sort": 300000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 11
+                },
+                "damageRolls": {
+                    "6qts6ztnmqlofx2zd9lb": {
+                        "damage": "1d8+3",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "reach-10"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "3psvmOBMbToGGKnF",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Claw",
+            "sort": 400000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 11
+                },
+                "damageRolls": {
+                    "7ykimsnioe51b09mtr03": {
+                        "damage": "1d6+3",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "unarmed"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "0Ew7KigrRdcxAx7K",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Jaws",
+            "sort": 500000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 11
+                },
+                "damageRolls": {
+                    "ultmqx2ctrqq4k95yli5": {
+                        "damage": "1d8+3",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": "jaws",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "unarmed"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "a4Zz1r0Kbk6SA66t",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "SCiAtVb11X3s8Zqx"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Spear",
+            "sort": 600000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 12
+                },
+                "damageRolls": {
+                    "7n3zegjxjvswjm0rkrmf": {
+                        "damage": "1d6+3",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "thrown-20"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "u59sSnB7GuFn9ofv",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Shark Commune 150 feet",
+            "sort": 700000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>The sea devil can communicate telepathically with sharks within range. It can communicate only simple concepts like \"come,\" \"guard,\" or \"attack.\"</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "mental"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "5Uq09OsuqP9JPmlt",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.VdSMQ6yRZ3YXNXHL"
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Wavesense 30 feet",
+            "sort": 800000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Wavesense]</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Bestiary"
+                },
+                "rules": [],
+                "slug": "wavesense",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "zHIioB6mgFk3W6Uz",
+            "img": "systems/pf2e/icons/actions/FreeAction.webp",
+            "name": "Blood Frenzy",
+            "sort": 900000,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p><strong>Requirements</strong> The sea devil is not @UUID[Compendium.pf2e.conditionitems.Item.Fatigued] or already in a frenzy</p>\n<p><strong>Trigger</strong> The sea devil deals bleed damage to a living creature.</p><hr /><p><strong>Effect</strong> The sea devil flies into a frenzy that lasts 1 minute. While frenzied, the sea devil gains a +1 status bonus to attack rolls with its claws and jaws, gains a +4 status bonus to damage rolls with its claws and jaws, gains 7 temporary HP until the end of the frenzy, and takes a -2 status penalty to AC. The sea devil can't voluntarily stop its frenzy. After its frenzy, the sea devil is @UUID[Compendium.pf2e.conditionitems.Item.Fatigued].</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:effect:blood-frenzy"
+                        ],
+                        "selector": "claw-attack",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:effect:blood-frenzy"
+                        ],
+                        "selector": "jaws-attack",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:effect:blood-frenzy"
+                        ],
+                        "selector": "claw-damage",
+                        "type": "status",
+                        "value": 4
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:effect:blood-frenzy"
+                        ],
+                        "selector": "jaws-damage",
+                        "type": "status",
+                        "value": 4
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "flags.system.frenzyMod",
+                        "value": 4
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:effect:blood-frenzy"
+                        ],
+                        "selector": "ac",
+                        "type": "status",
+                        "value": -2
+                    }
+                ],
+                "selfEffect": {
+                    "name": "Effect: Blood Frenzy",
+                    "uuid": "Compendium.pf2e.bestiary-effects.Item.Effect: Blood Frenzy"
+                },
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "rage"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "6bt34Jgx0jymQKsU",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Bloodletting",
+            "sort": 1000000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>When the sea devil deals piercing or slashing damage, it also deals @Damage[1d4[bleed]] if the target was @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] or if the attack was a critical hit.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "critical": false,
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d4",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "target:condition:off-guard",
+                            {
+                                "or": [
+                                    "item:damage:type:piercing",
+                                    "item:damage:type:slashing"
+                                ]
+                            }
+                        ],
+                        "selector": "damage"
+                    },
+                    {
+                        "critical": true,
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d4",
+                        "key": "DamageDice",
+                        "predicate": [
+                            {
+                                "not": "target:condition:off-guard"
+                            },
+                            {
+                                "or": [
+                                    "item:damage:type:piercing",
+                                    "item:damage:type:slashing"
+                                ]
+                            }
+                        ],
+                        "selector": "damage"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        }
+    ],
+    "name": "Sea Devil Scout",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": -1
+            },
+            "con": {
+                "mod": 1
+            },
+            "dex": {
+                "mod": 4
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 3
+            },
+            "wis": {
+                "mod": 3
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 18
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 30,
+                "temp": 0,
+                "value": 30
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "swim",
+                        "value": 35
+                    }
+                ],
+                "value": 25
+            }
+        },
+        "details": {
+            "blurb": "",
+            "languages": {
+                "details": "shark commune 150 feet",
+                "value": [
+                    "thalassic"
+                ]
+            },
+            "level": {
+                "value": 2
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Scouts, among the lowliest of sea devils, ply the inky waters of the ocean in search of aquatic prey, tread ashore to gauge landborne threats, or charge into battle with the advance forces of a greater sea devil war party.</p>\n<hr />\n<p>Sea devils are horrid, amphibious humanoids who lurk in Golarion's oceans and crawl ashore to steal away victims beneath the veil of darkness. When an entire fishing village disappears overnight, sea devils are the first suspects.</p>\n<p>Far from mindless monstrosities, sea devils are terribly intelligent, with a cunning limited only by their strict adherence to hierarchy. They call themselves \"sahuagin\" but have wholly embraced their enemies' name for their kind as their own. Their cultural militancy enables sea devils to act in concert to perform grand acts of sabotage, marauding, and pillaging, and only the strongest (and most conniving) members of the tribe make it to the top of the social ladder. For all their discipline, however, sea devils are widely known to snap into murderous frenzies at the scent of blood. Even the best-laid plans can fall apart when a sea devil breaks ranks to revel in the spilled blood of their victims, an indulgence that can quickly cause a chain reaction of bloodthirsty ecstasy throughout an entire raiding party. For this reason, sea devils typically capture landborne quarry using nets and ropes, dragging them to the depths of the sea before making even a single incision.</p>\n<p>Among sea devil society, individuals are rewarded based on their performance during hunts and shore excursions, with rebels and outliers quickly culled from the ranks. Every pup is given a fair chance, however, and even the lowest-born sea devil can strive for the rank of commander, general, or perhaps even king or queen. Sea devils in positions of leadership tend to be among the largest, most violent, and most calculating of their kind, and fully realized sea devils are skilled warriors capable of capturing entire villages on their own. The most powerful sea devils are mighty kings and queens who coordinate the activity of lesser sea devils across territories spanning leagues, foiling attempts at their positions via manufactured blood feuds and wars against their numerous enemies ashore and underwater.</p>",
+            "publication": {
+                "license": "OGL",
+                "remaster": false,
+                "title": "Pathfinder Bestiary"
+            }
+        },
+        "initiative": {
+            "statistic": "perception"
+        },
+        "perception": {
+            "details": "",
+            "mod": 9,
+            "senses": [
+                {
+                    "type": "darkvision"
+                },
+                {
+                    "acuity": "imprecise",
+                    "range": 30,
+                    "type": "wavesense"
+                }
+            ]
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 7
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 10
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 7
+            }
+        },
+        "skills": {
+            "athletics": {
+                "base": 9,
+                "special": [
+                    {
+                        "base": 11,
+                        "label": "to Swim",
+                        "predicate": [
+                            "action:swim"
+                        ]
+                    }
+                ]
+            },
+            "intimidation": {
+                "base": 5
+            },
+            "stealth": {
+                "base": 8
+            },
+            "survival": {
+                "base": 7
+            }
+        },
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "amphibious",
+                "evil",
+                "humanoid",
+                "lawful",
+                "sea-devil"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/src/lib/foundry/index.test.ts
+++ b/src/lib/foundry/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import airMephitJson from './fixtures/air-mephit.json?raw';
+import banditJson from './fixtures/bandit.json?raw';
+import seaDevilScoutJson from './fixtures/sea-devil-scout.json?raw';
+import { importCreatureFoundryJson } from './index';
+
+describe('importCreatureFoundryJson', () => {
+  test('returns a JSON parse issue on malformed input', () => {
+    const result = importCreatureFoundryJson('{ this is not json');
+    expect(result.creatures).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]!.message).toMatch(/JSON parse error/);
+  });
+
+  test('returns an issue for non-NPC documents', () => {
+    const result = importCreatureFoundryJson(JSON.stringify({ name: 'Sword', type: 'weapon' }));
+    expect(result.creatures).toEqual([]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]!.message).toMatch(/npc/i);
+  });
+
+  test('imports the air-mephit fixture and produces a valid Creature', () => {
+    const result = importCreatureFoundryJson(airMephitJson);
+
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+
+    const c = result.creatures[0]!;
+    expect(c.id).toBe('air-mephit');
+    expect(c.name).toBe('Air Mephit');
+    expect(c.level).toBe(1);
+    expect(c.ac).toBe(16);
+    expect(c.hp).toBe(12);
+    expect(c.size).toBe('small');
+    expect(c.speed.land).toBe(20);
+    expect(c.speed.fly).toBe(40);
+
+    // immunities arrive as objects, not strings.
+    expect(c.immunities.length).toBeGreaterThan(0);
+    expect(typeof c.immunities[0]).toBe('object');
+    expect(c.immunities.map((im) => im.type)).toEqual(
+      expect.arrayContaining(['bleed', 'paralyzed', 'poison', 'sleep'])
+    );
+
+    // ability scores closed the backlog gap.
+    expect(c.abilities).toBeDefined();
+    expect(c.abilities!.dex).toBe(4);
+
+    // senses present.
+    expect(c.senses).toBeDefined();
+    expect(c.senses!.some((s) => s.type === 'darkvision')).toBe(true);
+
+    // has at least the claw attack with parsed damage.
+    expect(c.attacks.length).toBeGreaterThan(0);
+    const claw = c.attacks.find((a) => a.name === 'Claw');
+    expect(claw).toBeDefined();
+    expect(claw!.modifier).toBe(9);
+    expect(claw!.damage[0]).toMatchObject({
+      dice: 1,
+      dieSize: 6,
+      bonus: 1,
+      type: 'slashing'
+    });
+
+    // spellcasting block was synthesized.
+    expect(c.spellcasting).toBeDefined();
+    expect(c.spellcasting!.length).toBeGreaterThanOrEqual(1);
+    const block = c.spellcasting![0]!;
+    expect(block.tradition).toBe('arcane');
+    expect(block.type).toBe('innate');
+    expect(block.dc).toBe(17);
+    expect(block.entries.some((e) => e.name === 'Blur')).toBe(true);
+    expect(block.entries.some((e) => e.name === 'Gust of Wind')).toBe(true);
+  });
+
+  test('imports the bandit fixture (humanoid with no spellcasting)', () => {
+    const result = importCreatureFoundryJson(banditJson);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+    const c = result.creatures[0]!;
+    expect(c.name).toBe('Bandit');
+    expect(c.id).toBe('bandit');
+    expect(c.abilities).toBeDefined();
+    expect(Array.isArray(c.immunities)).toBe(true);
+  });
+
+  test('imports the sea-devil-scout fixture', () => {
+    const result = importCreatureFoundryJson(seaDevilScoutJson);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+    const c = result.creatures[0]!;
+    expect(c.name).toBe('Sea Devil Scout');
+    expect(c.id).toBe('sea-devil-scout');
+  });
+});

--- a/src/lib/foundry/index.test.ts
+++ b/src/lib/foundry/index.test.ts
@@ -40,22 +40,18 @@ describe('importCreatureFoundryJson', () => {
     expect(c.speed.land).toBe(20);
     expect(c.speed.fly).toBe(40);
 
-    // immunities arrive as objects, not strings.
     expect(c.immunities.length).toBeGreaterThan(0);
     expect(typeof c.immunities[0]).toBe('object');
     expect(c.immunities.map((im) => im.type)).toEqual(
       expect.arrayContaining(['bleed', 'paralyzed', 'poison', 'sleep'])
     );
 
-    // ability scores closed the backlog gap.
     expect(c.abilities).toBeDefined();
     expect(c.abilities!.dex).toBe(4);
 
-    // senses present.
     expect(c.senses).toBeDefined();
     expect(c.senses!.some((s) => s.type === 'darkvision')).toBe(true);
 
-    // has at least the claw attack with parsed damage.
     expect(c.attacks.length).toBeGreaterThan(0);
     const claw = c.attacks.find((a) => a.name === 'Claw');
     expect(claw).toBeDefined();
@@ -67,7 +63,6 @@ describe('importCreatureFoundryJson', () => {
       type: 'slashing'
     });
 
-    // spellcasting block was synthesized.
     expect(c.spellcasting).toBeDefined();
     expect(c.spellcasting!.length).toBeGreaterThanOrEqual(1);
     const block = c.spellcasting![0]!;
@@ -108,7 +103,6 @@ describe('importCreatureFoundryJson', () => {
     const c = result.creatures[0]!;
     expect(c.name).toBe('Aasimar Redeemer');
 
-    // Two distinct spellcasting blocks: Divine Innate + Champion Devotion (focus).
     expect(c.spellcasting).toBeDefined();
     expect(c.spellcasting!.length).toBeGreaterThanOrEqual(2);
     const traditions = c.spellcasting!.map((b) => b.tradition);
@@ -116,7 +110,6 @@ describe('importCreatureFoundryJson', () => {
     const types = c.spellcasting!.map((b) => b.type);
     expect(types).toEqual(expect.arrayContaining(['innate', 'focus']));
 
-    // Devotion (focus) block carries the Lay on Hands family of spells.
     const focusBlock = c.spellcasting!.find((b) => b.type === 'focus');
     expect(focusBlock).toBeDefined();
     expect(focusBlock!.entries.some((e) => /lay on hands/i.test(e.name))).toBe(true);
@@ -131,16 +124,13 @@ describe('importCreatureFoundryJson', () => {
     expect(c.name).toBe('Barbazu');
     expect(c.size).toBe('medium');
 
-    // Reposition is a free action and should land in reactiveAbilities.
     const reposition = c.reactiveAbilities.find((a) => a.name === 'Reposition');
     expect(reposition).toBeDefined();
     expect(reposition!.actions).toBe('free');
 
-    // Languages carry both array values and the structured field.
     expect(c.languages).toBeDefined();
     expect(c.languages!.value.length).toBeGreaterThan(0);
 
-    // At least one innate-spellcasting block.
     expect(c.spellcasting).toBeDefined();
     expect(c.spellcasting!.some((b) => b.type === 'innate')).toBe(true);
   });
@@ -154,15 +144,12 @@ describe('importCreatureFoundryJson', () => {
     expect(c.name).toBe('Bloodseeker');
     expect(c.size).toBe('tiny');
 
-    // Has the Barbed Leg melee attack.
     expect(c.attacks.some((a) => a.name === 'Barbed Leg')).toBe(true);
 
-    // Senses include darkvision and scent.
     expect(c.senses).toBeDefined();
     const senseTypes = c.senses!.map((s) => s.type);
     expect(senseTypes).toEqual(expect.arrayContaining(['darkvision', 'scent']));
 
-    // Has the Attach and Blood Drain abilities partitioned correctly.
     const allAbilityNames = [
       ...c.passiveAbilities,
       ...c.reactiveAbilities,

--- a/src/lib/foundry/index.test.ts
+++ b/src/lib/foundry/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
+import aasimarRedeemerJson from './fixtures/aasimar-redeemer.json?raw';
 import airMephitJson from './fixtures/air-mephit.json?raw';
 import banditJson from './fixtures/bandit.json?raw';
+import barbazuJson from './fixtures/barbazu.json?raw';
+import bloodseekerJson from './fixtures/bloodseeker.json?raw';
 import seaDevilScoutJson from './fixtures/sea-devil-scout.json?raw';
 import { importCreatureFoundryJson } from './index';
 
@@ -95,5 +98,76 @@ describe('importCreatureFoundryJson', () => {
     const c = result.creatures[0]!;
     expect(c.name).toBe('Sea Devil Scout');
     expect(c.id).toBe('sea-devil-scout');
+  });
+
+  test('imports the aasimar-redeemer fixture and surfaces both spellcasting blocks', () => {
+    const result = importCreatureFoundryJson(aasimarRedeemerJson);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+    const c = result.creatures[0]!;
+    expect(c.name).toBe('Aasimar Redeemer');
+
+    // Two distinct spellcasting blocks: Divine Innate + Champion Devotion (focus).
+    expect(c.spellcasting).toBeDefined();
+    expect(c.spellcasting!.length).toBeGreaterThanOrEqual(2);
+    const traditions = c.spellcasting!.map((b) => b.tradition);
+    expect(traditions).toEqual(expect.arrayContaining(['divine']));
+    const types = c.spellcasting!.map((b) => b.type);
+    expect(types).toEqual(expect.arrayContaining(['innate', 'focus']));
+
+    // Devotion (focus) block carries the Lay on Hands family of spells.
+    const focusBlock = c.spellcasting!.find((b) => b.type === 'focus');
+    expect(focusBlock).toBeDefined();
+    expect(focusBlock!.entries.some((e) => /lay on hands/i.test(e.name))).toBe(true);
+  });
+
+  test('imports the barbazu fixture with a free action and innate spellcasting', () => {
+    const result = importCreatureFoundryJson(barbazuJson);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+    const c = result.creatures[0]!;
+    expect(c.name).toBe('Barbazu');
+    expect(c.size).toBe('medium');
+
+    // Reposition is a free action and should land in reactiveAbilities.
+    const reposition = c.reactiveAbilities.find((a) => a.name === 'Reposition');
+    expect(reposition).toBeDefined();
+    expect(reposition!.actions).toBe('free');
+
+    // Languages carry both array values and the structured field.
+    expect(c.languages).toBeDefined();
+    expect(c.languages!.value.length).toBeGreaterThan(0);
+
+    // At least one innate-spellcasting block.
+    expect(c.spellcasting).toBeDefined();
+    expect(c.spellcasting!.some((b) => b.type === 'innate')).toBe(true);
+  });
+
+  test('imports the bloodseeker fixture (tiny creature)', () => {
+    const result = importCreatureFoundryJson(bloodseekerJson);
+    expect(result.skipped).toEqual([]);
+    expect(result.issues).toEqual([]);
+    expect(result.creatures).toHaveLength(1);
+    const c = result.creatures[0]!;
+    expect(c.name).toBe('Bloodseeker');
+    expect(c.size).toBe('tiny');
+
+    // Has the Barbed Leg melee attack.
+    expect(c.attacks.some((a) => a.name === 'Barbed Leg')).toBe(true);
+
+    // Senses include darkvision and scent.
+    expect(c.senses).toBeDefined();
+    const senseTypes = c.senses!.map((s) => s.type);
+    expect(senseTypes).toEqual(expect.arrayContaining(['darkvision', 'scent']));
+
+    // Has the Attach and Blood Drain abilities partitioned correctly.
+    const allAbilityNames = [
+      ...c.passiveAbilities,
+      ...c.reactiveAbilities,
+      ...c.activeAbilities
+    ].map((a) => a.name);
+    expect(allAbilityNames).toEqual(expect.arrayContaining(['Attach', 'Blood Drain']));
   });
 });

--- a/src/lib/foundry/index.ts
+++ b/src/lib/foundry/index.ts
@@ -1,0 +1,53 @@
+import type { Creature } from '../../domain';
+import { validateCreature } from '../yaml/creature-validator';
+import type { CreatureImportResult } from '../yaml';
+import { mapFoundryNpcToCreature } from './mapper';
+
+export { mapFoundryNpcToCreature, slugifyName } from './mapper';
+export { stripFoundryMarkup } from './text';
+export type { MapResult } from './mapper';
+
+/**
+ * Imports a single Foundry pf2e NPC JSON document and maps it to a domain
+ * `Creature`. Returns the same `CreatureImportResult` shape used by the YAML
+ * path so call sites can branch on extension only.
+ *
+ * Issues use document index 0 (Foundry NPC files are single-document) and
+ * `skipped` is always empty here — non-NPC documents are reported as issues
+ * rather than skipped because there is no notion of a multi-doc stream.
+ */
+export function importCreatureFoundryJson(text: string): CreatureImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return {
+      creatures: [],
+      issues: [
+        {
+          documentIndex: 0,
+          path: '',
+          message: `JSON parse error: ${err instanceof Error ? err.message : String(err)}`
+        }
+      ],
+      skipped: []
+    };
+  }
+
+  const mapped = mapFoundryNpcToCreature(parsed);
+  if (!mapped.ok) {
+    return {
+      creatures: [],
+      issues: [{ documentIndex: 0, path: '', message: mapped.error }],
+      skipped: []
+    };
+  }
+
+  const validation = validateCreature(mapped.value, 0);
+  if (!validation.ok) {
+    return { creatures: [], issues: validation.issues, skipped: [] };
+  }
+
+  const creatures: Creature[] = [validation.value];
+  return { creatures, issues: validation.issues, skipped: [] };
+}

--- a/src/lib/foundry/index.ts
+++ b/src/lib/foundry/index.ts
@@ -43,11 +43,17 @@ export function importCreatureFoundryJson(text: string): CreatureImportResult {
     };
   }
 
+  const warningIssues = mapped.warnings.map((message) => ({
+    documentIndex: 0,
+    path: '',
+    message: `Note: ${message}`
+  }));
+
   const validation = validateCreature(mapped.value, 0);
   if (!validation.ok) {
-    return { creatures: [], issues: validation.issues, skipped: [] };
+    return { creatures: [], issues: [...warningIssues, ...validation.issues], skipped: [] };
   }
 
   const creatures: Creature[] = [validation.value];
-  return { creatures, issues: validation.issues, skipped: [] };
+  return { creatures, issues: [...warningIssues, ...validation.issues], skipped: [] };
 }

--- a/src/lib/foundry/mapper.test.ts
+++ b/src/lib/foundry/mapper.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, test } from 'vitest';
+import { mapFoundryNpcToCreature, slugifyName } from './mapper';
+import type { FoundryNpc } from './types';
+
+function baseNpc(overrides: Partial<FoundryNpc> = {}): FoundryNpc {
+  return {
+    _id: 'abc',
+    name: 'Test Goblin',
+    type: 'npc',
+    items: [],
+    system: {
+      details: { level: { value: 1 } },
+      traits: { rarity: 'common', size: { value: 'sm' }, value: ['goblin', 'humanoid'] },
+      attributes: {
+        ac: { value: 16 },
+        hp: { max: 12, value: 12 },
+        speed: { value: 25, otherSpeeds: [{ type: 'climb', value: 15 }] },
+        immunities: [],
+        resistances: [],
+        weaknesses: []
+      },
+      saves: { fortitude: { value: 5 }, reflex: { value: 7 }, will: { value: 3 } },
+      perception: { mod: 6, senses: [{ type: 'darkvision' }] },
+      abilities: {
+        str: { mod: 1 },
+        dex: { mod: 4 },
+        con: { mod: 0 },
+        int: { mod: -1 },
+        wis: { mod: 0 },
+        cha: { mod: 1 }
+      },
+      skills: { athletics: { base: 5 }, stealth: { base: 8 } }
+    },
+    ...overrides
+  };
+}
+
+describe('slugifyName', () => {
+  test('lowercases and kebab-cases names', () => {
+    expect(slugifyName('Air Mephit')).toBe('air-mephit');
+    expect(slugifyName("Gluttondark Babau")).toBe('gluttondark-babau');
+    expect(slugifyName("Yaashka, Xulgath Elder")).toBe('yaashka-xulgath-elder');
+  });
+
+  test('strips apostrophes', () => {
+    expect(slugifyName("Old One's Herald")).toBe('old-ones-herald');
+  });
+});
+
+describe('mapFoundryNpcToCreature', () => {
+  test('maps a minimal humanoid NPC end-to-end', () => {
+    const result = mapFoundryNpcToCreature(baseNpc());
+    if (!result.ok) throw new Error(result.error);
+
+    expect(result.value.id).toBe('test-goblin');
+    expect(result.value.name).toBe('Test Goblin');
+    expect(result.value.level).toBe(1);
+    expect(result.value.size).toBe('small');
+    expect(result.value.rarity).toBe('common');
+    expect(result.value.ac).toBe(16);
+    expect(result.value.hp).toBe(12);
+    expect(result.value.fortitude).toBe(5);
+    expect(result.value.reflex).toBe(7);
+    expect(result.value.will).toBe(3);
+    expect(result.value.perception).toBe(6);
+    expect(result.value.speed).toEqual({ land: 25, climb: 15 });
+    expect(result.value.traits).toEqual(['goblin', 'humanoid']);
+    expect(result.value.skills).toEqual({ athletics: 5, stealth: 8 });
+  });
+
+  test('rejects non-npc documents', () => {
+    const result = mapFoundryNpcToCreature({ name: 'Sword', type: 'weapon' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/npc/i);
+  });
+
+  test('rejects non-objects', () => {
+    expect(mapFoundryNpcToCreature(null).ok).toBe(false);
+    expect(mapFoundryNpcToCreature('text').ok).toBe(false);
+    expect(mapFoundryNpcToCreature([]).ok).toBe(false);
+  });
+
+  test('rejects NPC without a name', () => {
+    const result = mapFoundryNpcToCreature({ type: 'npc' });
+    expect(result.ok).toBe(false);
+  });
+
+  test('maps ability score modifiers', () => {
+    const result = mapFoundryNpcToCreature(baseNpc());
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.abilities).toEqual({
+      str: 1,
+      dex: 4,
+      con: 0,
+      int: -1,
+      wis: 0,
+      cha: 1
+    });
+  });
+
+  test('omits abilities when any score is missing', () => {
+    const npc = baseNpc();
+    delete npc.system!.abilities!.wis;
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.abilities).toBeUndefined();
+  });
+
+  test('maps senses with optional range', () => {
+    const npc = baseNpc({
+      system: {
+        ...baseNpc().system,
+        perception: {
+          mod: 7,
+          senses: [{ type: 'darkvision' }, { type: 'scent', range: 30, acuity: 'imprecise' }]
+        }
+      }
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.senses).toEqual([
+      { type: 'darkvision' },
+      { type: 'scent', acuity: 'imprecise', range: 30 }
+    ]);
+  });
+
+  test('maps languages with details', () => {
+    const npc = baseNpc({
+      system: {
+        ...baseNpc().system,
+        details: {
+          level: { value: 1 },
+          languages: { value: ['common', 'goblin'], details: 'telepathy 100 feet' }
+        }
+      }
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.languages).toEqual({
+      value: ['common', 'goblin'],
+      details: 'telepathy 100 feet'
+    });
+  });
+
+  test('maps immunities as objects with optional exceptions', () => {
+    const npc = baseNpc({
+      system: {
+        ...baseNpc().system,
+        attributes: {
+          ...baseNpc().system!.attributes,
+          immunities: [{ type: 'fire' }, { type: 'sleep' }],
+          resistances: [{ type: 'physical', value: 15, exceptions: ['vorpal-adamantine'] }],
+          weaknesses: [{ type: 'cold', value: 5 }]
+        }
+      }
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.immunities).toEqual([{ type: 'fire' }, { type: 'sleep' }]);
+    expect(result.value.resistances).toEqual([{ type: 'physical', value: 15 }]);
+    expect(result.value.weaknesses).toEqual([{ type: 'cold', value: 5 }]);
+  });
+
+  test('maps melee attacks with damage roll parsing', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'claw1',
+          name: 'Claw',
+          type: 'melee',
+          system: {
+            bonus: { value: 9 },
+            damageRolls: {
+              gn46d6t3xy: { damage: '1d6+1', damageType: 'slashing' }
+            },
+            range: null,
+            traits: { value: ['agile', 'finesse'] }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.attacks).toEqual([
+      {
+        name: 'Claw',
+        type: 'melee',
+        modifier: 9,
+        traits: ['agile', 'finesse'],
+        damage: [{ dice: 1, dieSize: 6, bonus: 1, type: 'slashing' }]
+      }
+    ]);
+  });
+
+  test('detects ranged attacks via non-null range', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'r1',
+          name: 'Shortbow',
+          type: 'melee',
+          system: {
+            bonus: { value: 7 },
+            damageRolls: { '0': { damage: '1d6', damageType: 'piercing' } },
+            range: { increment: 60, max: null },
+            traits: { value: ['deadly-d10'] }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.attacks[0]!.type).toBe('ranged');
+  });
+
+  test('partitions actions into passive / reactive / active', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'a1',
+          name: 'Sneak Attack',
+          type: 'action',
+          system: { actionType: { value: 'passive' }, description: { value: '<p>Bonus.</p>' } }
+        },
+        {
+          _id: 'a2',
+          name: 'Attack of Opportunity',
+          type: 'action',
+          system: { actionType: { value: 'reaction' }, description: { value: '<p>React.</p>' } }
+        },
+        {
+          _id: 'a3',
+          name: 'Breath Weapon',
+          type: 'action',
+          system: {
+            actionType: { value: 'action' },
+            actions: { value: 2 },
+            description: { value: '<p>Breathe.</p>' }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.passiveAbilities.map((a) => a.name)).toEqual(['Sneak Attack']);
+    expect(result.value.reactiveAbilities.map((a) => a.name)).toEqual(['Attack of Opportunity']);
+    expect(result.value.activeAbilities.map((a) => a.name)).toEqual(['Breath Weapon']);
+    expect(result.value.activeAbilities[0]!.actions).toBe(2);
+    expect(result.value.passiveAbilities[0]!.description).toBe('Bonus.');
+  });
+
+  test('groups spells under their spellcasting entry by location', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'sce1',
+          name: 'Arcane Innate Spells',
+          type: 'spellcastingEntry',
+          system: {
+            prepared: { value: 'innate' },
+            tradition: { value: 'arcane' },
+            spelldc: { dc: 17, value: 9 }
+          }
+        },
+        {
+          _id: 'sp1',
+          name: 'Blur',
+          type: 'spell',
+          system: { level: { value: 2 }, location: { value: 'sce1' }, traits: { value: ['illusion'] } }
+        },
+        {
+          _id: 'sp2',
+          name: 'Light',
+          type: 'spell',
+          system: { level: { value: 0 }, location: { value: 'sce1' }, traits: { value: ['cantrip'] } }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.spellcasting).toHaveLength(1);
+    const block = result.value.spellcasting![0]!;
+    expect(block.tradition).toBe('arcane');
+    expect(block.type).toBe('innate');
+    expect(block.dc).toBe(17);
+    expect(block.attackModifier).toBe(9);
+    expect(block.entries.map((e) => e.name)).toEqual(['Blur', 'Light']);
+    expect(block.entries.find((e) => e.name === 'Light')!.isCantrip).toBe(true);
+    expect(block.entries.find((e) => e.name === 'Blur')!.frequency).toEqual({ type: 'atWill' });
+  });
+
+  test('reads prepared slot counts', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'sce-prep',
+          name: 'Divine Prepared',
+          type: 'spellcastingEntry',
+          system: {
+            prepared: { value: 'prepared' },
+            tradition: { value: 'divine' },
+            spelldc: { dc: 18 },
+            slots: { slot1: { max: 4 }, slot2: { max: 3 }, slot3: { max: 0 } }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    const block = result.value.spellcasting![0]!;
+    expect(block.slots).toEqual({ 1: 4, 2: 3 });
+  });
+
+  test('strips HTML and macros from notes', () => {
+    const npc = baseNpc({
+      system: {
+        ...baseNpc().system,
+        details: {
+          level: { value: 1 },
+          publicNotes:
+            '<p>An <strong>air mephit</strong> grants @UUID[Compendium.pf2e.conditionitems.Item.Concealed]{concealed} status.</p>'
+        }
+      }
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.notes).toBe('An air mephit grants concealed status.');
+  });
+
+  test('maps publication title to source', () => {
+    const npc = baseNpc({
+      system: {
+        ...baseNpc().system,
+        details: {
+          level: { value: 1 },
+          publication: { title: 'Pathfinder Bestiary' }
+        }
+      }
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.source).toBe('Pathfinder Bestiary');
+  });
+});

--- a/src/lib/foundry/mapper.test.ts
+++ b/src/lib/foundry/mapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { mapFoundryNpcToCreature, slugifyName } from './mapper';
+import { mapFoundryNpcToCreature, parseDamageString, slugifyName } from './mapper';
 import type { FoundryNpc } from './types';
 
 function baseNpc(overrides: Partial<FoundryNpc> = {}): FoundryNpc {
@@ -34,6 +34,50 @@ function baseNpc(overrides: Partial<FoundryNpc> = {}): FoundryNpc {
     ...overrides
   };
 }
+
+describe('parseDamageString', () => {
+  test('parses standard dice + bonus', () => {
+    expect(parseDamageString('1d6+1')).toEqual({ dice: 1, dieSize: 6, bonus: 1, type: 'untyped' });
+    expect(parseDamageString('2d8+5')).toEqual({ dice: 2, dieSize: 8, bonus: 5, type: 'untyped' });
+  });
+
+  test('parses dice with no bonus', () => {
+    expect(parseDamageString('2d8')).toEqual({ dice: 2, dieSize: 8, type: 'untyped' });
+    expect(parseDamageString('3d10')).toEqual({ dice: 3, dieSize: 10, type: 'untyped' });
+  });
+
+  test('parses negative bonus', () => {
+    expect(parseDamageString('1d4-1')).toEqual({ dice: 1, dieSize: 4, bonus: -1, type: 'untyped' });
+    expect(parseDamageString('1d6-2')).toEqual({ dice: 1, dieSize: 6, bonus: -2, type: 'untyped' });
+  });
+
+  test('parses flat damage (bonus only, no dice)', () => {
+    expect(parseDamageString('+5')).toEqual({ bonus: 5, type: 'untyped' });
+  });
+
+  test('tolerates whitespace inside the expression', () => {
+    expect(parseDamageString('  1d6 + 1  ')).toEqual({
+      dice: 1,
+      dieSize: 6,
+      bonus: 1,
+      type: 'untyped'
+    });
+  });
+
+  test('returns null for unparseable strings', () => {
+    expect(parseDamageString('foo')).toBeNull();
+    expect(parseDamageString('1d')).toBeNull();
+    expect(parseDamageString('1dX')).toBeNull();
+    expect(parseDamageString('1d6+')).toBeNull();
+    expect(parseDamageString('')).toBeNull();
+    expect(parseDamageString('   ')).toBeNull();
+  });
+
+  test('returns null for an expression with neither dice nor bonus', () => {
+    // The regex matches "" → groups all undefined, then guard rejects.
+    expect(parseDamageString('   ')).toBeNull();
+  });
+});
 
 describe('slugifyName', () => {
   test('lowercases and kebab-cases names', () => {
@@ -340,5 +384,381 @@ describe('mapFoundryNpcToCreature', () => {
     const result = mapFoundryNpcToCreature(npc);
     if (!result.ok) throw new Error(result.error);
     expect(result.value.source).toBe('Pathfinder Bestiary');
+  });
+
+  describe('action partitioning edge cases', () => {
+    test("'free' actionType lands in reactiveAbilities", () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'f1',
+            name: 'Quick Quaff',
+            type: 'action',
+            system: {
+              actionType: { value: 'free' },
+              description: { value: '<p>Free.</p>' }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.reactiveAbilities.map((a) => a.name)).toEqual(['Quick Quaff']);
+      expect(result.value.reactiveAbilities[0]!.actions).toBe('free');
+    });
+
+    test('formats frequency on an ability', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'rare1',
+            name: 'Rare Ability',
+            type: 'action',
+            system: {
+              actionType: { value: 'action' },
+              actions: { value: 1 },
+              frequency: { max: 1, per: 'day' },
+              description: { value: '<p>Once daily.</p>' }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.activeAbilities[0]!.frequency).toBe('1 per day');
+    });
+  });
+
+  describe('damage parsing edge cases', () => {
+    test('flags persistent damage on a melee strike', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'fang',
+            name: 'Fang',
+            type: 'melee',
+            system: {
+              bonus: { value: 12 },
+              damageRolls: {
+                '0': { damage: '2d8+5', damageType: 'piercing' },
+                '1': { damage: '1d6', damageType: 'acid', category: 'persistent' }
+              },
+              range: null,
+              traits: { value: [] }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      const damage = result.value.attacks[0]!.damage;
+      expect(damage).toHaveLength(2);
+      const persistent = damage.find((d) => d.persistent);
+      expect(persistent).toMatchObject({
+        dice: 1,
+        dieSize: 6,
+        type: 'acid',
+        persistent: true
+      });
+    });
+
+    test('silently drops a damage roll with an unparseable damage string', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'mix',
+            name: 'Weird Strike',
+            type: 'melee',
+            system: {
+              bonus: { value: 8 },
+              damageRolls: {
+                '0': { damage: '1d6+1', damageType: 'slashing' },
+                '1': { damage: 'special — see text', damageType: 'untyped' }
+              },
+              range: null,
+              traits: { value: [] }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      // Only the parseable roll survives.
+      expect(result.value.attacks[0]!.damage).toEqual([
+        { dice: 1, dieSize: 6, bonus: 1, type: 'slashing' }
+      ]);
+    });
+
+    test('keeps an attack even when every damage roll is unparseable', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'odd',
+            name: 'Ineffable',
+            type: 'melee',
+            system: {
+              bonus: { value: 0 },
+              damageRolls: { '0': { damage: 'varies', damageType: 'untyped' } },
+              range: null,
+              traits: { value: [] }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.attacks).toHaveLength(1);
+      expect(result.value.attacks[0]!.damage).toEqual([]);
+    });
+  });
+
+  describe('spellcasting edge cases', () => {
+    test('handles multiple spellcasting blocks on one creature', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'innate',
+            name: 'Divine Innate',
+            type: 'spellcastingEntry',
+            system: {
+              prepared: { value: 'innate' },
+              tradition: { value: 'divine' },
+              spelldc: { dc: 18 }
+            }
+          },
+          {
+            _id: 'prep',
+            name: 'Divine Prepared',
+            type: 'spellcastingEntry',
+            system: {
+              prepared: { value: 'prepared' },
+              tradition: { value: 'divine' },
+              spelldc: { dc: 19 },
+              slots: { slot1: { max: 4 }, slot2: { max: 3 } }
+            }
+          },
+          {
+            _id: 's-innate',
+            name: 'Heal',
+            type: 'spell',
+            system: { level: { value: 4 }, location: { value: 'innate' }, traits: { value: [] } }
+          },
+          {
+            _id: 's-prep',
+            name: 'Bless',
+            type: 'spell',
+            system: { level: { value: 1 }, location: { value: 'prep' }, traits: { value: [] } }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.spellcasting).toHaveLength(2);
+      const byName = new Map(result.value.spellcasting!.map((b) => [b.name, b]));
+      expect(byName.get('Divine Innate')!.entries.map((e) => e.name)).toEqual(['Heal']);
+      expect(byName.get('Divine Prepared')!.entries.map((e) => e.name)).toEqual(['Bless']);
+      expect(byName.get('Divine Prepared')!.slots).toEqual({ 1: 4, 2: 3 });
+    });
+
+    test('silently drops orphan spells whose location matches no entry', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'block1',
+            name: 'Arcane',
+            type: 'spellcastingEntry',
+            system: { prepared: { value: 'innate' }, tradition: { value: 'arcane' }, spelldc: { dc: 15 } }
+          },
+          {
+            _id: 'orphan',
+            name: 'Lost Spell',
+            type: 'spell',
+            system: { level: { value: 1 }, location: { value: 'nonexistent-block' }, traits: { value: [] } }
+          },
+          {
+            _id: 'kept',
+            name: 'Kept Spell',
+            type: 'spell',
+            system: { level: { value: 1 }, location: { value: 'block1' }, traits: { value: [] } }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.spellcasting).toHaveLength(1);
+      expect(result.value.spellcasting![0]!.entries.map((e) => e.name)).toEqual(['Kept Spell']);
+    });
+
+    test('drops zero-slot ranks but keeps non-zero ones', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'prep',
+            name: 'Prepared',
+            type: 'spellcastingEntry',
+            system: {
+              prepared: { value: 'prepared' },
+              tradition: { value: 'divine' },
+              spelldc: { dc: 18 },
+              slots: { slot1: { max: 4 }, slot2: { max: 0 }, slot3: { max: 2 } }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.spellcasting![0]!.slots).toEqual({ 1: 4, 3: 2 });
+    });
+
+    test('falls back to safe defaults for unknown tradition / type strings', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'x',
+            name: 'Weird',
+            type: 'spellcastingEntry',
+            system: {
+              prepared: { value: 'unknown-style' },
+              tradition: { value: 'pyromantic' },
+              spelldc: { dc: 12 }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.spellcasting![0]!.tradition).toBe('arcane');
+      expect(result.value.spellcasting![0]!.type).toBe('innate');
+    });
+  });
+
+  describe('size and rarity mapping', () => {
+    test.each([
+      ['tiny', 'tiny'],
+      ['sm', 'small'],
+      ['small', 'small'],
+      ['med', 'medium'],
+      ['medium', 'medium'],
+      ['lg', 'large'],
+      ['large', 'large'],
+      ['huge', 'huge'],
+      ['grg', 'gargantuan'],
+      ['gargantuan', 'gargantuan']
+    ] as const)('maps Foundry size %s to %s', (foundrySize, expected) => {
+      const npc = baseNpc({
+        system: { ...baseNpc().system, traits: { rarity: 'common', size: { value: foundrySize }, value: [] } }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.size).toBe(expected);
+    });
+
+    test('falls back to medium for an unknown size', () => {
+      const npc = baseNpc({
+        system: { ...baseNpc().system, traits: { rarity: 'common', size: { value: 'colossal' }, value: [] } }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.size).toBe('medium');
+    });
+
+    test.each(['common', 'uncommon', 'rare', 'unique'] as const)('passes through %s rarity', (rarity) => {
+      const npc = baseNpc({
+        system: { ...baseNpc().system, traits: { rarity, size: { value: 'med' }, value: [] } }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.rarity).toBe(rarity);
+    });
+
+    test('falls back to common for an unknown rarity', () => {
+      const npc = baseNpc({
+        system: {
+          ...baseNpc().system,
+          traits: { rarity: 'legendary', size: { value: 'med' }, value: [] }
+        }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.rarity).toBe('common');
+    });
+  });
+
+  describe('graceful degradation on missing data', () => {
+    test('produces a Creature with zeroed defenses when system is entirely missing', () => {
+      const result = mapFoundryNpcToCreature({ name: 'Skeletal Stub', type: 'npc' });
+      if (!result.ok) throw new Error(result.error);
+      const c = result.value;
+      expect(c.name).toBe('Skeletal Stub');
+      expect(c.id).toBe('skeletal-stub');
+      expect(c.level).toBe(0);
+      expect(c.ac).toBe(0);
+      expect(c.hp).toBe(0);
+      expect(c.fortitude).toBe(0);
+      expect(c.reflex).toBe(0);
+      expect(c.will).toBe(0);
+      expect(c.perception).toBe(0);
+      expect(c.speed).toEqual({});
+      expect(c.immunities).toEqual([]);
+      expect(c.resistances).toEqual([]);
+      expect(c.weaknesses).toEqual([]);
+      expect(c.attacks).toEqual([]);
+      expect(c.passiveAbilities).toEqual([]);
+      expect(c.spellcasting).toBeUndefined();
+      expect(c.abilities).toBeUndefined();
+      expect(c.senses).toBeUndefined();
+      expect(c.languages).toBeUndefined();
+    });
+
+    test('uses hp.value when hp.max is missing', () => {
+      const npc = baseNpc({
+        system: {
+          ...baseNpc().system,
+          attributes: { ...baseNpc().system!.attributes, hp: { value: 7 } }
+        }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.hp).toBe(7);
+    });
+
+    test('skips malformed sense entries instead of failing', () => {
+      const npc = baseNpc({
+        system: {
+          ...baseNpc().system,
+          perception: {
+            mod: 5,
+            senses: [{ type: 'darkvision' }, { range: 60 } as unknown as { type: string }]
+          }
+        }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.senses).toEqual([{ type: 'darkvision' }]);
+    });
+
+    test('omits languages when both value is empty and details is empty', () => {
+      const npc = baseNpc({
+        system: {
+          ...baseNpc().system,
+          details: { level: { value: 1 }, languages: { value: [], details: '' } }
+        }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.languages).toBeUndefined();
+    });
+
+    test('keeps languages when only details is present', () => {
+      const npc = baseNpc({
+        system: {
+          ...baseNpc().system,
+          details: { level: { value: 1 }, languages: { value: [], details: 'telepathy 100 feet' } }
+        }
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.languages).toEqual({ value: [], details: 'telepathy 100 feet' });
+    });
   });
 });

--- a/src/lib/foundry/mapper.test.ts
+++ b/src/lib/foundry/mapper.test.ts
@@ -74,7 +74,6 @@ describe('parseDamageString', () => {
   });
 
   test('returns null for an expression with neither dice nor bonus', () => {
-    // The regex matches "" → groups all undefined, then guard rejects.
     expect(parseDamageString('   ')).toBeNull();
   });
 });
@@ -234,6 +233,48 @@ describe('mapFoundryNpcToCreature', () => {
         damage: [{ dice: 1, dieSize: 6, bonus: 1, type: 'slashing' }]
       }
     ]);
+  });
+
+  test('keeps thrown weapons classified as melee even when range.increment is positive', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'jav',
+          name: 'Javelin',
+          type: 'melee',
+          system: {
+            bonus: { value: 8 },
+            damageRolls: { '0': { damage: '1d6+2', damageType: 'piercing' } },
+            range: { increment: 30, max: null },
+            traits: { value: ['thrown-30'] }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.attacks[0]!.type).toBe('melee');
+  });
+
+  test('plain thrown trait (no range suffix) also stays melee', () => {
+    const npc = baseNpc({
+      items: [
+        {
+          _id: 'dag',
+          name: 'Dagger',
+          type: 'melee',
+          system: {
+            bonus: { value: 6 },
+            damageRolls: { '0': { damage: '1d4+1', damageType: 'piercing' } },
+            range: { increment: 10, max: null },
+            traits: { value: ['agile', 'thrown'] }
+          }
+        }
+      ]
+    });
+    const result = mapFoundryNpcToCreature(npc);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.attacks[0]!.type).toBe('melee');
   });
 
   test('detects ranged attacks via non-null range', () => {
@@ -407,6 +448,26 @@ describe('mapFoundryNpcToCreature', () => {
       expect(result.value.reactiveAbilities[0]!.actions).toBe('free');
     });
 
+    test('warns and treats unknown actionType as active', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'odd',
+            name: 'Downtime Ritual',
+            type: 'action',
+            system: {
+              actionType: { value: 'downtime' as never },
+              description: { value: '<p>Performed over hours.</p>' }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.value.activeAbilities.map((a) => a.name)).toEqual(['Downtime Ritual']);
+      expect(result.warnings.some((w) => /Downtime Ritual.*downtime/.test(w))).toBe(true);
+    });
+
     test('formats frequency on an ability', () => {
       const npc = baseNpc({
         items: [
@@ -483,7 +544,6 @@ describe('mapFoundryNpcToCreature', () => {
       });
       const result = mapFoundryNpcToCreature(npc);
       if (!result.ok) throw new Error(result.error);
-      // Only the parseable roll survives.
       expect(result.value.attacks[0]!.damage).toEqual([
         { dice: 1, dieSize: 6, bonus: 1, type: 'slashing' }
       ]);
@@ -610,7 +670,7 @@ describe('mapFoundryNpcToCreature', () => {
       expect(result.value.spellcasting![0]!.slots).toEqual({ 1: 4, 3: 2 });
     });
 
-    test('falls back to safe defaults for unknown tradition / type strings', () => {
+    test('falls back to safe defaults for unknown tradition / type strings and warns', () => {
       const npc = baseNpc({
         items: [
           {
@@ -629,6 +689,52 @@ describe('mapFoundryNpcToCreature', () => {
       if (!result.ok) throw new Error(result.error);
       expect(result.value.spellcasting![0]!.tradition).toBe('arcane');
       expect(result.value.spellcasting![0]!.type).toBe('innate');
+      expect(result.warnings.some((w) => /tradition.*pyromantic/.test(w))).toBe(true);
+      expect(result.warnings.some((w) => /type.*unknown-style/.test(w))).toBe(true);
+    });
+
+    test('innate daily-limited spells become perDay frequency', () => {
+      const npc = baseNpc({
+        items: [
+          {
+            _id: 'sce',
+            name: 'Innate Arcane',
+            type: 'spellcastingEntry',
+            system: {
+              prepared: { value: 'innate' },
+              tradition: { value: 'arcane' },
+              spelldc: { dc: 17 }
+            }
+          },
+          {
+            _id: 'sp-daily',
+            name: 'Dispel Magic',
+            type: 'spell',
+            system: {
+              level: { value: 3 },
+              location: { value: 'sce', uses: { max: 1, value: 1 } },
+              traits: { value: [] }
+            }
+          },
+          {
+            _id: 'sp-atwill',
+            name: 'Blur',
+            type: 'spell',
+            system: {
+              level: { value: 2 },
+              location: { value: 'sce' },
+              traits: { value: [] }
+            }
+          }
+        ]
+      });
+      const result = mapFoundryNpcToCreature(npc);
+      if (!result.ok) throw new Error(result.error);
+      const entries = result.value.spellcasting![0]!.entries;
+      const daily = entries.find((e) => e.name === 'Dispel Magic');
+      expect(daily!.frequency).toEqual({ type: 'perDay', uses: 1 });
+      const atWill = entries.find((e) => e.name === 'Blur');
+      expect(atWill!.frequency).toEqual({ type: 'atWill' });
     });
   });
 
@@ -685,29 +791,23 @@ describe('mapFoundryNpcToCreature', () => {
   });
 
   describe('graceful degradation on missing data', () => {
-    test('produces a Creature with zeroed defenses when system is entirely missing', () => {
+    test('rejects when load-bearing combat stats are missing', () => {
       const result = mapFoundryNpcToCreature({ name: 'Skeletal Stub', type: 'npc' });
-      if (!result.ok) throw new Error(result.error);
-      const c = result.value;
-      expect(c.name).toBe('Skeletal Stub');
-      expect(c.id).toBe('skeletal-stub');
-      expect(c.level).toBe(0);
-      expect(c.ac).toBe(0);
-      expect(c.hp).toBe(0);
-      expect(c.fortitude).toBe(0);
-      expect(c.reflex).toBe(0);
-      expect(c.will).toBe(0);
-      expect(c.perception).toBe(0);
-      expect(c.speed).toEqual({});
-      expect(c.immunities).toEqual([]);
-      expect(c.resistances).toEqual([]);
-      expect(c.weaknesses).toEqual([]);
-      expect(c.attacks).toEqual([]);
-      expect(c.passiveAbilities).toEqual([]);
-      expect(c.spellcasting).toBeUndefined();
-      expect(c.abilities).toBeUndefined();
-      expect(c.senses).toBeUndefined();
-      expect(c.languages).toBeUndefined();
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected ok: false');
+      expect(result.error).toMatch(/missing required fields/);
+      expect(result.error).toMatch(/ac/);
+      expect(result.error).toMatch(/hp/);
+      expect(result.error).toMatch(/fortitude/);
+    });
+
+    test('rejects when a single required stat is missing and names it in the error', () => {
+      const npc = baseNpc();
+      delete npc.system!.saves!.reflex;
+      const result = mapFoundryNpcToCreature(npc);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected ok: false');
+      expect(result.error).toMatch(/saves\.reflex/);
     });
 
     test('uses hp.value when hp.max is missing', () => {

--- a/src/lib/foundry/mapper.ts
+++ b/src/lib/foundry/mapper.ts
@@ -65,7 +65,7 @@ export function slugifyName(name: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
-function parseDamageString(raw: string): DamageComponent | null {
+export function parseDamageString(raw: string): DamageComponent | null {
   // Examples: "1d6+1", "2d8", "1d4-1", "5"
   const m = /^\s*(?:(\d+)d(\d+))?\s*(?:([+\-])\s*(\d+))?\s*$/.exec(raw);
   if (!m) return null;

--- a/src/lib/foundry/mapper.ts
+++ b/src/lib/foundry/mapper.ts
@@ -3,6 +3,7 @@ import type {
   AbilityScores,
   ActionCost,
   Attack,
+  AttackType,
   Creature,
   CreatureImmunity,
   CreatureRarity,
@@ -34,6 +35,8 @@ export type MapResult =
   | { ok: true; value: Creature; warnings: string[] }
   | { ok: false; error: string };
 
+type Warn = (msg: string) => void;
+
 const SIZE_MAP: Record<string, CreatureSize> = {
   tiny: 'tiny',
   sm: 'small',
@@ -56,6 +59,7 @@ const SPELLCASTING_TYPES: ReadonlySet<SpellcastingType> = new Set([
   'focus'
 ]);
 const SENSE_ACUITIES: ReadonlySet<SenseAcuity> = new Set(['precise', 'imprecise', 'vague']);
+const THROWN_TRAIT = /^thrown(-\d+)?$/;
 
 export function slugifyName(name: string): string {
   return name
@@ -66,7 +70,7 @@ export function slugifyName(name: string): string {
 }
 
 export function parseDamageString(raw: string): DamageComponent | null {
-  // Examples: "1d6+1", "2d8", "1d4-1", "5"
+  // Examples: "1d6+1", "2d8", "1d4-1", "+5"
   const m = /^\s*(?:(\d+)d(\d+))?\s*(?:([+\-])\s*(\d+))?\s*$/.exec(raw);
   if (!m) return null;
   const dice = m[1] ? Number(m[1]) : undefined;
@@ -79,6 +83,10 @@ export function parseDamageString(raw: string): DamageComponent | null {
   if (dieSize !== undefined) out.dieSize = dieSize;
   if (bonusAbs !== undefined) out.bonus = sign * bonusAbs;
   return { ...out, type: 'untyped' };
+}
+
+function requireNum(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 function mapSize(raw: string | undefined): CreatureSize {
@@ -189,10 +197,15 @@ function mapAttack(item: FoundryMeleeItem): Attack | null {
   if (typeof item.name !== 'string') return null;
   const sys: FoundryMeleeSystem = item.system ?? {};
   const modifier = typeof sys.bonus?.value === 'number' ? sys.bonus.value : 0;
-  const type = isRangedAttack(sys.range) ? 'ranged' : 'melee';
   const traits = Array.isArray(sys.traits?.value)
     ? sys.traits.value.filter((t): t is string => typeof t === 'string')
     : [];
+  // Foundry stores thrown melee weapons (javelin, dagger) as type:"melee" with a
+  // positive range.increment so the engine can resolve both modes. Bestiary
+  // statblocks render these as melee Strikes, so prefer melee when the trait
+  // says thrown.
+  const thrown = traits.some((t) => THROWN_TRAIT.test(t));
+  const type: AttackType = thrown ? 'melee' : isRangedAttack(sys.range) ? 'ranged' : 'melee';
 
   const damage: DamageComponent[] = [];
   for (const roll of Object.values(sys.damageRolls ?? {})) {
@@ -248,7 +261,10 @@ function mapAbility(item: FoundryActionItem): Ability | null {
   return ability;
 }
 
-function partitionAbilities(actions: FoundryItem[]): {
+function partitionAbilities(
+  actions: FoundryItem[],
+  warn: Warn
+): {
   passive: Ability[];
   reactive: Ability[];
   active: Ability[];
@@ -265,7 +281,11 @@ function partitionAbilities(actions: FoundryItem[]): {
     const kind = sys?.actionType?.value ?? 'passive';
     if (kind === 'passive') passive.push(ability);
     else if (kind === 'reaction' || kind === 'free') reactive.push(ability);
-    else active.push(ability);
+    else if (kind === 'action') active.push(ability);
+    else {
+      warn(`Ability "${ability.name}": unknown actionType "${kind}", treated as active`);
+      active.push(ability);
+    }
   }
   return { passive, reactive, active };
 }
@@ -285,12 +305,17 @@ function mapSpellListEntry(
     entry.isCantrip = true;
     entry.frequency = { type: 'atWill' };
   } else if (blockType === 'innate') {
-    entry.frequency = { type: 'atWill' };
+    const usesMax = sys.location?.uses?.max;
+    if (typeof usesMax === 'number' && Number.isFinite(usesMax) && usesMax > 0) {
+      entry.frequency = { type: 'perDay', uses: usesMax };
+    } else {
+      entry.frequency = { type: 'atWill' };
+    }
   }
   return entry;
 }
 
-function mapSpellcasting(items: FoundryItem[]): SpellcastingBlock[] {
+function mapSpellcasting(items: FoundryItem[], warn: Warn): SpellcastingBlock[] {
   const entries: FoundrySpellcastingEntryItem[] = items
     .filter((i) => i.type === 'spellcastingEntry')
     .map((i) => i as FoundrySpellcastingEntryItem);
@@ -311,16 +336,25 @@ function mapSpellcasting(items: FoundryItem[]): SpellcastingBlock[] {
   for (const entry of entries) {
     const sys: FoundrySpellcastingEntrySystem = entry.system ?? {};
     const blockId = typeof entry._id === 'string' && entry._id ? entry._id : (entry.name ?? 'spellcasting');
+    const blockLabel = typeof entry.name === 'string' && entry.name ? entry.name : blockId;
 
     const tradRaw = typeof sys.tradition?.value === 'string' ? sys.tradition.value : '';
-    const tradition: SpellTradition = TRADITIONS.has(tradRaw as SpellTradition)
-      ? (tradRaw as SpellTradition)
-      : 'arcane';
+    let tradition: SpellTradition;
+    if (TRADITIONS.has(tradRaw as SpellTradition)) {
+      tradition = tradRaw as SpellTradition;
+    } else {
+      warn(`Spellcasting block "${blockLabel}": unknown tradition "${tradRaw}", defaulted to arcane`);
+      tradition = 'arcane';
+    }
 
     const typeRaw = typeof sys.prepared?.value === 'string' ? sys.prepared.value : '';
-    const type: SpellcastingType = SPELLCASTING_TYPES.has(typeRaw as SpellcastingType)
-      ? (typeRaw as SpellcastingType)
-      : 'innate';
+    let type: SpellcastingType;
+    if (SPELLCASTING_TYPES.has(typeRaw as SpellcastingType)) {
+      type = typeRaw as SpellcastingType;
+    } else {
+      warn(`Spellcasting block "${blockLabel}": unknown type "${typeRaw}", defaulted to innate`);
+      type = 'innate';
+    }
 
     const dc = typeof sys.spelldc?.dc === 'number' ? sys.spelldc.dc : 0;
     const attackModifier = typeof sys.spelldc?.value === 'number' ? sys.spelldc.value : undefined;
@@ -367,7 +401,34 @@ export function mapFoundryNpcToCreature(npc: unknown): MapResult {
     return { ok: false, error: 'Foundry NPC is missing a name' };
   }
 
+  const sys = doc.system ?? {};
+
+  const level = requireNum(sys.details?.level?.value);
+  const ac = requireNum(sys.attributes?.ac?.value);
+  const fortitude = requireNum(sys.saves?.fortitude?.value);
+  const reflex = requireNum(sys.saves?.reflex?.value);
+  const will = requireNum(sys.saves?.will?.value);
+  const perception = requireNum(sys.perception?.mod);
+  const hp = requireNum(sys.attributes?.hp?.max) ?? requireNum(sys.attributes?.hp?.value);
+
+  const missing: string[] = [];
+  if (level === null) missing.push('system.details.level.value');
+  if (ac === null) missing.push('system.attributes.ac.value');
+  if (fortitude === null) missing.push('system.saves.fortitude.value');
+  if (reflex === null) missing.push('system.saves.reflex.value');
+  if (will === null) missing.push('system.saves.will.value');
+  if (perception === null) missing.push('system.perception.mod');
+  if (hp === null) missing.push('system.attributes.hp.max or .value');
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Foundry NPC "${doc.name}" is missing required fields: ${missing.join(', ')}`
+    };
+  }
+
   const warnings: string[] = [];
+  const warn: Warn = (msg) => warnings.push(msg);
   const items = Array.isArray(doc.items) ? doc.items : [];
 
   const attacks: Attack[] = [];
@@ -377,32 +438,27 @@ export function mapFoundryNpcToCreature(npc: unknown): MapResult {
     if (a) attacks.push(a);
   }
 
-  const { passive, reactive, active } = partitionAbilities(items);
-  const spellcasting = mapSpellcasting(items);
+  const { passive, reactive, active } = partitionAbilities(items, warn);
+  const spellcasting = mapSpellcasting(items, warn);
 
-  const sys = doc.system ?? {};
   const source = sys.details?.publication?.title;
   const notes = stripFoundryMarkup(sys.details?.publicNotes);
 
   const creature: Creature = {
     id: slugifyName(doc.name),
     name: doc.name,
-    level: typeof sys.details?.level?.value === 'number' ? sys.details.level.value : 0,
+    level: level!,
     traits: Array.isArray(sys.traits?.value)
       ? sys.traits.value.filter((t): t is string => typeof t === 'string')
       : [],
     size: mapSize(sys.traits?.size?.value),
     rarity: mapRarity(sys.traits?.rarity),
-    ac: typeof sys.attributes?.ac?.value === 'number' ? sys.attributes.ac.value : 0,
-    fortitude: typeof sys.saves?.fortitude?.value === 'number' ? sys.saves.fortitude.value : 0,
-    reflex: typeof sys.saves?.reflex?.value === 'number' ? sys.saves.reflex.value : 0,
-    will: typeof sys.saves?.will?.value === 'number' ? sys.saves.will.value : 0,
-    perception: typeof sys.perception?.mod === 'number' ? sys.perception.mod : 0,
-    hp: typeof sys.attributes?.hp?.max === 'number'
-      ? sys.attributes.hp.max
-      : typeof sys.attributes?.hp?.value === 'number'
-        ? sys.attributes.hp.value
-        : 0,
+    ac: ac!,
+    fortitude: fortitude!,
+    reflex: reflex!,
+    will: will!,
+    perception: perception!,
+    hp: hp!,
     immunities: mapImmunities(doc),
     resistances: mapDamageTypeArray(sys.attributes?.resistances),
     weaknesses: mapDamageTypeArray(sys.attributes?.weaknesses),

--- a/src/lib/foundry/mapper.ts
+++ b/src/lib/foundry/mapper.ts
@@ -1,0 +1,435 @@
+import type {
+  Ability,
+  AbilityScores,
+  ActionCost,
+  Attack,
+  Creature,
+  CreatureImmunity,
+  CreatureRarity,
+  CreatureSize,
+  DamageComponent,
+  Languages,
+  Sense,
+  SenseAcuity,
+  SpellListEntry,
+  SpellTradition,
+  SpellcastingBlock,
+  SpellcastingType
+} from '../../domain';
+import { stripFoundryMarkup } from './text';
+import type {
+  FoundryActionItem,
+  FoundryActionSystem,
+  FoundryItem,
+  FoundryMeleeItem,
+  FoundryMeleeSystem,
+  FoundryNpc,
+  FoundrySpellItem,
+  FoundrySpellSystem,
+  FoundrySpellcastingEntryItem,
+  FoundrySpellcastingEntrySystem
+} from './types';
+
+export type MapResult =
+  | { ok: true; value: Creature; warnings: string[] }
+  | { ok: false; error: string };
+
+const SIZE_MAP: Record<string, CreatureSize> = {
+  tiny: 'tiny',
+  sm: 'small',
+  small: 'small',
+  med: 'medium',
+  medium: 'medium',
+  lg: 'large',
+  large: 'large',
+  huge: 'huge',
+  grg: 'gargantuan',
+  gargantuan: 'gargantuan'
+};
+
+const RARITIES: ReadonlySet<CreatureRarity> = new Set(['common', 'uncommon', 'rare', 'unique']);
+const TRADITIONS: ReadonlySet<SpellTradition> = new Set(['arcane', 'divine', 'occult', 'primal']);
+const SPELLCASTING_TYPES: ReadonlySet<SpellcastingType> = new Set([
+  'prepared',
+  'spontaneous',
+  'innate',
+  'focus'
+]);
+const SENSE_ACUITIES: ReadonlySet<SenseAcuity> = new Set(['precise', 'imprecise', 'vague']);
+
+export function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/['']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parseDamageString(raw: string): DamageComponent | null {
+  // Examples: "1d6+1", "2d8", "1d4-1", "5"
+  const m = /^\s*(?:(\d+)d(\d+))?\s*(?:([+\-])\s*(\d+))?\s*$/.exec(raw);
+  if (!m) return null;
+  const dice = m[1] ? Number(m[1]) : undefined;
+  const dieSize = m[2] ? Number(m[2]) : undefined;
+  const sign = m[3] === '-' ? -1 : 1;
+  const bonusAbs = m[4] !== undefined ? Number(m[4]) : undefined;
+  if (dice === undefined && bonusAbs === undefined) return null;
+  const out: { dice?: number; dieSize?: number; bonus?: number } = {};
+  if (dice !== undefined) out.dice = dice;
+  if (dieSize !== undefined) out.dieSize = dieSize;
+  if (bonusAbs !== undefined) out.bonus = sign * bonusAbs;
+  return { ...out, type: 'untyped' };
+}
+
+function mapSize(raw: string | undefined): CreatureSize {
+  if (!raw) return 'medium';
+  return SIZE_MAP[raw.toLowerCase()] ?? 'medium';
+}
+
+function mapRarity(raw: string | undefined): CreatureRarity {
+  if (raw && RARITIES.has(raw as CreatureRarity)) return raw as CreatureRarity;
+  return 'common';
+}
+
+function mapSpeed(npc: FoundryNpc): Record<string, number> {
+  const out: Record<string, number> = {};
+  const speed = npc.system?.attributes?.speed;
+  if (typeof speed?.value === 'number') out.land = speed.value;
+  for (const other of speed?.otherSpeeds ?? []) {
+    if (typeof other?.value === 'number' && typeof other?.type === 'string') {
+      out[other.type] = other.value;
+    }
+  }
+  return out;
+}
+
+function mapImmunities(npc: FoundryNpc): CreatureImmunity[] {
+  const out: CreatureImmunity[] = [];
+  for (const im of npc.system?.attributes?.immunities ?? []) {
+    if (typeof im?.type !== 'string') continue;
+    const entry: CreatureImmunity = { type: im.type };
+    if (Array.isArray(im.exceptions) && im.exceptions.length > 0) {
+      entry.exceptions = im.exceptions.filter((e): e is string => typeof e === 'string');
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+function mapDamageTypeArray(
+  raw: { type?: string; value?: number; exceptions?: string[] }[] | undefined
+): { type: string; value: number }[] {
+  const out: { type: string; value: number }[] = [];
+  for (const r of raw ?? []) {
+    if (typeof r?.type !== 'string' || typeof r?.value !== 'number') continue;
+    out.push({ type: r.type, value: r.value });
+  }
+  return out;
+}
+
+function mapSenses(npc: FoundryNpc): Sense[] | undefined {
+  const raw = npc.system?.perception?.senses;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const out: Sense[] = [];
+  for (const s of raw) {
+    if (typeof s?.type !== 'string') continue;
+    const entry: Sense = { type: s.type };
+    if (typeof s.acuity === 'string' && SENSE_ACUITIES.has(s.acuity as SenseAcuity)) {
+      entry.acuity = s.acuity as SenseAcuity;
+    }
+    if (typeof s.range === 'number') entry.range = s.range;
+    out.push(entry);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function mapAbilityScores(npc: FoundryNpc): AbilityScores | undefined {
+  const a = npc.system?.abilities;
+  if (!a) return undefined;
+  const get = (k: keyof typeof a): number | undefined => {
+    const mod = a[k]?.mod;
+    return typeof mod === 'number' ? mod : undefined;
+  };
+  const str = get('str');
+  const dex = get('dex');
+  const con = get('con');
+  const int = get('int');
+  const wis = get('wis');
+  const cha = get('cha');
+  if ([str, dex, con, int, wis, cha].some((v) => v === undefined)) return undefined;
+  return { str: str!, dex: dex!, con: con!, int: int!, wis: wis!, cha: cha! };
+}
+
+function mapLanguages(npc: FoundryNpc): Languages | undefined {
+  const l = npc.system?.details?.languages;
+  if (!l) return undefined;
+  const value = Array.isArray(l.value) ? l.value.filter((s): s is string => typeof s === 'string') : [];
+  const details = typeof l.details === 'string' && l.details.trim() !== '' ? l.details.trim() : undefined;
+  if (value.length === 0 && !details) return undefined;
+  const out: Languages = { value };
+  if (details !== undefined) out.details = details;
+  return out;
+}
+
+function mapSkills(npc: FoundryNpc): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [key, val] of Object.entries(npc.system?.skills ?? {})) {
+    if (val && typeof val.base === 'number') out[key] = val.base;
+  }
+  return out;
+}
+
+function isRangedAttack(range: FoundryMeleeSystem['range']): boolean {
+  if (range == null) return false;
+  if (typeof range === 'string') return range.trim() !== '';
+  return typeof range.increment === 'number' && range.increment > 0;
+}
+
+function mapAttack(item: FoundryMeleeItem): Attack | null {
+  if (typeof item.name !== 'string') return null;
+  const sys: FoundryMeleeSystem = item.system ?? {};
+  const modifier = typeof sys.bonus?.value === 'number' ? sys.bonus.value : 0;
+  const type = isRangedAttack(sys.range) ? 'ranged' : 'melee';
+  const traits = Array.isArray(sys.traits?.value)
+    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+    : [];
+
+  const damage: DamageComponent[] = [];
+  for (const roll of Object.values(sys.damageRolls ?? {})) {
+    if (!roll) continue;
+    const parsed = typeof roll.damage === 'string' ? parseDamageString(roll.damage) : null;
+    if (!parsed) continue;
+    parsed.type = typeof roll.damageType === 'string' && roll.damageType !== '' ? roll.damageType : 'untyped';
+    if (roll.category === 'persistent') parsed.persistent = true;
+    damage.push(parsed);
+  }
+
+  const effects = Array.isArray(sys.attackEffects?.value)
+    ? sys.attackEffects.value.filter((e): e is string => typeof e === 'string')
+    : [];
+
+  const out: Attack = {
+    name: item.name,
+    type,
+    modifier,
+    traits,
+    damage
+  };
+  if (effects.length > 0) out.effects = effects;
+  return out;
+}
+
+function mapAbility(item: FoundryActionItem): Ability | null {
+  if (typeof item.name !== 'string') return null;
+  const sys: FoundryActionSystem = item.system ?? {};
+  const description = stripFoundryMarkup(sys.description?.value);
+  const traits = Array.isArray(sys.traits?.value)
+    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+    : undefined;
+
+  let actions: ActionCost | undefined;
+  const actionType = sys.actionType?.value;
+  if (actionType === 'reaction') actions = 'reaction';
+  else if (actionType === 'free') actions = 'free';
+  else if (actionType === 'action') {
+    const n = sys.actions?.value;
+    if (n === 1 || n === 2 || n === 3) actions = n;
+  }
+
+  let frequency: string | undefined;
+  if (sys.frequency && typeof sys.frequency.max === 'number' && typeof sys.frequency.per === 'string') {
+    frequency = `${sys.frequency.max} per ${sys.frequency.per}`;
+  }
+
+  const ability: Ability = { name: item.name, description };
+  if (actions !== undefined) ability.actions = actions;
+  if (traits !== undefined && traits.length > 0) ability.traits = traits;
+  if (frequency !== undefined) ability.frequency = frequency;
+  return ability;
+}
+
+function partitionAbilities(actions: FoundryItem[]): {
+  passive: Ability[];
+  reactive: Ability[];
+  active: Ability[];
+} {
+  const passive: Ability[] = [];
+  const reactive: Ability[] = [];
+  const active: Ability[] = [];
+  for (const item of actions) {
+    if (item.type !== 'action') continue;
+    const actionItem = item as FoundryActionItem;
+    const sys = actionItem.system;
+    const ability = mapAbility(actionItem);
+    if (!ability) continue;
+    const kind = sys?.actionType?.value ?? 'passive';
+    if (kind === 'passive') passive.push(ability);
+    else if (kind === 'reaction' || kind === 'free') reactive.push(ability);
+    else active.push(ability);
+  }
+  return { passive, reactive, active };
+}
+
+function mapSpellListEntry(
+  item: FoundrySpellItem,
+  blockType: SpellcastingType
+): SpellListEntry | null {
+  if (typeof item.name !== 'string') return null;
+  const sys: FoundrySpellSystem = item.system ?? {};
+  const level = typeof sys.level?.value === 'number' ? sys.level.value : 0;
+  const traits = Array.isArray(sys.traits?.value) ? sys.traits.value : [];
+  const isCantrip = traits.includes('cantrip') || level === 0;
+  const slug = slugifyName(item.name);
+  const entry: SpellListEntry = { spellSlug: slug, name: item.name, level };
+  if (isCantrip) {
+    entry.isCantrip = true;
+    entry.frequency = { type: 'atWill' };
+  } else if (blockType === 'innate') {
+    entry.frequency = { type: 'atWill' };
+  }
+  return entry;
+}
+
+function mapSpellcasting(items: FoundryItem[]): SpellcastingBlock[] {
+  const entries: FoundrySpellcastingEntryItem[] = items
+    .filter((i) => i.type === 'spellcastingEntry')
+    .map((i) => i as FoundrySpellcastingEntryItem);
+  if (entries.length === 0) return [];
+
+  const spellsByLocation = new Map<string, FoundrySpellItem[]>();
+  for (const item of items) {
+    if (item.type !== 'spell') continue;
+    const spellItem = item as FoundrySpellItem;
+    const loc = spellItem.system?.location?.value;
+    if (typeof loc !== 'string') continue;
+    const arr = spellsByLocation.get(loc) ?? [];
+    arr.push(spellItem);
+    spellsByLocation.set(loc, arr);
+  }
+
+  const out: SpellcastingBlock[] = [];
+  for (const entry of entries) {
+    const sys: FoundrySpellcastingEntrySystem = entry.system ?? {};
+    const blockId = typeof entry._id === 'string' && entry._id ? entry._id : (entry.name ?? 'spellcasting');
+
+    const tradRaw = typeof sys.tradition?.value === 'string' ? sys.tradition.value : '';
+    const tradition: SpellTradition = TRADITIONS.has(tradRaw as SpellTradition)
+      ? (tradRaw as SpellTradition)
+      : 'arcane';
+
+    const typeRaw = typeof sys.prepared?.value === 'string' ? sys.prepared.value : '';
+    const type: SpellcastingType = SPELLCASTING_TYPES.has(typeRaw as SpellcastingType)
+      ? (typeRaw as SpellcastingType)
+      : 'innate';
+
+    const dc = typeof sys.spelldc?.dc === 'number' ? sys.spelldc.dc : 0;
+    const attackModifier = typeof sys.spelldc?.value === 'number' ? sys.spelldc.value : undefined;
+
+    const slots: Record<number, number> = {};
+    for (const [k, v] of Object.entries(sys.slots ?? {})) {
+      const m = /^slot(\d+)$/.exec(k);
+      if (!m) continue;
+      const rank = Number(m[1]);
+      if (v && typeof v.max === 'number' && v.max > 0) slots[rank] = v.max;
+    }
+
+    const spellList = spellsByLocation.get(entry._id ?? '') ?? [];
+    const spellEntries: SpellListEntry[] = [];
+    for (const spell of spellList) {
+      const e = mapSpellListEntry(spell, type);
+      if (e) spellEntries.push(e);
+    }
+
+    const block: SpellcastingBlock = {
+      blockId,
+      name: typeof entry.name === 'string' ? entry.name : 'Spellcasting',
+      tradition,
+      type,
+      dc,
+      entries: spellEntries
+    };
+    if (attackModifier !== undefined) block.attackModifier = attackModifier;
+    if (Object.keys(slots).length > 0) block.slots = slots;
+    out.push(block);
+  }
+  return out;
+}
+
+export function mapFoundryNpcToCreature(npc: unknown): MapResult {
+  if (typeof npc !== 'object' || npc === null || Array.isArray(npc)) {
+    return { ok: false, error: 'Foundry document must be a JSON object' };
+  }
+  const doc = npc as FoundryNpc;
+  if (doc.type !== 'npc') {
+    return { ok: false, error: `Expected document type "npc", got ${JSON.stringify(doc.type)}` };
+  }
+  if (typeof doc.name !== 'string' || doc.name.trim() === '') {
+    return { ok: false, error: 'Foundry NPC is missing a name' };
+  }
+
+  const warnings: string[] = [];
+  const items = Array.isArray(doc.items) ? doc.items : [];
+
+  const attacks: Attack[] = [];
+  for (const item of items) {
+    if (item.type !== 'melee') continue;
+    const a = mapAttack(item as FoundryMeleeItem);
+    if (a) attacks.push(a);
+  }
+
+  const { passive, reactive, active } = partitionAbilities(items);
+  const spellcasting = mapSpellcasting(items);
+
+  const sys = doc.system ?? {};
+  const source = sys.details?.publication?.title;
+  const notes = stripFoundryMarkup(sys.details?.publicNotes);
+
+  const creature: Creature = {
+    id: slugifyName(doc.name),
+    name: doc.name,
+    level: typeof sys.details?.level?.value === 'number' ? sys.details.level.value : 0,
+    traits: Array.isArray(sys.traits?.value)
+      ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+      : [],
+    size: mapSize(sys.traits?.size?.value),
+    rarity: mapRarity(sys.traits?.rarity),
+    ac: typeof sys.attributes?.ac?.value === 'number' ? sys.attributes.ac.value : 0,
+    fortitude: typeof sys.saves?.fortitude?.value === 'number' ? sys.saves.fortitude.value : 0,
+    reflex: typeof sys.saves?.reflex?.value === 'number' ? sys.saves.reflex.value : 0,
+    will: typeof sys.saves?.will?.value === 'number' ? sys.saves.will.value : 0,
+    perception: typeof sys.perception?.mod === 'number' ? sys.perception.mod : 0,
+    hp: typeof sys.attributes?.hp?.max === 'number'
+      ? sys.attributes.hp.max
+      : typeof sys.attributes?.hp?.value === 'number'
+        ? sys.attributes.hp.value
+        : 0,
+    immunities: mapImmunities(doc),
+    resistances: mapDamageTypeArray(sys.attributes?.resistances),
+    weaknesses: mapDamageTypeArray(sys.attributes?.weaknesses),
+    speed: mapSpeed(doc),
+    attacks,
+    passiveAbilities: passive,
+    reactiveAbilities: reactive,
+    activeAbilities: active,
+    skills: mapSkills(doc),
+    tags: []
+  };
+
+  const alignment = sys.details?.alignment?.value;
+  if (typeof alignment === 'string' && alignment.trim() !== '') creature.alignment = alignment;
+  if (typeof source === 'string' && source.trim() !== '') creature.source = source;
+  if (notes !== '') creature.notes = notes;
+
+  const senses = mapSenses(doc);
+  if (senses) creature.senses = senses;
+
+  const abilities = mapAbilityScores(doc);
+  if (abilities) creature.abilities = abilities;
+
+  const languages = mapLanguages(doc);
+  if (languages) creature.languages = languages;
+
+  if (spellcasting.length > 0) creature.spellcasting = spellcasting;
+
+  return { ok: true, value: creature, warnings };
+}

--- a/src/lib/foundry/text.test.ts
+++ b/src/lib/foundry/text.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { stripFoundryMarkup } from './text';
+
+describe('stripFoundryMarkup', () => {
+  test('strips simple HTML tags and preserves text', () => {
+    expect(stripFoundryMarkup('<p>Hello <strong>world</strong>.</p>')).toBe('Hello world.');
+  });
+
+  test('replaces paragraph closes with newlines', () => {
+    expect(stripFoundryMarkup('<p>One.</p><p>Two.</p>')).toBe('One.\nTwo.');
+  });
+
+  test('keeps the label part of @UUID with braces', () => {
+    expect(
+      stripFoundryMarkup('Becomes @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard]{off-guard}.')
+    ).toBe('Becomes off-guard.');
+  });
+
+  test('falls back to last path segment for bare @UUID', () => {
+    expect(
+      stripFoundryMarkup('Becomes @UUID[Compendium.pf2e.conditionitems.Item.Prone].')
+    ).toBe('Becomes Prone.');
+  });
+
+  test('formats @Check macros as readable text', () => {
+    expect(stripFoundryMarkup('Roll @Check[reflex|dc:17|basic|options:area-effect].')).toBe(
+      'Roll Reflex DC 17 basic.'
+    );
+  });
+
+  test('formats @Damage macros', () => {
+    expect(stripFoundryMarkup('Takes @Damage[2d6[slashing]|options:area-damage] damage.')).toBe(
+      'Takes 2d6 slashing damage.'
+    );
+  });
+
+  test('drops @Localize markers entirely', () => {
+    expect(stripFoundryMarkup('See @Localize[PF2E.NPC.Abilities.Glossary.FastHealing] for rules.')).toBe(
+      'See  for rules.'.replace(/\s+/g, ' ')
+    );
+  });
+
+  test('preserves the dice expression of inline rolls and drops macro names/comments', () => {
+    expect(stripFoundryMarkup('Then [[/gmr 1d4 #Recharge]] to recharge.')).toBe(
+      'Then 1d4 to recharge.'
+    );
+  });
+
+  test('handles <hr> and <br> as paragraph breaks', () => {
+    expect(stripFoundryMarkup('Top<hr/>Middle<br>Bottom')).toBe('Top\nMiddle\nBottom');
+  });
+
+  test('returns empty string for null/undefined input', () => {
+    expect(stripFoundryMarkup(undefined)).toBe('');
+    expect(stripFoundryMarkup(null)).toBe('');
+  });
+
+  test('collapses non-breaking spaces and runs of whitespace', () => {
+    expect(stripFoundryMarkup('a    b c')).toBe('a b c');
+  });
+
+  test('handles multiple markers in one description', () => {
+    const input =
+      '<p><strong>Failure</strong> The creature is knocked @UUID[Compendium.pf2e.conditionitems.Item.Prone]. Make a @Check[reflex|dc:20|basic] save.</p>';
+    expect(stripFoundryMarkup(input)).toBe(
+      'Failure The creature is knocked Prone. Make a Reflex DC 20 basic save.'
+    );
+  });
+});

--- a/src/lib/foundry/text.ts
+++ b/src/lib/foundry/text.ts
@@ -58,8 +58,8 @@ function prettifyDamage(body: string): string {
   return head.replace(/\[([^\]]+)\]/g, ' $1').trim();
 }
 
-export function stripFoundryMarkup(input: string | undefined | null): string {
-  if (input == null) return '';
+export function stripFoundryMarkup(input: unknown): string {
+  if (typeof input !== 'string') return '';
   let text = input;
 
   text = text.replace(UUID_WITH_LABEL, (_, label) => label);
@@ -69,7 +69,6 @@ export function stripFoundryMarkup(input: string | undefined | null): string {
   text = text.replace(LOCALIZE, '');
   text = text.replace(INLINE_ROLL, (_, expr) => expr);
 
-  // Paragraph and break tags → newline before stripping the rest.
   text = text.replace(/<\/(p|div|li|h[1-6])>/gi, '\n');
   text = text.replace(/<br\s*\/?>/gi, '\n');
   text = text.replace(/<hr\s*\/?>/gi, '\n');
@@ -77,8 +76,6 @@ export function stripFoundryMarkup(input: string | undefined | null): string {
   text = text.replace(HTML_TAG, '');
   text = text.replace(NBSP, ' ');
 
-  // Normalize whitespace: collapse runs of spaces, but preserve paragraph
-  // breaks. We do this by splitting on newlines first.
   const lines = text.split('\n').map((line) => line.replace(MULTI_WHITESPACE, ' ').trim());
   return lines.filter((l) => l.length > 0).join('\n').trim();
 }

--- a/src/lib/foundry/text.ts
+++ b/src/lib/foundry/text.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure stripper for the Foundry-flavored markup that appears in NPC
+ * description fields. Converts the cocktail of HTML + @-prefixed inline
+ * macros into plain text suitable for our `notes` / `description` fields.
+ *
+ * Order matters: process @-macros and bracketed inline rolls *before*
+ * collapsing HTML, so attribute-style content inside braces isn't
+ * accidentally consumed by the HTML pass.
+ */
+
+const UUID_WITH_LABEL = /@UUID\[[^\]]*\]\{([^}]*)\}/g;
+const UUID_BARE = /@UUID\[([^\]]*)\]/g;
+const CHECK = /@Check\[([^\]]*)\]/g;
+// @Damage syntax allows single-level nested [type] brackets:
+//   @Damage[2d6[slashing]|options:area-damage]
+// So we accept either non-bracket chars or a balanced inner [..] pair.
+const DAMAGE = /@Damage\[((?:[^\[\]]|\[[^\[\]]*\])*)\]/g;
+const LOCALIZE = /@Localize\[[^\]]*\]/g;
+const INLINE_ROLL = /\[\[\/[a-z]+ ([^|#\]]+?)(?:\s+#[^\]]*)?\]\]/g;
+const HTML_TAG = /<\/?[^>]+>/g;
+const NBSP = / /g;
+const MULTI_WHITESPACE = /\s+/g;
+
+function lastSegment(uuid: string): string {
+  const trimmed = uuid.trim();
+  const dot = trimmed.lastIndexOf('.');
+  return dot === -1 ? trimmed : trimmed.slice(dot + 1);
+}
+
+function prettifyCheck(body: string): string {
+  // @Check[reflex|dc:17|basic] → "Reflex DC 17 basic"
+  const parts = body.split('|').map((p) => p.trim()).filter(Boolean);
+  if (parts.length === 0) return '';
+  const [first, ...rest] = parts;
+  const statistic = first ? first.charAt(0).toUpperCase() + first.slice(1) : '';
+  const out: string[] = [];
+  if (statistic) out.push(statistic);
+  for (const piece of rest) {
+    const eq = piece.indexOf(':');
+    if (eq === -1) {
+      out.push(piece);
+      continue;
+    }
+    const key = piece.slice(0, eq).trim().toLowerCase();
+    const value = piece.slice(eq + 1).trim();
+    if (key === 'dc') out.push(`DC ${value}`);
+    else if (key === 'name') continue;
+    else if (key === 'options') continue;
+    else out.push(value);
+  }
+  return out.join(' ');
+}
+
+function prettifyDamage(body: string): string {
+  // @Damage[2d6[slashing]] or @Damage[2d6[slashing]|options:area-damage]
+  // We keep the first pipe segment and rewrite [type] → " type".
+  const head = body.split('|')[0] ?? '';
+  return head.replace(/\[([^\]]+)\]/g, ' $1').trim();
+}
+
+export function stripFoundryMarkup(input: string | undefined | null): string {
+  if (input == null) return '';
+  let text = input;
+
+  text = text.replace(UUID_WITH_LABEL, (_, label) => label);
+  text = text.replace(UUID_BARE, (_, body) => lastSegment(body));
+  text = text.replace(CHECK, (_, body) => prettifyCheck(body));
+  text = text.replace(DAMAGE, (_, body) => prettifyDamage(body));
+  text = text.replace(LOCALIZE, '');
+  text = text.replace(INLINE_ROLL, (_, expr) => expr);
+
+  // Paragraph and break tags → newline before stripping the rest.
+  text = text.replace(/<\/(p|div|li|h[1-6])>/gi, '\n');
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+  text = text.replace(/<hr\s*\/?>/gi, '\n');
+
+  text = text.replace(HTML_TAG, '');
+  text = text.replace(NBSP, ' ');
+
+  // Normalize whitespace: collapse runs of spaces, but preserve paragraph
+  // breaks. We do this by splitting on newlines first.
+  const lines = text.split('\n').map((line) => line.replace(MULTI_WHITESPACE, ' ').trim());
+  return lines.filter((l) => l.length > 0).join('\n').trim();
+}

--- a/src/lib/foundry/types.ts
+++ b/src/lib/foundry/types.ts
@@ -86,7 +86,13 @@ export interface FoundrySpellcastingEntrySystem {
 
 export interface FoundrySpellSystem {
   level?: { value?: number };
-  location?: { value?: string };
+  location?: {
+    value?: string;
+    // Innate daily-limited spells carry their uses on the spell item itself,
+    // not on the spellcastingEntry — `max` is what the mapper turns into a
+    // perDay frequency.
+    uses?: { max?: number; value?: number };
+  };
   traits?: { value?: string[]; traditions?: string[] };
   time?: { value?: string };
   range?: { value?: string } | string;

--- a/src/lib/foundry/types.ts
+++ b/src/lib/foundry/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Narrow TypeScript types for the subset of the Foundry pf2e NPC JSON schema
+ * we actually read when mapping into our domain `Creature`.
+ *
+ * These are intentionally minimal — every field optional unless the mapper
+ * truly requires it — because Foundry's real schema is sprawling and we want
+ * the mapper to degrade gracefully on adventure-bestiary edge cases.
+ */
+
+export type FoundryActionType = 'passive' | 'action' | 'reaction' | 'free';
+
+export interface FoundryNamedValue {
+  value?: unknown;
+}
+
+export interface FoundryAttributes {
+  ac?: { value?: number };
+  hp?: { max?: number; value?: number };
+  speed?: {
+    value?: number;
+    otherSpeeds?: { type?: string; value?: number }[];
+  };
+  immunities?: { type?: string; exceptions?: string[] }[];
+  weaknesses?: { type?: string; value?: number; exceptions?: string[] }[];
+  resistances?: { type?: string; value?: number; exceptions?: string[] }[];
+}
+
+export interface FoundrySaves {
+  fortitude?: { value?: number };
+  reflex?: { value?: number };
+  will?: { value?: number };
+}
+
+export interface FoundryPerception {
+  mod?: number;
+  senses?: { type?: string; acuity?: string; range?: number }[];
+}
+
+export interface FoundryAbilities {
+  str?: { mod?: number };
+  dex?: { mod?: number };
+  con?: { mod?: number };
+  int?: { mod?: number };
+  wis?: { mod?: number };
+  cha?: { mod?: number };
+}
+
+export interface FoundryDetails {
+  level?: { value?: number };
+  alignment?: { value?: string };
+  languages?: { value?: string[]; details?: string };
+  publication?: { title?: string };
+  publicNotes?: string;
+}
+
+export interface FoundryTraits {
+  rarity?: string;
+  size?: { value?: string };
+  value?: string[];
+}
+
+export interface FoundryNpcSystem {
+  attributes?: FoundryAttributes;
+  saves?: FoundrySaves;
+  perception?: FoundryPerception;
+  abilities?: FoundryAbilities;
+  details?: FoundryDetails;
+  traits?: FoundryTraits;
+  skills?: Record<string, { base?: number }>;
+}
+
+export interface FoundryMeleeSystem {
+  bonus?: { value?: number };
+  damageRolls?: Record<string, { damage?: string; damageType?: string; category?: string | null }>;
+  range?: null | string | { increment?: number; max?: number | null };
+  traits?: { value?: string[] };
+  attackEffects?: { value?: string[]; custom?: string };
+}
+
+export interface FoundrySpellcastingEntrySystem {
+  prepared?: { value?: string };
+  tradition?: { value?: string };
+  spelldc?: { dc?: number; value?: number; mod?: number };
+  slots?: Record<string, { max?: number }>;
+}
+
+export interface FoundrySpellSystem {
+  level?: { value?: number };
+  location?: { value?: string };
+  traits?: { value?: string[]; traditions?: string[] };
+  time?: { value?: string };
+  range?: { value?: string } | string;
+}
+
+export interface FoundryActionSystem {
+  actionType?: { value?: FoundryActionType };
+  actions?: { value?: number | null };
+  category?: string;
+  traits?: { value?: string[] };
+  description?: { value?: string };
+  frequency?: { max?: number; per?: string };
+}
+
+interface FoundryItemBase {
+  _id?: string;
+  name?: string;
+}
+
+export interface FoundryMeleeItem extends FoundryItemBase {
+  type: 'melee';
+  system?: FoundryMeleeSystem;
+}
+
+export interface FoundrySpellcastingEntryItem extends FoundryItemBase {
+  type: 'spellcastingEntry';
+  system?: FoundrySpellcastingEntrySystem;
+}
+
+export interface FoundrySpellItem extends FoundryItemBase {
+  type: 'spell';
+  system?: FoundrySpellSystem;
+}
+
+export interface FoundryActionItem extends FoundryItemBase {
+  type: 'action';
+  system?: FoundryActionSystem;
+}
+
+export interface FoundryOtherItem extends FoundryItemBase {
+  type: string;
+  system?: Record<string, unknown>;
+}
+
+export type FoundryItem =
+  | FoundryMeleeItem
+  | FoundrySpellcastingEntryItem
+  | FoundrySpellItem
+  | FoundryActionItem
+  | FoundryOtherItem;
+
+export interface FoundryNpc {
+  _id?: string;
+  name?: string;
+  type?: string;
+  system?: FoundryNpcSystem;
+  items?: FoundryItem[];
+}

--- a/src/lib/storage/creature-library.test.ts
+++ b/src/lib/storage/creature-library.test.ts
@@ -10,8 +10,7 @@ import { CREATURE_LIBRARY_STORE, getDb } from './db';
 
 /**
  * Plants a raw object directly into the creature-library store, bypassing the
- * typed `addCreatures` path. Used to simulate pre-migration entries already
- * sitting in IndexedDB.
+ * typed `addCreatures` path.
  */
 async function plantRaw(id: string, value: unknown): Promise<void> {
   const promise = getDb();
@@ -205,6 +204,38 @@ describe('creature library storage', () => {
 
       const stored = await loadOrThrow();
       expect(stored.find((c) => c.id === 'empty')).toBeDefined();
+    });
+
+    it('returns droppedLegacy count so callers can surface a recovery prompt', async () => {
+      const legacyA = {
+        ...makeCreature({ id: 'a', name: 'A' }),
+        immunities: ['fire']
+      };
+      const legacyB = {
+        ...makeCreature({ id: 'b', name: 'B' }),
+        immunities: ['cold']
+      };
+      const modern = makeCreature({
+        id: 'c',
+        immunities: [{ type: 'sleep' }]
+      });
+      await plantRaw('a', legacyA);
+      await plantRaw('b', legacyB);
+      await plantRaw('c', modern);
+
+      const result = await loadCreatures();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.droppedLegacy).toBe(2);
+        expect(result.creatures.map((c) => c.id)).toEqual(['c']);
+      }
+    });
+
+    it('returns droppedLegacy: 0 when nothing legacy is present', async () => {
+      await addCreatures([makeCreature({ id: 'x', immunities: [{ type: 'sleep' }] })]);
+      const result = await loadCreatures();
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.droppedLegacy).toBe(0);
     });
   });
 

--- a/src/lib/storage/creature-library.test.ts
+++ b/src/lib/storage/creature-library.test.ts
@@ -6,6 +6,21 @@ import {
   loadCreatures,
   removeCreature
 } from './creature-library';
+import { CREATURE_LIBRARY_STORE, getDb } from './db';
+
+/**
+ * Plants a raw object directly into the creature-library store, bypassing the
+ * typed `addCreatures` path. Used to simulate pre-migration entries already
+ * sitting in IndexedDB.
+ */
+async function plantRaw(id: string, value: unknown): Promise<void> {
+  const promise = getDb();
+  if (!promise) throw new Error('IndexedDB unavailable');
+  const db = await promise;
+  const tx = db.transaction(CREATURE_LIBRARY_STORE, 'readwrite');
+  await tx.store.put(value, id);
+  await tx.done;
+}
 
 function makeCreature(overrides: Partial<Creature> = {}): Creature {
   return {
@@ -122,6 +137,75 @@ describe('creature library storage', () => {
     await addCreatures([makeCreature({ id: 'a' }), makeCreature({ id: 'b' })]);
     expect(await clearCreatures()).toEqual({ ok: true });
     expect(await loadOrThrow()).toEqual([]);
+  });
+
+  describe('legacy-immunity filter', () => {
+    it('drops a stored creature whose immunities use the pre-migration string[] shape', async () => {
+      const legacy = {
+        ...makeCreature({ id: 'legacy-goblin', name: 'Legacy Goblin' }),
+        immunities: ['fire', 'sleep'] // pre-migration shape
+      };
+      await plantRaw('legacy-goblin', legacy);
+
+      const stored = await loadOrThrow();
+      expect(stored.find((c) => c.id === 'legacy-goblin')).toBeUndefined();
+    });
+
+    it('keeps a stored creature whose immunities use the new object shape', async () => {
+      const modern = makeCreature({
+        id: 'modern-goblin',
+        immunities: [{ type: 'fire' }, { type: 'sleep' }]
+      });
+      await plantRaw('modern-goblin', modern);
+
+      const stored = await loadOrThrow();
+      expect(stored.find((c) => c.id === 'modern-goblin')).toBeDefined();
+    });
+
+    it('drops entries with a mixed-shape immunities array', async () => {
+      const mixed = {
+        ...makeCreature({ id: 'mixed' }),
+        immunities: [{ type: 'fire' }, 'sleep']
+      };
+      await plantRaw('mixed', mixed);
+
+      const stored = await loadOrThrow();
+      expect(stored.find((c) => c.id === 'mixed')).toBeUndefined();
+    });
+
+    it('drops entries whose immunities field is missing or non-array', async () => {
+      const broken = { ...makeCreature({ id: 'broken' }) } as Partial<Creature>;
+      delete broken.immunities;
+      await plantRaw('broken', broken);
+
+      const stored = await loadOrThrow();
+      expect(stored.find((c) => c.id === 'broken')).toBeUndefined();
+    });
+
+    it('preserves modern entries while filtering out legacy entries in the same store', async () => {
+      const legacy = {
+        ...makeCreature({ id: 'legacy', name: 'Legacy' }),
+        immunities: ['fire']
+      };
+      const modern = makeCreature({
+        id: 'modern',
+        name: 'Modern',
+        immunities: [{ type: 'fire' }]
+      });
+      await plantRaw('legacy', legacy);
+      await plantRaw('modern', modern);
+
+      const stored = await loadOrThrow();
+      expect(stored.map((c) => c.id).sort()).toEqual(['modern']);
+    });
+
+    it('treats an empty immunities array as the modern shape (passes through)', async () => {
+      const empty = makeCreature({ id: 'empty', immunities: [] });
+      await plantRaw('empty', empty);
+
+      const stored = await loadOrThrow();
+      expect(stored.find((c) => c.id === 'empty')).toBeDefined();
+    });
   });
 
   it('persists creatures across a simulated page reload', async () => {

--- a/src/lib/storage/creature-library.ts
+++ b/src/lib/storage/creature-library.ts
@@ -5,7 +5,7 @@ import { CREATURE_LIBRARY_STORE, getDb } from './db';
 export type StorageFailureReason = 'unavailable' | 'failed';
 
 export type LoadCreaturesResult =
-  | { ok: true; creatures: Creature[] }
+  | { ok: true; creatures: Creature[]; droppedLegacy: number }
   | { ok: false; reason: StorageFailureReason; error?: unknown };
 
 export type AddCreaturesResult =
@@ -31,10 +31,11 @@ export async function loadCreatures(): Promise<LoadCreaturesResult> {
   try {
     const db = await promise;
     const stored = (await db.getAll(CREATURE_LIBRARY_STORE)) as Creature[];
-    // Drop legacy entries whose immunities use the pre-migration string[] shape.
-    // Users re-import; see plan: "Strict + drop legacy data".
+    // Drop entries whose immunities use the pre-migration string[] shape.
+    // Schema migrated to { type; exceptions? }[]; legacy rows are filtered
+    // here and the caller surfaces the drop count so the user can re-import.
     const creatures = stored.filter((c) => !hasLegacyImmunityShape(c));
-    return { ok: true, creatures };
+    return { ok: true, creatures, droppedLegacy: stored.length - creatures.length };
   } catch (error) {
     return { ok: false, reason: 'failed', error };
   }

--- a/src/lib/storage/creature-library.ts
+++ b/src/lib/storage/creature-library.ts
@@ -20,13 +20,21 @@ export type ClearCreaturesResult =
   | { ok: true }
   | { ok: false; reason: StorageFailureReason; error?: unknown };
 
+function hasLegacyImmunityShape(c: Creature): boolean {
+  if (!Array.isArray(c.immunities)) return true;
+  return c.immunities.some((im) => typeof im === 'string' || im == null);
+}
+
 export async function loadCreatures(): Promise<LoadCreaturesResult> {
   const promise = getDb();
   if (!promise) return { ok: false, reason: 'unavailable' };
   try {
     const db = await promise;
     const stored = (await db.getAll(CREATURE_LIBRARY_STORE)) as Creature[];
-    return { ok: true, creatures: stored };
+    // Drop legacy entries whose immunities use the pre-migration string[] shape.
+    // Users re-import; see plan: "Strict + drop legacy data".
+    const creatures = stored.filter((c) => !hasLegacyImmunityShape(c));
+    return { ok: true, creatures };
   } catch (error) {
     return { ok: false, reason: 'failed', error };
   }

--- a/src/lib/yaml/creature-validator.test.ts
+++ b/src/lib/yaml/creature-validator.test.ts
@@ -420,7 +420,6 @@ describe('validateCreature - spellcasting', () => {
       const data = { ...minimalCreature, immunities: ['fire', 'sleep'] };
       const result = validateCreature(data, 0);
       expect(result.ok).toBe(false);
-      // Each string element is checked as an object — both should fail with the same shape error.
       expect(result.issues.some((i) => /immunities\[\d+\]/.test(i.path))).toBe(true);
     });
 

--- a/src/lib/yaml/creature-validator.test.ts
+++ b/src/lib/yaml/creature-validator.test.ts
@@ -393,4 +393,202 @@ describe('validateCreature - spellcasting', () => {
     expect(result.ok).toBe(false);
     expect(result.issues.some((i) => i.path === 'spellcasting[0].entries[0].frequency.uses')).toBe(true);
   });
+
+  describe('immunities (object shape)', () => {
+    it('accepts the new { type } object form', () => {
+      const data = { ...minimalCreature, immunities: [{ type: 'fire' }, { type: 'sleep' }] };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.immunities).toEqual([{ type: 'fire' }, { type: 'sleep' }]);
+      }
+    });
+
+    it('accepts exceptions on an immunity', () => {
+      const data = {
+        ...minimalCreature,
+        immunities: [{ type: 'physical', exceptions: ['vorpal-adamantine'] }]
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.immunities[0]).toEqual({ type: 'physical', exceptions: ['vorpal-adamantine'] });
+      }
+    });
+
+    it('rejects the legacy string-array shape', () => {
+      const data = { ...minimalCreature, immunities: ['fire', 'sleep'] };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      // Each string element is checked as an object — both should fail with the same shape error.
+      expect(result.issues.some((i) => /immunities\[\d+\]/.test(i.path))).toBe(true);
+    });
+
+    it('rejects an immunity object missing type', () => {
+      const data = { ...minimalCreature, immunities: [{ exceptions: ['adamantine'] }] };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'immunities[0].type')).toBe(true);
+    });
+
+    it('rejects immunities entirely when not an array', () => {
+      const data = { ...minimalCreature, immunities: 'fire' };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'immunities' && /array/i.test(i.message))).toBe(true);
+    });
+
+    it('rejects non-string exceptions on an immunity', () => {
+      const data = {
+        ...minimalCreature,
+        immunities: [{ type: 'physical', exceptions: [123] }]
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'immunities[0].exceptions')).toBe(true);
+    });
+  });
+
+  describe('senses', () => {
+    it('accepts senses with optional acuity and range', () => {
+      const data = {
+        ...minimalCreature,
+        senses: [
+          { type: 'darkvision' },
+          { type: 'scent', acuity: 'imprecise', range: 30 }
+        ]
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.senses).toEqual([
+          { type: 'darkvision' },
+          { type: 'scent', acuity: 'imprecise', range: 30 }
+        ]);
+      }
+    });
+
+    it('omits senses entirely when the field is absent', () => {
+      const result = validateCreature(minimalCreature, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.senses).toBeUndefined();
+    });
+
+    it('rejects an unknown acuity value', () => {
+      const data = {
+        ...minimalCreature,
+        senses: [{ type: 'tremorsense', acuity: 'cosmic' }]
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'senses[0].acuity')).toBe(true);
+    });
+
+    it('rejects a non-number range', () => {
+      const data = {
+        ...minimalCreature,
+        senses: [{ type: 'scent', range: '30 feet' }]
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'senses[0].range')).toBe(true);
+    });
+
+    it('rejects a sense entry missing type', () => {
+      const data = { ...minimalCreature, senses: [{ range: 30 }] };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'senses[0].type')).toBe(true);
+    });
+  });
+
+  describe('abilities (ability score modifiers)', () => {
+    it('accepts a full ability score block', () => {
+      const data = {
+        ...minimalCreature,
+        abilities: { str: 1, dex: 4, con: 0, int: -1, wis: 2, cha: 0 }
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.abilities).toEqual({ str: 1, dex: 4, con: 0, int: -1, wis: 2, cha: 0 });
+      }
+    });
+
+    it('omits abilities entirely when the field is absent', () => {
+      const result = validateCreature(minimalCreature, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.abilities).toBeUndefined();
+    });
+
+    it('rejects when any of the six keys is missing', () => {
+      const data = { ...minimalCreature, abilities: { str: 1, dex: 4, con: 0, int: -1, wis: 2 } };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'abilities.cha')).toBe(true);
+    });
+
+    it('rejects a non-number ability mod', () => {
+      const data = {
+        ...minimalCreature,
+        abilities: { str: 1, dex: 4, con: 0, int: -1, wis: 2, cha: '+0' }
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'abilities.cha')).toBe(true);
+    });
+  });
+
+  describe('languages', () => {
+    it('accepts a languages block with details', () => {
+      const data = {
+        ...minimalCreature,
+        languages: { value: ['common', 'goblin'], details: 'telepathy 100 feet' }
+      };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.languages).toEqual({
+          value: ['common', 'goblin'],
+          details: 'telepathy 100 feet'
+        });
+      }
+    });
+
+    it('accepts a languages block without details', () => {
+      const data = { ...minimalCreature, languages: { value: ['draconic'] } };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.languages).toEqual({ value: ['draconic'] });
+      }
+    });
+
+    it('omits languages when the field is absent', () => {
+      const result = validateCreature(minimalCreature, 0);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.languages).toBeUndefined();
+    });
+
+    it('rejects a languages block missing value', () => {
+      const data = { ...minimalCreature, languages: { details: 'telepathy' } };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'languages.value')).toBe(true);
+    });
+
+    it('rejects a non-string value entry', () => {
+      const data = { ...minimalCreature, languages: { value: ['common', 7] } };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'languages.value')).toBe(true);
+    });
+
+    it('rejects non-string details', () => {
+      const data = { ...minimalCreature, languages: { value: ['common'], details: 42 } };
+      const result = validateCreature(data, 0);
+      expect(result.ok).toBe(false);
+      expect(result.issues.some((i) => i.path === 'languages.details')).toBe(true);
+    });
+  });
 });

--- a/src/lib/yaml/creature-validator.ts
+++ b/src/lib/yaml/creature-validator.ts
@@ -1,12 +1,17 @@
 import type {
   Ability,
+  AbilityScores,
   ActionCost,
   Attack,
   AttackType,
   Creature,
+  CreatureImmunity,
   CreatureRarity,
   CreatureSize,
   DamageComponent,
+  Languages,
+  Sense,
+  SenseAcuity,
   SpellcastingBlock,
   SpellcastingType,
   SpellFrequency,
@@ -21,6 +26,8 @@ const ATTACK_TYPES: ReadonlySet<AttackType> = new Set(['melee', 'ranged']);
 const ACTION_COSTS = new Set<ActionCost>([1, 2, 3, 'free', 'reaction']);
 const TRADITIONS: ReadonlySet<SpellTradition> = new Set(['arcane', 'divine', 'occult', 'primal']);
 const SPELLCASTING_TYPES: ReadonlySet<SpellcastingType> = new Set(['prepared', 'spontaneous', 'innate', 'focus']);
+const SENSE_ACUITIES: ReadonlySet<SenseAcuity> = new Set(['precise', 'imprecise', 'vague']);
+const ABILITY_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'] as const;
 
 export type ParseOutcome<T> =
   | { ok: true; value: T; issues: ValidationIssue[] }
@@ -404,6 +411,82 @@ function validateSpellcastingBlock(bag: IssueBag, path: string, raw: unknown): S
   return block;
 }
 
+function validateCreatureImmunity(bag: IssueBag, path: string, raw: unknown): CreatureImmunity | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const type = requireString(bag, `${path}.type`, obj.type);
+  if (type === null) ok = false;
+  let exceptions: string[] | undefined;
+  if (obj.exceptions !== undefined) {
+    const e = requireStringArray(bag, `${path}.exceptions`, obj.exceptions);
+    if (e === null) ok = false;
+    else exceptions = e;
+  }
+  if (!ok || type === null) return null;
+  const out: CreatureImmunity = { type };
+  if (exceptions !== undefined) out.exceptions = exceptions;
+  return out;
+}
+
+function validateSense(bag: IssueBag, path: string, raw: unknown): Sense | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const type = requireString(bag, `${path}.type`, obj.type);
+  if (type === null) ok = false;
+  let acuity: SenseAcuity | undefined;
+  if (obj.acuity !== undefined) {
+    if (typeof obj.acuity !== 'string' || !SENSE_ACUITIES.has(obj.acuity as SenseAcuity)) {
+      bag.add(`${path}.acuity`, 'must be one of: precise, imprecise, vague');
+      ok = false;
+    } else acuity = obj.acuity as SenseAcuity;
+  }
+  let range: number | undefined;
+  if (obj.range !== undefined) {
+    const n = requireNumber(bag, `${path}.range`, obj.range);
+    if (n === null) ok = false;
+    else range = n;
+  }
+  if (!ok || type === null) return null;
+  const out: Sense = { type };
+  if (acuity !== undefined) out.acuity = acuity;
+  if (range !== undefined) out.range = range;
+  return out;
+}
+
+function validateAbilityScores(bag: IssueBag, path: string, raw: unknown): AbilityScores | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  const out = {} as Record<string, number>;
+  let ok = true;
+  for (const key of ABILITY_KEYS) {
+    const n = requireNumber(bag, `${path}.${key}`, obj[key]);
+    if (n === null) ok = false;
+    else out[key] = n;
+  }
+  if (!ok) return null;
+  return out as unknown as AbilityScores;
+}
+
+function validateLanguages(bag: IssueBag, path: string, raw: unknown): Languages | null {
+  const obj = requireObject(bag, path, raw);
+  if (!obj) return null;
+  let ok = true;
+  const value = requireStringArray(bag, `${path}.value`, obj.value);
+  if (value === null) ok = false;
+  let details: string | undefined;
+  if (obj.details !== undefined) {
+    const s = requireString(bag, `${path}.details`, obj.details);
+    if (s === null) ok = false;
+    else details = s;
+  }
+  if (!ok || value === null) return null;
+  const out: Languages = { value };
+  if (details !== undefined) out.details = details;
+  return out;
+}
+
 function validateAbilityArray(bag: IssueBag, path: string, raw: unknown): Ability[] | null {
   const arr = requireArray(bag, path, raw);
   if (arr === null) return null;
@@ -459,8 +542,20 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
   const hp = requireNumber(bag, 'hp', obj.hp);
   if (hp === null) ok = false;
 
-  const immunities = requireStringArray(bag, 'immunities', obj.immunities);
-  if (immunities === null) ok = false;
+  const immunitiesRaw = requireArray(bag, 'immunities', obj.immunities);
+  const immunities: CreatureImmunity[] = [];
+  let immunitiesOk: boolean = immunitiesRaw !== null;
+  if (immunitiesRaw === null) {
+    ok = false;
+  } else {
+    for (let i = 0; i < immunitiesRaw.length; i++) {
+      const im = validateCreatureImmunity(bag, `immunities[${i}]`, immunitiesRaw[i]);
+      if (im === null) {
+        ok = false;
+        immunitiesOk = false;
+      } else immunities.push(im);
+    }
+  }
 
   const resistancesRaw = requireArray(bag, 'resistances', obj.resistances);
   const resistances: { type: string; value: number }[] = [];
@@ -530,6 +625,37 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
     else notes = s;
   }
 
+  let senses: Sense[] | undefined;
+  if (obj.senses !== undefined) {
+    const arr = requireArray(bag, 'senses', obj.senses);
+    if (arr === null) ok = false;
+    else {
+      const out: Sense[] = [];
+      let allOk = true;
+      for (let i = 0; i < arr.length; i++) {
+        const s = validateSense(bag, `senses[${i}]`, arr[i]);
+        if (s === null) allOk = false;
+        else out.push(s);
+      }
+      if (allOk) senses = out;
+      else ok = false;
+    }
+  }
+
+  let abilities: AbilityScores | undefined;
+  if (obj.abilities !== undefined) {
+    const a = validateAbilityScores(bag, 'abilities', obj.abilities);
+    if (a === null) ok = false;
+    else abilities = a;
+  }
+
+  let languages: Languages | undefined;
+  if (obj.languages !== undefined) {
+    const l = validateLanguages(bag, 'languages', obj.languages);
+    if (l === null) ok = false;
+    else languages = l;
+  }
+
   let spellcasting: SpellcastingBlock[] | undefined;
   if (obj.spellcasting !== undefined) {
     const arr = requireArray(bag, 'spellcasting', obj.spellcasting);
@@ -559,7 +685,7 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
     will === null ||
     perception === null ||
     hp === null ||
-    immunities === null ||
+    !immunitiesOk ||
     speed === null ||
     passive === null ||
     reactive === null ||
@@ -596,7 +722,10 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
     ...(alignment !== undefined ? { alignment } : {}),
     ...(source !== undefined ? { source } : {}),
     ...(notes !== undefined ? { notes } : {}),
-    ...(spellcasting !== undefined ? { spellcasting } : {})
+    ...(spellcasting !== undefined ? { spellcasting } : {}),
+    ...(senses !== undefined ? { senses } : {}),
+    ...(abilities !== undefined ? { abilities } : {}),
+    ...(languages !== undefined ? { languages } : {})
   };
   return { ok: true, value: creature, issues: bag.issues };
 }

--- a/src/lib/yaml/creature-validator.ts
+++ b/src/lib/yaml/creature-validator.ts
@@ -544,16 +544,13 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
 
   const immunitiesRaw = requireArray(bag, 'immunities', obj.immunities);
   const immunities: CreatureImmunity[] = [];
-  let immunitiesOk: boolean = immunitiesRaw !== null;
   if (immunitiesRaw === null) {
     ok = false;
   } else {
     for (let i = 0; i < immunitiesRaw.length; i++) {
       const im = validateCreatureImmunity(bag, `immunities[${i}]`, immunitiesRaw[i]);
-      if (im === null) {
-        ok = false;
-        immunitiesOk = false;
-      } else immunities.push(im);
+      if (im === null) ok = false;
+      else immunities.push(im);
     }
   }
 
@@ -685,7 +682,6 @@ export function validateCreature(raw: unknown, documentIndex: number): ParseOutc
     will === null ||
     perception === null ||
     hp === null ||
-    !immunitiesOk ||
     speed === null ||
     passive === null ||
     reactive === null ||

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,6 +72,7 @@
   } from '$lib/storage/party-members';
   import { createPersistenceController } from '$lib/storage/persistence-controller';
   import { importCreatureYaml, importPartyMemberYaml } from '$lib/yaml';
+  import { importCreatureFoundryJson } from '$lib/foundry';
 
   const conditionOptions = listConditionOptions();
   const conditionGroups = groupConditionsByCategory();
@@ -295,7 +296,7 @@
     runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
   }
 
-  async function handleImportYamlFiles(files: File[]) {
+  async function handleImportCreatureFiles(files: File[]) {
     for (const file of files) {
       let text: string;
       try {
@@ -308,11 +309,14 @@
         continue;
       }
 
+      const isJson = file.name.toLowerCase().endsWith('.json');
       let creatures: Creature[];
       let issues: ReturnType<typeof importCreatureYaml>['issues'];
       let skipped: ReturnType<typeof importCreatureYaml>['skipped'];
       try {
-        ({ creatures, issues, skipped } = importCreatureYaml(text));
+        ({ creatures, issues, skipped } = isJson
+          ? importCreatureFoundryJson(text)
+          : importCreatureYaml(text));
       } catch (err) {
         appendFeedback(
           nextFeedbackId('import-fail'),
@@ -886,7 +890,7 @@
         onAddOneFromBestiary={handleAddOneFromBestiary}
         onRemoveOneFromBestiaryCount={handleRemoveOneFromBestiaryCount}
         onAddManual={handleAddManual}
-        onImportYamlFiles={handleImportYamlFiles}
+        onImportCreatureFiles={handleImportCreatureFiles}
         onRemoveCreature={handleRemoveCreature}
         onAddPartyMemberToEncounter={handleAddPartyMemberToEncounter}
         onRemovePartyMember={handleRemovePartyMember}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -187,6 +187,14 @@
     }
     if (loadResult.ok) {
       storedCreatures = loadResult.creatures;
+      if (loadResult.droppedLegacy > 0) {
+        const n = loadResult.droppedLegacy;
+        appendFeedback(
+          nextFeedbackId('legacy-drop'),
+          `Dropped ${n} creature${n === 1 ? '' : 's'} from a previous version of the schema. Re-import the YAML or JSON to recover ${n === 1 ? 'it' : 'them'}.`,
+          'info'
+        );
+      }
     } else {
       appendFeedback(
         nextFeedbackId('library-load-fail'),
@@ -309,7 +317,17 @@
         continue;
       }
 
-      const isJson = file.name.toLowerCase().endsWith('.json');
+      const lower = file.name.toLowerCase();
+      const isJson = lower.endsWith('.json');
+      const isYaml = lower.endsWith('.yaml') || lower.endsWith('.yml');
+      if (!isJson && !isYaml) {
+        appendFeedback(
+          nextFeedbackId('import-bad-ext'),
+          `"${file.name}": unsupported file type. Use .yaml, .yml, or .json.`
+        );
+        continue;
+      }
+
       let creatures: Creature[];
       let issues: ReturnType<typeof importCreatureYaml>['issues'];
       let skipped: ReturnType<typeof importCreatureYaml>['skipped'];


### PR DESCRIPTION
## Summary

- Adds a new `src/lib/foundry/` module that imports Foundry pf2e NPC JSON files into the bestiary alongside YAML — same `CreatureImportResult` contract, same dedup/persist sink, sniffed by extension at the UI handler.
- Closes three backlog items (`senses`, `ability score modifiers`, `languages`) by adding the Foundry-shaped optional fields to `Creature`. Immunities also migrate from `string[]` to `{ type; exceptions? }[]` for symmetry with resistances and weaknesses.
- End-to-end tested against three real Foundry NPCs copied as fixtures: `air-mephit` (innate spellcaster with resistances + exceptions), `bandit` (NPC-core humanoid), `sea-devil-scout`.

## Schema changes

- `Creature.immunities: string[]` → `CreatureImmunity[]` (shape change). Legacy IndexedDB entries are filtered on read; users re-import.
- New optional fields: `senses?: Sense[]`, `abilities?: AbilityScores`, `languages?: Languages`.
- `PartyMember.immunities?: string[]` is untouched.

See `docs/creature-schema-backlog.md` for what's still open (immunity classification, items/equipment).

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 738/738 pass (35 new tests in `src/lib/foundry/`)
- [x] `npm run audit` — only the pre-existing 3 low-severity advisories in `cookie` via SvelteKit; below the moderate threshold
- [x] `npm run build` — static build succeeds
- [ ] Manual smoke after `npm run dev`:
  - [ ] Open bestiary → "Import…" → select a Foundry NPC JSON (e.g. `pathfinder-bestiary/air-mephit.json`)
  - [ ] Confirm import toast + creature appears with correct AC/HP/saves and a spellcasting block
  - [ ] Re-import same file → "already in library" toast, no duplication
  - [ ] Import an existing YAML from `docs/sample-creatures.yaml` → YAML path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)