### PR TITLE
Tests for LibraryPane, PartySection, SpellcastingBlockView, party-member-validator

### DIFF
--- a/src/components/LibraryPane.test.ts
+++ b/src/components/LibraryPane.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Creature, PartyMember } from '../domain';
+import LibraryPane from './LibraryPane.svelte';
+
+function creature(id: string, name: string): Creature {
+  return {
+    id,
+    name,
+    level: 1,
+    traits: [],
+    size: 'medium',
+    rarity: 'common',
+    ac: 16,
+    fortitude: 5,
+    reflex: 5,
+    will: 5,
+    perception: 5,
+    hp: 20,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    speed: { land: 25 },
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    skills: {},
+    source: 'test',
+    tags: []
+  };
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    canStart: false,
+    creatures: [] as Creature[],
+    partyMembers: [] as PartyMember[],
+    conditionOptions: [],
+    encounterCounts: {},
+    onAddOneFromBestiary: vi.fn(),
+    onRemoveOneFromBestiaryCount: vi.fn(),
+    onAddManual: vi.fn(),
+    onImportCreatureFiles: vi.fn(),
+    onRemoveCreature: vi.fn(),
+    onAddPartyMemberToEncounter: vi.fn(),
+    onRemovePartyMember: vi.fn(),
+    onSavePartyMember: vi.fn(),
+    onImportPartyMemberYamlFiles: vi.fn(),
+    onStart: vi.fn(),
+    onReset: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('LibraryPane', () => {
+  test('renders a labelled aside with the Library heading', () => {
+    render(LibraryPane, { props: baseProps() });
+    expect(screen.getByRole('heading', { level: 2, name: 'Library' })).toBeInTheDocument();
+  });
+
+  test('LibraryManageModal is not rendered initially', () => {
+    render(LibraryPane, { props: baseProps({ creatures: [creature('goblin-1', 'Goblin')] }) });
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+  });
+
+  test('clicking "Manage…" from the bestiary section opens the manage modal', async () => {
+    render(LibraryPane, { props: baseProps({ creatures: [creature('goblin-1', 'Goblin')] }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    // Manage modal shows a "Done" button — the cheapest non-ambiguous handle.
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  });
+
+  test('closing the manage modal hides it again', async () => {
+    render(LibraryPane, { props: baseProps({ creatures: [creature('goblin-1', 'Goblin')] }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+  });
+
+  test('manage modal forwards remove-creature events through onRemoveCreature', async () => {
+    const onRemoveCreature = vi.fn();
+    render(LibraryPane, {
+      props: baseProps({
+        creatures: [creature('goblin-1', 'Goblin Warrior')],
+        onRemoveCreature
+      })
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Goblin Warrior from library' })
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onRemoveCreature).toHaveBeenCalledWith('goblin-1');
+  });
+});

--- a/src/components/PartySection.test.ts
+++ b/src/components/PartySection.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { PartyMember } from '../domain';
+import PartySection from './PartySection.svelte';
+
+function member(id: string, name: string, overrides: Partial<PartyMember> = {}): PartyMember {
+  return {
+    id,
+    name,
+    level: 3,
+    ac: 18,
+    fortitude: 7,
+    reflex: 8,
+    will: 6,
+    perception: 7,
+    hp: 32,
+    persistentEffects: [],
+    companionIds: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    partyMembers: [] as PartyMember[],
+    conditionOptions: [],
+    onAddPartyMemberToEncounter: vi.fn(),
+    onRemovePartyMember: vi.fn(),
+    onSavePartyMember: vi.fn(),
+    onImportPartyMemberYamlFiles: vi.fn(),
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('PartySection — summary + collapse persistence', () => {
+  test('renders the section heading and member count', () => {
+    render(PartySection, {
+      props: baseProps({ partyMembers: [member('a', 'Sun'), member('b', 'Moon')] })
+    });
+    expect(screen.getByText('Party')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  test('section starts open when no collapse preference is stored', () => {
+    const { container } = render(PartySection, { props: baseProps() });
+    expect(container.querySelector('details.party')).toHaveAttribute('open');
+  });
+
+  test('section starts collapsed when the preference is set to "1"', () => {
+    localStorage.setItem('pf2e:partyCollapsed', '1');
+    const { container } = render(PartySection, { props: baseProps() });
+    expect(container.querySelector('details.party')).not.toHaveAttribute('open');
+  });
+
+  test('toggling open persists "0" to localStorage', async () => {
+    localStorage.setItem('pf2e:partyCollapsed', '1');
+    const { container } = render(PartySection, { props: baseProps() });
+    const details = container.querySelector('details.party') as HTMLDetailsElement;
+    details.open = true;
+    await fireEvent(details, new Event('toggle'));
+    expect(localStorage.getItem('pf2e:partyCollapsed')).toBe('0');
+  });
+
+  test('toggling closed persists "1" to localStorage', async () => {
+    const { container } = render(PartySection, { props: baseProps() });
+    const details = container.querySelector('details.party') as HTMLDetailsElement;
+    details.open = false;
+    await fireEvent(details, new Event('toggle'));
+    expect(localStorage.getItem('pf2e:partyCollapsed')).toBe('1');
+  });
+});
+
+describe('PartySection — empty state and members list', () => {
+  test('shows the empty-state hint when no party members are present', () => {
+    const { container } = render(PartySection, { props: baseProps() });
+    const empty = container.querySelector('p.empty');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toMatch(/Click New or Import YAML to add party members/);
+  });
+
+  test('renders one row per member with name, level, and subtext', () => {
+    render(PartySection, {
+      props: baseProps({
+        partyMembers: [
+          member('a', 'Aric', { level: 5, playerName: 'Mateusz', class: 'Wizard' })
+        ]
+      })
+    });
+    expect(screen.getByLabelText('Add Aric to encounter')).toBeInTheDocument();
+    expect(screen.getByLabelText('Level 5')).toBeInTheDocument();
+    expect(screen.getByText('Mateusz · Wizard')).toBeInTheDocument();
+  });
+
+  test('subtext falls back to playerName/class/ancestry when only one is present', () => {
+    render(PartySection, {
+      props: baseProps({
+        partyMembers: [member('a', 'Aric', { ancestry: 'Elf' })]
+      })
+    });
+    expect(screen.getByText('Elf')).toBeInTheDocument();
+  });
+
+  test('clicking a member row calls onAddPartyMemberToEncounter with that member', async () => {
+    const onAdd = vi.fn();
+    const pm = member('a', 'Aric');
+    render(PartySection, {
+      props: baseProps({ partyMembers: [pm], onAddPartyMemberToEncounter: onAdd })
+    });
+    await fireEvent.click(screen.getByLabelText('Add Aric to encounter'));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledWith(pm);
+  });
+
+  test('clicking remove calls onRemovePartyMember with the id', async () => {
+    const onRemove = vi.fn();
+    render(PartySection, {
+      props: baseProps({
+        partyMembers: [member('a', 'Aric')],
+        onRemovePartyMember: onRemove
+      })
+    });
+    await fireEvent.click(screen.getByLabelText('Remove Aric from library'));
+    expect(onRemove).toHaveBeenCalledWith('a');
+  });
+});
+
+describe('PartySection — edit modal', () => {
+  test('clicking New opens the modal in create mode', async () => {
+    render(PartySection, { props: baseProps() });
+    await fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('New Party Member')).toBeInTheDocument();
+  });
+
+  test('clicking edit on an existing member opens the modal in edit mode', async () => {
+    render(PartySection, {
+      props: baseProps({ partyMembers: [member('a', 'Aric')] })
+    });
+    await fireEvent.click(screen.getByLabelText('Edit Aric'));
+    expect(screen.getByText('Edit Party Member')).toBeInTheDocument();
+  });
+});

--- a/src/components/details/SpellcastingBlockView.test.ts
+++ b/src/components/details/SpellcastingBlockView.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { CombatantSpellcasting, SpellListEntry } from '../../domain';
+import SpellcastingBlockView from './SpellcastingBlockView.svelte';
+
+function entry(over: Partial<SpellListEntry> = {}): SpellListEntry {
+  return {
+    spellSlug: over.spellSlug ?? 'magic-missile',
+    name: over.name ?? 'Magic Missile',
+    level: over.level ?? 1,
+    ...over
+  };
+}
+
+function preparedBlock(over: Partial<CombatantSpellcasting> = {}): CombatantSpellcasting {
+  return {
+    blockId: 'wizard-1',
+    name: 'Arcane Spells',
+    tradition: 'arcane',
+    type: 'prepared',
+    dc: 22,
+    attackModifier: 12,
+    slots: { 1: 3, 2: 2 },
+    entries: [
+      entry({ spellSlug: 'magic-missile', name: 'Magic Missile', level: 1, count: 2 }),
+      entry({ spellSlug: 'shield', name: 'Shield', level: 1, isCantrip: true })
+    ],
+    ...over
+  };
+}
+
+function focusBlock(over: Partial<CombatantSpellcasting> = {}): CombatantSpellcasting {
+  return {
+    blockId: 'monk-1',
+    name: 'Focus Spells',
+    tradition: 'occult',
+    type: 'focus',
+    dc: 21,
+    focusPoints: 2,
+    entries: [entry({ spellSlug: 'ki-strike', name: 'Ki Strike', level: 4 })],
+    ...over
+  };
+}
+
+function innateBlock(over: Partial<CombatantSpellcasting> = {}): CombatantSpellcasting {
+  return {
+    blockId: 'dragon-1',
+    name: 'Innate Spells',
+    tradition: 'arcane',
+    type: 'innate',
+    dc: 30,
+    entries: [
+      entry({
+        spellSlug: 'fireball',
+        name: 'Fireball',
+        level: 6,
+        frequency: { type: 'perDay', uses: 3 }
+      }),
+      entry({
+        spellSlug: 'detect-magic',
+        name: 'Detect Magic',
+        level: 1,
+        frequency: { type: 'atWill' }
+      }),
+      entry({
+        spellSlug: 'true-seeing',
+        name: 'True Seeing',
+        level: 6,
+        frequency: { type: 'constant' }
+      })
+    ],
+    ...over
+  };
+}
+
+function baseHandlers() {
+  return {
+    onUseSlot: vi.fn(),
+    onRestoreSlot: vi.fn(),
+    onUseFocus: vi.fn(),
+    onRestoreFocus: vi.fn(),
+    onUseInnate: vi.fn(),
+    onRestoreInnate: vi.fn()
+  };
+}
+
+describe('SpellcastingBlockView — header', () => {
+  test('renders block name, tradition, and type', () => {
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock(), ...baseHandlers() }
+    });
+    expect(screen.getByText('Arcane Spells')).toBeInTheDocument();
+    expect(screen.getByText('arcane')).toBeInTheDocument();
+    expect(screen.getByText('prepared')).toBeInTheDocument();
+  });
+
+  test('shows raw DC when dcBonus is 0', () => {
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock(), ...baseHandlers() }
+    });
+    expect(screen.getByText('DC 22')).toBeInTheDocument();
+  });
+
+  test('adds dcBonus to displayed DC and tags it as modified', () => {
+    const { container } = render(SpellcastingBlockView, {
+      props: { block: preparedBlock(), dcBonus: 2, dcTooltip: '+2 frightened', ...baseHandlers() }
+    });
+    expect(screen.getByText('DC 24')).toBeInTheDocument();
+    expect(container.querySelector('.block__stat.modified')).not.toBeNull();
+  });
+
+  test('renders attack modifier with sign when present', () => {
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock({ attackModifier: 12 }), ...baseHandlers() }
+    });
+    expect(screen.getByText('atk +12')).toBeInTheDocument();
+  });
+
+  test('omits attack modifier line when undefined', () => {
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock({ attackModifier: undefined }), ...baseHandlers() }
+    });
+    expect(screen.queryByText(/^atk /)).not.toBeInTheDocument();
+  });
+});
+
+describe('SpellcastingBlockView — prepared slot pips', () => {
+  test('renders pip groups for each rank with full/empty pips based on usedSlots', () => {
+    const block = preparedBlock({
+      slots: { 1: 3 },
+      usedSlots: { 1: 1 }
+    });
+    const { container } = render(SpellcastingBlockView, {
+      props: { block, ...baseHandlers() }
+    });
+    const full = container.querySelectorAll('.pip--full');
+    const empty = container.querySelectorAll('.pip--empty');
+    expect(full.length).toBe(2);
+    expect(empty.length).toBe(1);
+    expect(screen.getByText('2/3')).toBeInTheDocument();
+  });
+
+  test('clicking a full pip calls onUseSlot with block id and rank', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock({ slots: { 2: 2 } }), ...handlers }
+    });
+    const pip = screen.getAllByRole('button', { name: /Use a 2nd-rank slot/ })[0];
+    await fireEvent.click(pip);
+    expect(handlers.onUseSlot).toHaveBeenCalledWith('wizard-1', 2);
+  });
+
+  test('right-click (contextmenu) on a full pip calls onRestoreSlot', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock({ slots: { 2: 2 } }), ...handlers }
+    });
+    const pip = screen.getAllByRole('button', { name: /Use a 2nd-rank slot/ })[0];
+    await fireEvent.contextMenu(pip);
+    expect(handlers.onRestoreSlot).toHaveBeenCalledWith('wizard-1', 2);
+  });
+
+  test('clicking an empty pip restores the slot', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: preparedBlock({ slots: { 1: 1 }, usedSlots: { 1: 1 } }), ...handlers }
+    });
+    const pip = screen.getByRole('button', { name: /Restore a 1st-rank slot/ });
+    await fireEvent.click(pip);
+    expect(handlers.onRestoreSlot).toHaveBeenCalledWith('wizard-1', 1);
+  });
+
+  test('prepared spells with count > 1 render a ×N suffix', () => {
+    render(SpellcastingBlockView, {
+      props: {
+        block: preparedBlock({
+          slots: { 1: 4 },
+          entries: [entry({ spellSlug: 'mm', name: 'Magic Missile', level: 1, count: 3 })]
+        }),
+        ...baseHandlers()
+      }
+    });
+    expect(screen.getByText('Magic Missile (×3)')).toBeInTheDocument();
+  });
+});
+
+describe('SpellcastingBlockView — focus pool', () => {
+  test('renders focus pip pool and entries', () => {
+    const { container } = render(SpellcastingBlockView, {
+      props: { block: focusBlock({ usedFocusPoints: 1 }), ...baseHandlers() }
+    });
+    expect(container.querySelectorAll('.pip--full').length).toBe(1);
+    expect(container.querySelectorAll('.pip--empty').length).toBe(1);
+    expect(screen.getByText('1/2')).toBeInTheDocument();
+    expect(screen.getByText(/Ki Strike/)).toBeInTheDocument();
+  });
+
+  test('clicking a full focus pip calls onUseFocus', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: focusBlock(), ...handlers }
+    });
+    const pip = screen.getAllByRole('button', { name: /Spend a focus point/ })[0];
+    await fireEvent.click(pip);
+    expect(handlers.onUseFocus).toHaveBeenCalledWith('monk-1');
+  });
+
+  test('clicking an empty focus pip calls onRestoreFocus', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: {
+        block: focusBlock({ focusPoints: 1, usedFocusPoints: 1 }),
+        ...handlers
+      }
+    });
+    const pip = screen.getByRole('button', { name: /Restore a focus point/ });
+    await fireEvent.click(pip);
+    expect(handlers.onRestoreFocus).toHaveBeenCalledWith('monk-1');
+  });
+});
+
+describe('SpellcastingBlockView — innate spells', () => {
+  test('per-day spell renders interactive pip pool with use buttons', () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: innateBlock(), ...handlers }
+    });
+    // Fireball has uses=3 — should render 3 pips and a count.
+    const useButtons = screen.getAllByRole('button', { name: 'Use Fireball' });
+    expect(useButtons.length).toBe(3);
+    expect(screen.getByText('3/3')).toBeInTheDocument();
+  });
+
+  test('at-will spell renders the "at will" marker instead of pips', () => {
+    render(SpellcastingBlockView, {
+      props: { block: innateBlock(), ...baseHandlers() }
+    });
+    expect(screen.getByText('at will')).toBeInTheDocument();
+  });
+
+  test('constant spell renders the "constant" marker', () => {
+    render(SpellcastingBlockView, {
+      props: { block: innateBlock(), ...baseHandlers() }
+    });
+    expect(screen.getByText('constant')).toBeInTheDocument();
+  });
+
+  test('clicking a full per-day pip calls onUseInnate with spell slug', async () => {
+    const handlers = baseHandlers();
+    render(SpellcastingBlockView, {
+      props: { block: innateBlock(), ...handlers }
+    });
+    const pip = screen.getAllByRole('button', { name: 'Use Fireball' })[0];
+    await fireEvent.click(pip);
+    expect(handlers.onUseInnate).toHaveBeenCalledWith('dragon-1', 'fireball');
+  });
+
+  test('clicking an empty per-day pip calls onRestoreInnate', async () => {
+    const handlers = baseHandlers();
+    const block = innateBlock({
+      entries: [
+        entry({
+          spellSlug: 'fireball',
+          name: 'Fireball',
+          level: 6,
+          frequency: { type: 'perDay', uses: 2 }
+        })
+      ],
+      usedEntries: { fireball: 2 }
+    });
+    render(SpellcastingBlockView, { props: { block, ...handlers } });
+    const pip = screen.getAllByRole('button', { name: 'Restore use of Fireball' })[0];
+    await fireEvent.click(pip);
+    expect(handlers.onRestoreInnate).toHaveBeenCalledWith('dragon-1', 'fireball');
+  });
+});
+
+describe('SpellcastingBlockView — cantrips', () => {
+  test('renders the cantrips list when any cantrip is present', () => {
+    render(SpellcastingBlockView, {
+      props: {
+        block: preparedBlock({
+          slots: { 1: 2 },
+          entries: [
+            entry({ spellSlug: 'shield', name: 'Shield', level: 1, isCantrip: true }),
+            entry({ spellSlug: 'electric-arc', name: 'Electric Arc', level: 1, isCantrip: true })
+          ]
+        }),
+        ...baseHandlers()
+      }
+    });
+    expect(screen.getByText(/Cantrips/)).toBeInTheDocument();
+    expect(screen.getByText('Shield')).toBeInTheDocument();
+    expect(screen.getByText('Electric Arc')).toBeInTheDocument();
+  });
+
+  test('omits the cantrips section when there are no cantrips', () => {
+    const { container } = render(SpellcastingBlockView, {
+      props: {
+        block: preparedBlock({ slots: { 1: 1 }, entries: [entry({ level: 1 })] }),
+        ...baseHandlers()
+      }
+    });
+    expect(container.querySelector('.cantrips')).toBeNull();
+  });
+});

