### PR TITLE
Make spellcasting DC values readable in details panel

### DIFF
--- a/src/components/details/SpellcastingBlockView.svelte
+++ b/src/components/details/SpellcastingBlockView.svelte
@@ -39,14 +39,12 @@
   <header class="block__head">
     <div class="block__title">{view.header.name}</div>
     <div class="block__meta">
-      <span>{view.header.tradition}</span>
-      <span>·</span>
-      <span>{view.header.type}</span>
-      <span>·</span>
-      <span class:modified={dcBonus !== 0} title={dcTooltip}>DC {view.header.dc + dcBonus}</span>
+      <span class="block__tag">{view.header.tradition}</span>
+      <span class="block__sep">·</span>
+      <span class="block__tag">{view.header.type}</span>
+      <span class="block__stat" class:modified={dcBonus !== 0} title={dcTooltip}>DC {view.header.dc + dcBonus}</span>
       {#if view.header.attackModifier !== undefined}
-        <span>·</span>
-        <span class:modified={attackBonus !== 0} title={attackTooltip}>attack {formatModifier(view.header.attackModifier + attackBonus)}</span>
+        <span class="block__stat" class:modified={attackBonus !== 0} title={attackTooltip}>atk {formatModifier(view.header.attackModifier + attackBonus)}</span>
       {/if}
     </div>
   </header>
@@ -246,11 +244,30 @@
 
   .block__meta {
     display: flex;
+    flex-wrap: wrap;
     gap: 6px;
+    align-items: baseline;
     color: var(--color-ink-soft);
     font-family: var(--font-sans);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
+  }
+
+  .block__tag {
     text-transform: lowercase;
+  }
+
+  .block__sep {
+    color: var(--color-ink-mute);
+  }
+
+  .block__stat {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-ink);
+    background: var(--color-panel-2);
+    border: var(--border-thin);
+    border-radius: 4px;
+    padding: 1px 6px;
   }
 
   .ranks {
@@ -271,10 +288,10 @@
   }
 
   .rank__label {
-    min-width: 36px;
+    min-width: 40px;
     color: var(--color-ink-soft);
     font-family: var(--font-sans);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
     font-weight: 700;
     letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
@@ -287,9 +304,9 @@
   }
 
   .rank__count {
-    color: var(--color-ink-mute);
+    color: var(--color-ink-soft);
     font-family: var(--font-mono);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
   }
 
   .pip {
@@ -354,7 +371,7 @@
   .innate-marker {
     color: var(--color-ink-soft);
     font-family: var(--font-sans);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
     text-transform: uppercase;
     letter-spacing: var(--tracking-wide);
   }
@@ -367,7 +384,7 @@
   .cantrips__label {
     color: var(--color-ink-soft);
     font-family: var(--font-sans);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
     font-weight: 700;
     letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
@@ -376,13 +393,12 @@
   .muted {
     color: var(--color-ink-mute);
     font-family: var(--font-mono);
-    font-size: var(--text-xs);
+    font-size: var(--text-sm);
   }
 
-  .block__meta .modified {
+  .block__stat.modified {
     color: var(--effect-cond);
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-underline-offset: 2px;
+    border-color: var(--effect-cond);
+    background: var(--effect-cond-soft);
   }
 </style>


### PR DESCRIPTION
## Summary
- Spellcasting block header was rendering `DC 20` / `attack +12` at 9px in muted color *with `text-transform: lowercase`*, so the most-glanced numbers showed as a tiny dim `dc 20 · attack +12`.
- DC and attack are now monospace chips matching the AbilityCard save-chip style (panel-2 background, thin border, primary ink). Tradition/type stay as small lowercase tags as before.
- Bumped rank labels, slot counts, cantrips/innate labels, and the `(1st)`-style level suffix from `--text-xs` (9px) to `--text-sm` (11px) for general scanability.
- `class:modified` still indicates condition-driven DC/attack changes — now via chip color (effect-cond ink, effect-cond-soft fill) instead of a dotted underline that was easy to miss at 9px.

Before / after, on the Aasimar Redeemer's innate and focus blocks:

| | Header text size | DC presentation |
| --- | --- | --- |
| Before | 9px lowercase muted (`dc 20 · attack +12`) | inline text |
| After | 11px (tags) + 11px mono chips | bordered chip, primary ink |

## Test plan
- [x] `npm run check`
- [x] `npm run test:run` (862 passed / 1 skipped, no changes to test logic)
- [x] `npm run audit`
- [x] `npm run build`
- [x] Manual: imported `aasimar-redeemer.json` via Foundry importer, added combatant, opened details — both spellcasting blocks ("Divine Innate Spells", "Champion Devotion Spells") now show `DC 20` and `atk +12` as clearly legible chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)