### PR TITLE
Add coverage tooling + tests for 5 untested components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,7 +275,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -324,9 +323,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1213,7 +1234,6 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -1256,7 +1276,6 @@
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1431,7 +1450,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -1576,7 +1594,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2564,7 +2581,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2839,7 +2855,6 @@
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3007,7 +3022,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3028,7 +3042,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3043,7 +3056,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3142,7 +3154,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -3314,7 +3325,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
+        "@vitest/coverage-v8": "^4.1.6",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "svelte": "^5.38.0",
@@ -103,6 +104,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -113,6 +124,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -121,6 +148,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -224,6 +275,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -272,31 +324,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1183,6 +1213,7 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -1225,6 +1256,7 @@
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1393,17 +1425,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1412,13 +1476,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1439,9 +1503,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1452,13 +1516,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1466,14 +1530,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1482,9 +1546,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1492,13 +1556,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1512,6 +1576,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1561,6 +1626,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -1884,6 +1968,16 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1896,6 +1990,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/idb": {
       "version": "8.0.3",
@@ -1928,6 +2029,45 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {
@@ -2296,6 +2436,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -2396,6 +2564,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2572,6 +2741,19 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
@@ -2638,12 +2820,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/svelte": {
       "version": "5.55.5",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2811,6 +3007,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2831,6 +3028,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2845,6 +3043,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2938,19 +3137,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2978,12 +3178,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3114,6 +3314,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.domain.json --noEmit",
     "test:run": "vitest run",
+    "coverage": "vitest run --coverage",
     "yaml:check": "tsx scripts/validate-creature-yaml.ts",
     "audit": "npm audit --audit-level=moderate",
     "audit:low": "npm audit --audit-level=low"
@@ -22,6 +23,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
+    "@vitest/coverage-v8": "^4.1.6",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "svelte": "^5.38.0",

--- a/src/components/EncounterDifficultyMeter.test.ts
+++ b/src/components/EncounterDifficultyMeter.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { EncounterXPSummary } from '../domain';
+import EncounterDifficultyMeter from './EncounterDifficultyMeter.svelte';
+
+function summary(overrides: Partial<EncounterXPSummary> = {}): EncounterXPSummary {
+  return {
+    partyLevel: 3,
+    partySize: 4,
+    enemyCount: 2,
+    totalXP: 80,
+    difficulty: 'Moderate',
+    thresholds: { trivial: 40, low: 60, moderate: 80, severe: 120, extreme: 160 },
+    xpAward: 80,
+    hasOutOfRange: false,
+    contributions: [],
+    ...overrides
+  };
+}
+
+describe('EncounterDifficultyMeter — visibility gate', () => {
+  test('hides entirely when there are no enemies', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary({ enemyCount: 0, difficulty: null }) }
+    });
+    expect(container.querySelector('section.meter')).toBeNull();
+  });
+
+  test('shows the empty hint when there are enemies but no party level', () => {
+    render(EncounterDifficultyMeter, {
+      props: {
+        summary: summary({
+          partyLevel: null,
+          thresholds: null,
+          difficulty: null,
+          xpAward: 0,
+          totalXP: 40,
+          enemyCount: 1
+        })
+      }
+    });
+    expect(
+      screen.getByText('Add party members to compute encounter difficulty.')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('EncounterDifficultyMeter — main render', () => {
+  test('renders the difficulty label in the difficulty slot', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary({ difficulty: 'Severe', totalXP: 120, xpAward: 120 }) }
+    });
+    expect(container.querySelector('.meter__difficulty')).toHaveTextContent('Severe');
+  });
+
+  test('renders the total budget XP and awarded XP in their respective slots', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary({ totalXP: 95, xpAward: 60 }) }
+    });
+    const numbers = container.querySelectorAll('.meter__number .meter__value');
+    // Two number slots: Budget (totalXP) and Awarded to party (xpAward), in that order.
+    expect(numbers[0]).toHaveTextContent('95');
+    expect(numbers[1]).toHaveTextContent('60');
+  });
+
+  test('renders the party meta line with level and size', () => {
+    render(EncounterDifficultyMeter, {
+      props: { summary: summary({ partyLevel: 5, partySize: 4 }) }
+    });
+    expect(screen.getByText('Party L5')).toBeInTheDocument();
+    expect(screen.getByText('4 PC')).toBeInTheDocument();
+  });
+
+  test('renders one band per difficulty tier', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary() }
+    });
+    expect(container.querySelectorAll('.meter__zone').length).toBe(5);
+  });
+
+  test('marks the current band with the --current modifier class', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary({ difficulty: 'Severe', totalXP: 120 }) }
+    });
+    const current = container.querySelector('.meter__zone--current');
+    expect(current).not.toBeNull();
+    expect(current?.classList.contains('meter__zone--severe')).toBe(true);
+  });
+});
+
+describe('EncounterDifficultyMeter — out-of-range and overflow', () => {
+  test('appends * to the difficulty label and renders the note when hasOutOfRange', () => {
+    const { container } = render(EncounterDifficultyMeter, {
+      props: { summary: summary({ hasOutOfRange: true, difficulty: 'Moderate' }) }
+    });
+    expect(container.querySelector('.meter__difficulty')).toHaveTextContent('Moderate*');
+    expect(screen.getByText(/clamped to 160/i)).toBeInTheDocument();
+  });
+
+  test('omits the out-of-range note when hasOutOfRange is false', () => {
+    render(EncounterDifficultyMeter, {
+      props: { summary: summary({ hasOutOfRange: false }) }
+    });
+    expect(screen.queryByText(/clamped to 160/i)).not.toBeInTheDocument();
+  });
+
+  test('shows totalXP + "+" suffix when total exceeds the extreme*1.25 ceiling', () => {
+    render(EncounterDifficultyMeter, {
+      props: {
+        summary: summary({
+          totalXP: 300,
+          difficulty: 'Extreme',
+          thresholds: { trivial: 40, low: 60, moderate: 80, severe: 120, extreme: 160 }
+        })
+      }
+    });
+    expect(screen.getByText('300+')).toBeInTheDocument();
+  });
+});