--- a/src/lib/yaml/party-member-validator.test.ts
+++ b/src/lib/yaml/party-member-validator.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from 'vitest';
+import { validatePartyMember } from './party-member-validator';
+
+function minimalRaw() {
+  return {
+    id: 'aric',
+    name: 'Aric',
+    level: 3,
+    ac: 18,
+    fortitude: 7,
+    reflex: 8,
+    will: 6,
+    perception: 7,
+    hp: 32,
+    tags: [],
+    companionIds: [],
+    persistentEffects: []
+  };
+}
+
+describe('validatePartyMember — happy path', () => {
+  test('returns ok with the minimal required fields and no issues', () => {
+    const result = validatePartyMember(minimalRaw(), 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.issues).toEqual([]);
+    expect(result.value.id).toBe('aric');
+    expect(result.value.persistentEffects).toEqual([]);
+  });
+
+  test('passes through optional string fields when provided', () => {
+    const result = validatePartyMember(
+      { ...minimalRaw(), playerName: 'Mateusz', ancestry: 'Elf', class: 'Wizard', notes: 'Hi.' },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.playerName).toBe('Mateusz');
+    expect(result.value.ancestry).toBe('Elf');
+    expect(result.value.class).toBe('Wizard');
+    expect(result.value.notes).toBe('Hi.');
+  });
+
+  test('passes through speed and skills records when provided', () => {
+    const result = validatePartyMember(
+      { ...minimalRaw(), speed: { land: 30, fly: 20 }, skills: { arcana: 12 } },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.speed).toEqual({ land: 30, fly: 20 });
+    expect(result.value.skills).toEqual({ arcana: 12 });
+  });
+
+  test('passes through resistances and weaknesses arrays', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        resistances: [{ type: 'cold', value: 5 }],
+        weaknesses: [{ type: 'fire', value: 10 }]
+      },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.resistances).toEqual([{ type: 'cold', value: 5 }]);
+    expect(result.value.weaknesses).toEqual([{ type: 'fire', value: 10 }]);
+  });
+
+  test('passes through immunities when provided', () => {
+    const result = validatePartyMember({ ...minimalRaw(), immunities: ['sleep'] }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.immunities).toEqual(['sleep']);
+  });
+});
+
+describe('validatePartyMember — required-field rejection', () => {
+  test('rejects when the raw value is not an object', () => {
+    const result = validatePartyMember('not an object', 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].message).toContain('must be a mapping');
+    expect(result.issues[0].documentIndex).toBe(0);
+  });
+
+  test('rejects when id is empty', () => {
+    const result = validatePartyMember({ ...minimalRaw(), id: '   ' }, 1);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'id' && i.message.includes('must not be empty')))
+      .toBe(true);
+    expect(result.issues.every((i) => i.documentIndex === 1)).toBe(true);
+  });
+
+  test('rejects when level is below 1', () => {
+    const result = validatePartyMember({ ...minimalRaw(), level: 0 }, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'level' && i.message.includes('>= 1'))).toBe(true);
+  });
+
+  test('rejects when a defensive stat is negative', () => {
+    const result = validatePartyMember({ ...minimalRaw(), ac: -1 }, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'ac' && i.message.includes('>= 0'))).toBe(true);
+  });
+
+  test('rejects when level is not a finite number', () => {
+    const result = validatePartyMember({ ...minimalRaw(), level: 'three' }, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'level')).toBe(true);
+  });
+
+  test('rejects when tags is not a string array', () => {
+    const result = validatePartyMember({ ...minimalRaw(), tags: ['ok', 7] }, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'tags')).toBe(true);
+  });
+
+  test('rejects when persistentEffects is missing', () => {
+    const raw = minimalRaw() as Record<string, unknown>;
+    delete raw.persistentEffects;
+    const result = validatePartyMember(raw, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'persistentEffects')).toBe(true);
+  });
+
+  test('rejects when an optional record field has a non-numeric entry', () => {
+    const result = validatePartyMember({ ...minimalRaw(), speed: { land: 'fast' } }, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'speed.land')).toBe(true);
+  });
+});
+
+describe('validatePartyMember — persistentEffects', () => {
+  test('accepts an effect with value, note, parentInstanceId, and default duration unlimited', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [
+          {
+            instanceId: 'p1',
+            effectId: 'frightened',
+            value: 2,
+            note: 'failed save',
+            parentInstanceId: 'aura-1'
+          }
+        ]
+      },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.persistentEffects[0]).toEqual({
+      instanceId: 'p1',
+      effectId: 'frightened',
+      duration: { type: 'unlimited' },
+      value: 2,
+      note: 'failed save',
+      parentInstanceId: 'aura-1'
+    });
+  });
+
+  test('accepts a rounds duration', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [
+          {
+            instanceId: 'p1',
+            effectId: 'haste',
+            duration: { type: 'rounds', count: 3 }
+          }
+        ]
+      },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.persistentEffects[0].duration).toEqual({ type: 'rounds', count: 3 });
+  });
+
+  test('accepts a conditional duration with description', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [
+          {
+            instanceId: 'p1',
+            effectId: 'blessed',
+            duration: { type: 'conditional', description: 'until you sleep' }
+          }
+        ]
+      },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.persistentEffects[0].duration).toEqual({
+      type: 'conditional',
+      description: 'until you sleep'
+    });
+  });
+
+  test('accepts untilTurnEnd duration with combatantId', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [
+          {
+            instanceId: 'p1',
+            effectId: 'flat-footed',
+            duration: { type: 'untilTurnEnd', combatantId: 'goblin-1' }
+          }
+        ]
+      },
+      0
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.persistentEffects[0].duration).toEqual({
+      type: 'untilTurnEnd',
+      combatantId: 'goblin-1'
+    });
+  });
+
+  test('rejects an unknown duration type', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [
+          { instanceId: 'p1', effectId: 'oddly', duration: { type: 'forever' } }
+        ]
+      },
+      0
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      result.issues.some((i) => i.path === 'persistentEffects[0].duration.type')
+    ).toBe(true);
+  });
+
+  test('rejects when instanceId is missing or empty', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [{ instanceId: '', effectId: 'frightened' }]
+      },
+      0
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      result.issues.some((i) => i.path === 'persistentEffects[0].instanceId')
+    ).toBe(true);
+  });
+
+  test('rejects when a persistent effect entry is not an object', () => {
+    const result = validatePartyMember(
+      { ...minimalRaw(), persistentEffects: ['not an object'] },
+      0
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'persistentEffects[0]')).toBe(true);
+  });
+
+  test('rejects when value field is non-numeric', () => {
+    const result = validatePartyMember(
+      {
+        ...minimalRaw(),
+        persistentEffects: [{ instanceId: 'p1', effectId: 'frightened', value: 'two' }]
+      },
+      0
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'persistentEffects[0].value')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

**Batch B** of the test push (Batch A is #120). Targets the next tier of coverage gaps — large composite components and the validator that was sitting at 74%.

| File | Tests | Notes |
|---|---|---|
| `LibraryPane.test.ts` | 5 | Composition smoke test, manage-modal open/close, remove forwarding |
| `PartySection.test.ts` | 12 | Collapse persistence (localStorage), member rows, add/remove callbacks, edit modal new vs edit mode |
| `party-member-validator.test.ts` | 21 | Branch-fills the YAML validator: required-field rejection, all four `Duration` variants, optional fields, error-path `documentIndex` propagation |
| `SpellcastingBlockView.test.ts` | 20 | All four spellcasting shapes (prepared, focus, innate per-day/at-will/constant). Pip click/contextmenu, DC + dcBonus modified styling, cantrip section |

Suite: **862 → 920 passing** (+58 tests). No source changes.

## Independent from #120

This branch is cut from `master` and adds no tooling — Batch A's `@vitest/coverage-v8` and `Element.prototype.animate` shim aren't needed here because none of these tests use Svelte transitions and coverage tooling is optional. The PRs are mergeable in either order; if both land, the test runs simply add.

## After this lands

What's left for "sweet" coverage:
- `routes/+page.svelte` (1039 LOC at 0%) — orchestrator, would only need a smoke test since most logic is in `$lib/encounter-app.ts` (94%)
- `PartyMemberEditModal.svelte` (576 LOC at 0%) — core flows only would be a tractable next batch
- Branch-coverage gaps in `EffectModal` (63%), `RadialConditionMenu` (66%), `CombatantCard` (60% — biggest component at 1189 LOC)

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run test:run` — 920 passed, 1 skipped (pre-existing legacy skip)
- [x] `npm run audit` — exit 0
- [x] `npm run build` — built successfully via static adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)