### PR TITLE
Migrate pre-#117 combatants to baseSnapshot on load

### DIFF
--- a/src/lib/storage/active-encounter.test.ts
+++ b/src/lib/storage/active-encounter.test.ts
@@ -86,6 +86,88 @@ describe('active encounter storage', () => {
     }
   });
 
+  it('migrates legacy baseStats+level combatants to baseSnapshot on load', async () => {
+    // Regression: pre-#117 encounters stored combatants as
+    // { baseStats: { hp, ac, ... }, level: number, templateAdjustment? }.
+    // The new shape is { baseSnapshot: { level, hp, ac, ... },
+    // templateAdjustment }. Without a migration, computeEncounterXP reads
+    // c.baseSnapshot.level on these legacy combatants and throws
+    // "Cannot read properties of undefined (reading 'level')", which broke
+    // the bestiary list while the lazily-rendered Manage modal still worked.
+    const state = activeEncounter();
+    await saveActiveEncounter(state);
+
+    const { getDb, ACTIVE_ENCOUNTER_STORE } = await import('./db');
+    const db = await (getDb() as Promise<import('idb').IDBPDatabase>);
+    const stored = (await db.get(ACTIVE_ENCOUNTER_STORE, 'current')) as Record<string, unknown>;
+    const combatants = stored.combatants as Record<string, Record<string, unknown>>;
+    for (const c of Object.values(combatants)) {
+      const snap = c.baseSnapshot as Record<string, unknown>;
+      c.baseStats = {
+        hp: snap.hp,
+        ac: snap.ac,
+        fortitude: snap.fortitude,
+        reflex: snap.reflex,
+        will: snap.will,
+        perception: snap.perception,
+        speed: snap.speed,
+        skills: snap.skills
+      };
+      c.level = snap.level;
+      delete c.baseSnapshot;
+    }
+    await db.put(ACTIVE_ENCOUNTER_STORE, stored, 'current');
+
+    const restored = await loadActiveEncounter();
+    expect(restored).not.toBeNull();
+    for (const c of Object.values(restored!.combatants)) {
+      expect(c.baseSnapshot).toBeDefined();
+      expect(c.baseSnapshot.level).toBe(1);
+      expect(c.baseSnapshot.hp).toBe(20);
+      expect(c.baseSnapshot.ac).toBe(16);
+      expect(c.baseSnapshot.fortitude).toBe(7);
+      expect(c.baseSnapshot.reflex).toBe(8);
+      expect(c.baseSnapshot.will).toBe(5);
+      expect(c.baseSnapshot.perception).toBe(6);
+      expect(c.baseSnapshot.speed).toBe(25);
+    }
+
+    // The original symptom: computeEncounterXP threw on legacy combatants.
+    // Importing here (rather than top-of-file) keeps the dependency local
+    // to the regression test.
+    const { computeEncounterXP } = await import('../../domain');
+    expect(() => computeEncounterXP(restored!)).not.toThrow();
+  });
+
+  it('resets templateAdjustment to normal when migrating legacy combatants', async () => {
+    // Old baseStats values were already post-adjustment (applyEliteWeak ran
+    // before the snapshot was taken). Preserving templateAdjustment="elite"
+    // would make getAdjustedView add +2 a second time. Force adjustment to
+    // 'normal' on migrate so what the user saw before still matches.
+    const state = activeEncounter();
+    await saveActiveEncounter(state);
+
+    const { getDb, ACTIVE_ENCOUNTER_STORE } = await import('./db');
+    const db = await (getDb() as Promise<import('idb').IDBPDatabase>);
+    const stored = (await db.get(ACTIVE_ENCOUNTER_STORE, 'current')) as Record<string, unknown>;
+    const combatants = stored.combatants as Record<string, Record<string, unknown>>;
+    for (const c of Object.values(combatants)) {
+      const snap = c.baseSnapshot as Record<string, unknown>;
+      c.baseStats = { ...snap };
+      delete (c.baseStats as Record<string, unknown>).level;
+      c.level = snap.level;
+      c.templateAdjustment = 'elite';
+      delete c.baseSnapshot;
+    }
+    await db.put(ACTIVE_ENCOUNTER_STORE, stored, 'current');
+
+    const restored = await loadActiveEncounter();
+    expect(restored).not.toBeNull();
+    for (const c of Object.values(restored!.combatants)) {
+      expect(c.templateAdjustment).toBe('normal');
+    }
+  });
+
 });
 
 describe('active encounter storage when indexedDB is unavailable', () => {

--- a/src/lib/storage/active-encounter.ts
+++ b/src/lib/storage/active-encounter.ts
@@ -1,4 +1,4 @@
-import type { EncounterState } from '../../domain/types';
+import type { CreatureSnapshot, EncounterState } from '../../domain/types';
 import { ACTIVE_ENCOUNTER_STORE, getDb } from './db';
 
 const KEY = 'current';
@@ -19,11 +19,49 @@ export async function loadActiveEncounter(): Promise<EncounterState | null> {
   if (stored.phase === 'COMPLETED') return null;
   // Back-compat: rename creatureId -> sourceId on combatants saved under DB
   // versions <= 3. Keeps existing active encounters loadable after the rename.
+  // Also: migrate pre-#117 combatants that stored baseStats + top-level level
+  // into the new baseSnapshot shape. Old baseStats values were already
+  // post-adjusted by applyEliteWeak before persistence, so reset
+  // templateAdjustment to 'normal' to avoid double-applying elite/weak.
   if (stored.combatants) {
     for (const c of Object.values(stored.combatants)) {
-      const legacy = c as unknown as { sourceId?: string; creatureId?: string };
+      const legacy = c as unknown as {
+        sourceId?: string;
+        creatureId?: string;
+        baseSnapshot?: CreatureSnapshot;
+        baseStats?: {
+          hp: number;
+          ac: number;
+          fortitude: number;
+          reflex: number;
+          will: number;
+          perception: number;
+          speed: number;
+          skills?: Record<string, number>;
+        };
+        level?: number;
+        templateAdjustment?: 'normal' | 'elite' | 'weak';
+      };
       if (legacy.sourceId === undefined && legacy.creatureId !== undefined) {
         legacy.sourceId = legacy.creatureId;
+      }
+      if (
+        legacy.baseSnapshot === undefined &&
+        legacy.baseStats !== undefined &&
+        typeof legacy.level === 'number'
+      ) {
+        legacy.baseSnapshot = {
+          level: legacy.level,
+          hp: legacy.baseStats.hp,
+          ac: legacy.baseStats.ac,
+          fortitude: legacy.baseStats.fortitude,
+          reflex: legacy.baseStats.reflex,
+          will: legacy.baseStats.will,
+          perception: legacy.baseStats.perception,
+          speed: legacy.baseStats.speed,
+          skills: legacy.baseStats.skills ?? {}
+        };
+        legacy.templateAdjustment = 'normal';
       }
     }
   }


### PR DESCRIPTION
## Summary
- `loadActiveEncounter` already migrated the `creatureId → sourceId` rename, but the #117 `baseStats + level → baseSnapshot` schema bump was never wired up. Restoring a pre-#117 encounter left combatants without `c.baseSnapshot`, and `computeEncounterXP` then threw `Cannot read properties of undefined (reading 'level')` on `c.baseSnapshot.level` (and `partyMembers.map((c) => c.baseSnapshot.level)`). The throw broke the synchronous render of the bestiary list while the lazily-rendered `LibraryManageModal` still worked after a user click — matching the reported symptom of imported creatures being visible in Manage but not in the list to be added.
- Migration synthesises `baseSnapshot` from `{ level, ...baseStats }` and resets `templateAdjustment` to `'normal'` to avoid double-applying elite/weak (old `baseStats` were already post-adjusted by `applyEliteWeak` before being persisted).
- Two regression tests plant legacy-shape combatants directly in IDB to lock in both the migration and the follow-on assertion that `computeEncounterXP` no longer throws on the restored state.

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:run` — 862 passed, 1 skipped (pre-existing)
- [x] `npm run audit` — only 3 pre-existing low-severity advisories (gate fails at moderate+)
- [x] `npm run build` — static build succeeds
- [x] New regression tests fail without the migration and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)