--- a/src/components/InlineNumberEdit.test.ts
+++ b/src/components/InlineNumberEdit.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import InlineNumberEdit from './InlineNumberEdit.svelte';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    value: 12,
+    ariaLabel: 'Edit HP',
+    onCommit: vi.fn(),
+    ...overrides
+  };
+}
+
+async function startEditing(displayName = 'Edit HP'): Promise<HTMLInputElement> {
+  screen.getByRole('button', { name: displayName }).click();
+  await tick();
+  return screen.getByRole('textbox', { name: 'Edit HP' }) as HTMLInputElement;
+}
+
+function inputGone(): boolean {
+  return screen.queryByRole('textbox', { name: 'Edit HP' }) === null;
+}
+
+describe('InlineNumberEdit display button', () => {
+  test('renders the numeric value as a button labelled by ariaLabel', () => {
+    render(InlineNumberEdit, { props: baseProps({ value: 17 }) });
+    const button = screen.getByRole('button', { name: 'Edit HP' });
+    expect(button).toHaveTextContent('17');
+  });
+
+  test('uses displayAriaLabel for the display button when provided', () => {
+    render(InlineNumberEdit, {
+      props: baseProps({ ariaLabel: 'Edit HP', displayAriaLabel: 'Current HP, click to edit' })
+    });
+    expect(
+      screen.getByRole('button', { name: 'Current HP, click to edit' })
+    ).toBeInTheDocument();
+  });
+
+  test('renders emptyDisplay text when value is 0 and emptyDisplay is provided', () => {
+    render(InlineNumberEdit, { props: baseProps({ value: 0, emptyDisplay: '—' }) });
+    expect(screen.getByRole('button', { name: 'Edit HP' })).toHaveTextContent('—');
+  });
+
+  test('renders "0" when value is 0 and emptyDisplay is not provided', () => {
+    render(InlineNumberEdit, { props: baseProps({ value: 0 }) });
+    expect(screen.getByRole('button', { name: 'Edit HP' })).toHaveTextContent('0');
+  });
+});
+
+describe('InlineNumberEdit edit mode transitions', () => {
+  test('clicking the display switches to an input seeded with the current value', async () => {
+    render(InlineNumberEdit, { props: baseProps({ value: 42 }) });
+    const input = await startEditing();
+    expect(input.value).toBe('42');
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+  });
+
+  test('Escape cancels editing without calling onCommit', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '99' } });
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(inputGone()).toBe(true);
+    expect(screen.getByRole('button', { name: 'Edit HP' })).toHaveTextContent('12');
+  });
+
+  test('blur cancels editing without calling onCommit (unlike NotesEditor)', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '99' } });
+    await fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(inputGone()).toBe(true);
+  });
+
+  test('empty buffer + Enter cancels (parses as kind=cancel)', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(inputGone()).toBe(true);
+  });
+});
+
+describe('InlineNumberEdit commit', () => {
+  test('Enter with a plain integer commits a "set" parsed edit', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '25' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'set', n: 25 });
+  });
+
+  test('Enter with +N commits an "add" parsed edit', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '+3' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'add', n: 3 });
+  });
+
+  test('Enter with -N commits a "sub" parsed edit', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '-5' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'sub', n: 5 });
+  });
+
+  test('a successful commit leaves the display showing the unchanged value (parent owns updates)', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ value: 12, onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: '+5' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(inputGone()).toBe(true);
+    expect(screen.getByRole('button', { name: 'Edit HP' })).toHaveTextContent('12');
+  });
+});
+
+describe('InlineNumberEdit invalid input', () => {
+  test('invalid expression keeps editing open and marks the input invalid', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+    await fireEvent.input(input, { target: { value: 'abc' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent(/use 42/);
+  });
+
+  test('correcting an invalid expression then pressing Enter commits successfully', async () => {
+    const onCommit = vi.fn();
+    render(InlineNumberEdit, { props: baseProps({ onCommit }) });
+    const input = await startEditing();
+
+    await fireEvent.input(input, { target: { value: 'abc' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+
+    await fireEvent.input(input, { target: { value: '7' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith({ kind: 'set', n: 7 });
+  });
+});

--- a/src/components/RollBubble.test.ts
+++ b/src/components/RollBubble.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import RollBubble from './RollBubble.svelte';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    x: 100,
+    y: 200,
+    total: '17',
+    detail: '',
+    tone: 'normal' as const,
+    badge: '',
+    ...overrides
+  };
+}
+
+describe('RollBubble', () => {
+  test('renders the total in the status region', () => {
+    render(RollBubble, { props: baseProps({ total: '22' }) });
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('22');
+  });
+
+  test('uses aria-live=polite for screen-reader-friendly announcements', () => {
+    render(RollBubble, { props: baseProps() });
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('positions itself using the x/y props as inline left/top pixels', () => {
+    render(RollBubble, { props: baseProps({ x: 250, y: 80 }) });
+    const status = screen.getByRole('status');
+    expect(status.getAttribute('style')).toContain('left: 250px');
+    expect(status.getAttribute('style')).toContain('top: 80px');
+  });
+
+  test('renders the detail text when provided', () => {
+    render(RollBubble, { props: baseProps({ detail: '1d20+7=17' }) });
+    expect(screen.getByText('1d20+7=17')).toBeInTheDocument();
+  });
+
+  test('omits the detail span when detail is empty', () => {
+    const { container } = render(RollBubble, { props: baseProps({ detail: '' }) });
+    expect(container.querySelector('.bubble__detail')).toBeNull();
+  });
+
+  test('renders the badge text when provided', () => {
+    render(RollBubble, { props: baseProps({ badge: 'STRIKE' }) });
+    expect(screen.getByText('STRIKE')).toBeInTheDocument();
+  });
+
+  test('omits the badge span when badge is empty', () => {
+    const { container } = render(RollBubble, { props: baseProps({ badge: '' }) });
+    expect(container.querySelector('.bubble__badge')).toBeNull();
+  });
+
+  test('applies a tone-specific modifier class', () => {
+    const { container } = render(RollBubble, { props: baseProps({ tone: 'crit' }) });
+    expect(container.querySelector('.bubble--crit')).not.toBeNull();
+  });
+
+  test('applies fumble tone class', () => {
+    const { container } = render(RollBubble, { props: baseProps({ tone: 'fumble' }) });
+    expect(container.querySelector('.bubble--fumble')).not.toBeNull();
+  });
+
+  test('applies damage tone class', () => {
+    const { container } = render(RollBubble, { props: baseProps({ tone: 'damage' }) });
+    expect(container.querySelector('.bubble--damage')).not.toBeNull();
+  });
+});

--- a/src/components/SetupPanel.test.ts
+++ b/src/components/SetupPanel.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import SetupPanel from './SetupPanel.svelte';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    canStart: false,
+    onAddManual: vi.fn(),
+    onStart: vi.fn(),
+    onReset: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('SetupPanel — Start Encounter button', () => {
+  test('Start is disabled when canStart=false', () => {
+    render(SetupPanel, { props: baseProps({ canStart: false }) });
+    expect(screen.getByRole('button', { name: 'Start Encounter' })).toBeDisabled();
+  });
+
+  test('Start is enabled and calls onStart when canStart=true', async () => {
+    const onStart = vi.fn();
+    render(SetupPanel, { props: baseProps({ canStart: true, onStart }) });
+    const button = screen.getByRole('button', { name: 'Start Encounter' });
+    expect(button).not.toBeDisabled();
+    await fireEvent.click(button);
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  test('Reset Local button calls onReset', async () => {
+    const onReset = vi.fn();
+    render(SetupPanel, { props: baseProps({ onReset }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Reset Local' }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SetupPanel — Custom Combatant form', () => {
+  test('submitting the form with defaults calls onAddManual with the seeded values', async () => {
+    const onAddManual = vi.fn();
+    const { container } = render(SetupPanel, { props: baseProps({ onAddManual }) });
+    const form = container.querySelector('form.manual-form') as HTMLFormElement;
+    await fireEvent.submit(form);
+    expect(onAddManual).toHaveBeenCalledTimes(1);
+    expect(onAddManual).toHaveBeenCalledWith({
+      name: 'Goblin Warrior',
+      maxHp: 18,
+      ac: 16,
+      fortitude: 6,
+      reflex: 8,
+      will: 5,
+      perception: 7,
+      speed: 25
+    });
+  });
+
+  test('blank name falls back to "Combatant"', async () => {
+    const onAddManual = vi.fn();
+    const { container } = render(SetupPanel, { props: baseProps({ onAddManual }) });
+    const nameInput = screen.getByLabelText(/^Name/) as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: '   ' } });
+
+    const form = container.querySelector('form.manual-form') as HTMLFormElement;
+    await fireEvent.submit(form);
+
+    expect(onAddManual).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Combatant' })
+    );
+  });
+
+  test('trimmed name is passed through', async () => {
+    const onAddManual = vi.fn();
+    const { container } = render(SetupPanel, { props: baseProps({ onAddManual }) });
+    const nameInput = screen.getByLabelText(/^Name/) as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: '  Cave Wolf  ' } });
+
+    await fireEvent.submit(container.querySelector('form.manual-form') as HTMLFormElement);
+
+    expect(onAddManual).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Cave Wolf' })
+    );
+  });
+
+  test('non-finite numeric inputs fall back to their per-field defaults', async () => {
+    // Svelte binds numeric inputs as NaN when the field is cleared. numberOrDefault
+    // is the guard that prevents NaN from leaking into the payload.
+    const onAddManual = vi.fn();
+    const { container } = render(SetupPanel, { props: baseProps({ onAddManual }) });
+
+    const hpInput = screen.getByLabelText(/^HP/) as HTMLInputElement;
+    const acInput = screen.getByLabelText(/^AC/) as HTMLInputElement;
+    await fireEvent.input(hpInput, { target: { value: '' } });
+    await fireEvent.input(acInput, { target: { value: '' } });
+
+    await fireEvent.submit(container.querySelector('form.manual-form') as HTMLFormElement);
+
+    expect(onAddManual).toHaveBeenCalledWith(
+      expect.objectContaining({ maxHp: 1, ac: 10 })
+    );
+  });
+
+  test('truncates fractional inputs (e.g. 18.7 → 18)', async () => {
+    const onAddManual = vi.fn();
+    const { container } = render(SetupPanel, { props: baseProps({ onAddManual }) });
+
+    const hpInput = screen.getByLabelText(/^HP/) as HTMLInputElement;
+    await fireEvent.input(hpInput, { target: { value: '18.7' } });
+
+    await fireEvent.submit(container.querySelector('form.manual-form') as HTMLFormElement);
+
+    expect(onAddManual).toHaveBeenCalledWith(
+      expect.objectContaining({ maxHp: 18 })
+    );
+  });
+});

--- a/src/components/TopBar.test.ts
+++ b/src/components/TopBar.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TopBar from './TopBar.svelte';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Goblin Ambush',
+    phase: 'PREPARING' as const,
+    round: 0,
+    activeName: undefined,
+    ...overrides
+  };
+}
+
+describe('TopBar', () => {
+  test('renders the encounter name as the h1', () => {
+    render(TopBar, { props: baseProps({ name: 'Storm at Saggorak' }) });
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Storm at Saggorak');
+  });
+
+  test('renders the phase chip with the phase label', () => {
+    render(TopBar, { props: baseProps({ phase: 'ACTIVE' }) });
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+  });
+
+  test('renders the round number', () => {
+    render(TopBar, { props: baseProps({ phase: 'ACTIVE', round: 3 }) });
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  test('shows "No active turn" when no active combatant', () => {
+    render(TopBar, { props: baseProps({ activeName: undefined }) });
+    expect(screen.getByText('No active turn')).toBeInTheDocument();
+  });
+
+  test('shows the active combatant\'s turn when activeName is provided', () => {
+    render(TopBar, {
+      props: baseProps({ phase: 'ACTIVE', round: 1, activeName: 'Goblin Warrior' })
+    });
+    expect(screen.getByText("Goblin Warrior's turn")).toBeInTheDocument();
+  });
+
+  test('links to /settings', () => {
+    render(TopBar, { props: baseProps() });
+    const link = screen.getByRole('link', { name: 'Settings' });
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
+  test('the status region is labelled for assistive tech', () => {
+    const { container } = render(TopBar, { props: baseProps() });
+    const status = container.querySelector('[aria-label="Encounter status"]');
+    expect(status).not.toBeNull();
+  });
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,2 +1,29 @@
 import '@testing-library/jest-dom/vitest';
 import 'fake-indexeddb/auto';
+
+// JSDOM doesn't implement Element.prototype.animate, but Svelte transitions
+// (fly/fade) call it. Stub it with a no-op Animation-shaped object so
+// components that opt into transitions can render in tests.
+if (typeof Element !== 'undefined' && typeof Element.prototype.animate !== 'function') {
+  Element.prototype.animate = function animate() {
+    return {
+      cancel() {},
+      finish() {},
+      pause() {},
+      play() {},
+      reverse() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return true;
+      },
+      finished: Promise.resolve(),
+      ready: Promise.resolve(),
+      onfinish: null,
+      oncancel: null,
+      currentTime: 0,
+      playState: 'finished',
+      playbackRate: 1
+    } as unknown as Animation;
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,18 @@ export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'jsdom',
-    setupFiles: ['src/test-setup.ts']
+    setupFiles: ['src/test-setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,svelte}'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.test.svelte',
+        'src/test-setup.ts',
+        'src/app.d.ts',
+        'src/domain/test-support.ts'
+      ]
+    }
   }
 });


### PR DESCRIPTION
## Summary

This is **Batch A** of a planned 2-3 batch test push, aimed at lifting composite-component coverage from a baseline of ~54%.

- Adds `@vitest/coverage-v8` and an `npm run coverage` script (not gated in `check` — purely diagnostic for now)
- Adds tests for five components that were sitting at 0% (or 33% for `InlineNumberEdit`)
- Shims `Element.prototype.animate` in `test-setup.ts` so Svelte transitions (`fly`/`fade` in `RollBubble`) can render under jsdom

### What got tested

| Component | Before | After | Tests |
|---|---|---|---|
| `InlineNumberEdit` | 33.8% / 30% br | 100% / 90% br | 14 |
| `TopBar` | 0% | (fully covered) | 7 |
| `RollBubble` | 0% | 95.8% / 70% br | 10 |
| `EncounterDifficultyMeter` | 0% | 100% / 78.6% br | 10 |
| `SetupPanel` | 0% | 93.2% / 100% br | 8 |

Tests follow the established patterns in the repo: semantic queries (`getByRole`, `getByText`), behavior-over-implementation, edge cases (blank/whitespace inputs, NaN fallbacks, escape/blur), and accessibility (`aria-live`, `aria-label`).

### Overall coverage impact

| Layer | Before | After |
|---|---|---|
| Statements | 68.19% | 72.09% |
| Branches | 66.22% | 67.63% |
| Functions | 63.24% | 67.16% |
| Lines | 72.46% | 75.62% |
| `src/components` (composite) | 53.93% | 62.94% |

### Still 0% (Batch B candidates, not in this PR)

- `LibraryPane.svelte`
- `PartyMemberEditModal.svelte` (576 LOC — pick core flows only)
- `PartySection.svelte`
- `routes/+page.svelte` (most logic is in `$lib/encounter-app.ts`, already 94%)
- Plus `party-member-validator.ts` (73.89%) and a few branch gaps in `SpellcastingBlockView`, `RadialConditionMenu`, `EffectModal`

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run test:run` — 911 passed, 1 skipped (pre-existing legacy skip)
- [x] `npm run audit` — exit 0 (3 pre-existing low-severity `cookie` advisories under threshold)
- [x] `npm run build` — built successfully via static adapter
- [x] `npm run coverage` — reports as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)