### PR TITLE
feat(radial): add Remove combatant wedge with inline confirm

### DIFF
--- a/src/components/RadialConditionMenu.svelte
+++ b/src/components/RadialConditionMenu.svelte
@@ -18,6 +18,7 @@
   export let wedgeCounts: ConditionWedgeCounts;
   export let onApply: (choice: ApplyConditionChoice) => void;
   export let onOpenModal: (tab: EffectModalTab) => void;
+  export let onRemove: () => void;
   export let onClose: () => void;
 
   // Geometry — ported verbatim from design/radial-menu.jsx.
@@ -28,7 +29,7 @@
   const SUB_RING_R = 200;
   const LABEL_R = 95;
   const SUB_LABEL_R = 165;
-  const WEDGE_COUNT = 6;
+  const WEDGE_COUNT = 7;
   const SLICE = 360 / WEDGE_COUNT;
   const SCRUB_DEG_PER_TICK = 5;
   const RADIAL_DIAMETER = 440;
@@ -41,14 +42,16 @@
     | 'persistent'
     | 'manage'
     | 'effects'
-    | 'afflict';
-  // Only Recent fans out as a sub-arc; the others open the modal.
+    | 'afflict'
+    | 'remove';
+  // Only Recent fans out as a sub-arc; the others open the modal or (for remove) a confirm step.
   type SubArcWedgeId = 'recent';
   interface WedgeDef {
     id: WedgeId;
     icon: string;
     label: string;
     modalTab: EffectModalTab | null;
+    danger?: boolean;
   }
 
   const WEDGES: readonly WedgeDef[] = [
@@ -57,13 +60,15 @@
     { id: 'persistent', icon: '✷', label: 'Persistent', modalTab: 'persistent' },
     { id: 'manage', icon: '⚙', label: 'Manage', modalTab: 'applied' },
     { id: 'effects', icon: '✚', label: 'Effects', modalTab: 'effects' },
-    { id: 'afflict', icon: '☣', label: 'Afflictions', modalTab: 'afflictions' }
+    { id: 'afflict', icon: '☣', label: 'Afflictions', modalTab: 'afflictions' },
+    { id: 'remove', icon: '✕', label: 'Remove', modalTab: null, danger: true }
   ];
 
   type Phase =
     | { kind: 'hub' }
     | { kind: 'subarc'; wedge: SubArcWedgeId }
-    | { kind: 'scrub'; wedge: SubArcWedgeId; option: ConditionOption; value: number };
+    | { kind: 'scrub'; wedge: SubArcWedgeId; option: ConditionOption; value: number }
+    | { kind: 'confirm-remove'; focus: 'cancel' | 'confirm' };
 
   let phase: Phase = { kind: 'hub' };
   let hoveredWedgeId: WedgeId | null = null;
@@ -160,6 +165,11 @@
   function selectWedge(wedgeId: WedgeId) {
     const wedge = WEDGES.find((w) => w.id === wedgeId);
     if (!wedge) return;
+    if (wedge.id === 'remove') {
+      phase = { kind: 'confirm-remove', focus: 'cancel' };
+      hoveredWedgeId = 'remove';
+      return;
+    }
     if (wedge.modalTab) {
       onOpenModal(wedge.modalTab);
       onClose();
@@ -168,6 +178,16 @@
     // Recent wedge: fan out the sub-arc.
     phase = { kind: 'subarc', wedge: 'recent' };
     hoveredItemIndex = null;
+  }
+
+  function commitRemove() {
+    onRemove();
+    onClose();
+  }
+
+  function cancelRemove() {
+    phase = { kind: 'hub' };
+    hoveredWedgeId = 'remove';
   }
 
   function handleSubItemActivate(index: number) {
@@ -264,14 +284,44 @@
     }
   }
 
+  function handleConfirmRemoveKey(event: KeyboardEvent) {
+    if (phase.kind !== 'confirm-remove') return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelRemove();
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (phase.focus === 'confirm') {
+        commitRemove();
+      } else {
+        cancelRemove();
+      }
+      return;
+    }
+    if (
+      event.key === 'ArrowRight' ||
+      event.key === 'ArrowLeft' ||
+      event.key === 'ArrowUp' ||
+      event.key === 'ArrowDown' ||
+      event.key === 'Tab'
+    ) {
+      event.preventDefault();
+      phase = { kind: 'confirm-remove', focus: phase.focus === 'cancel' ? 'confirm' : 'cancel' };
+    }
+  }
+
   function handleKeyDown(event: KeyboardEvent) {
     if (phase.kind === 'hub') handleHubKey(event);
     else if (phase.kind === 'subarc') handleSubarcKey(event);
-    else handleScrubKey(event);
+    else if (phase.kind === 'scrub') handleScrubKey(event);
+    else handleConfirmRemoveKey(event);
   }
 
   function handlePointerMove(event: PointerEvent) {
     if (!svgEl) return;
+    if (phase.kind === 'confirm-remove') return;
     const { x, y } = clientToSvg(svgEl, event.clientX, event.clientY);
     const r = radiusOf(x, y);
     const ang = angleOf(x, y);
@@ -447,17 +497,22 @@
     {#each WEDGES as w, i (w.id)}
       {@const angles = wedgeAngles(i)}
       {@const labelPos = polar(angles.mid, LABEL_R)}
-      {@const isActiveWedge = (phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge === w.id}
-      {@const isDimmed = (phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge !== w.id}
+      {@const isActiveWedge =
+        ((phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge === w.id) ||
+        (phase.kind === 'confirm-remove' && w.id === 'remove')}
+      {@const isDimmed =
+        ((phase.kind === 'subarc' || phase.kind === 'scrub') && phase.wedge !== w.id) ||
+        (phase.kind === 'confirm-remove' && w.id !== 'remove')}
       {@const isHover = phase.kind === 'hub' && hoveredWedgeId === w.id}
       <g
         class="wedge wedge-active"
         class:wedge-hover={isHover}
         class:wedge-selected={isActiveWedge}
         class:wedge-dim={isDimmed}
+        class:wedge-danger={w.danger}
         role="menuitem"
         tabindex="-1"
-        aria-label={`${w.label} ${wedgeCount(w.id)}`}
+        aria-label={w.danger ? w.label : `${w.label} ${wedgeCount(w.id)}`}
       >
         <path
           class="wedge-fill"
@@ -465,7 +520,9 @@
         />
         <text class="wedge-icon" x={labelPos.x} y={labelPos.y - 4} text-anchor="middle">{w.icon}</text>
         <text class="wedge-label" x={labelPos.x} y={labelPos.y + 14} text-anchor="middle">{w.label.toUpperCase()}</text>
-        <text class="wedge-count" x={labelPos.x} y={labelPos.y + 26} text-anchor="middle">{wedgeCount(w.id)}</text>
+        {#if !w.danger}
+          <text class="wedge-count" x={labelPos.x} y={labelPos.y + 26} text-anchor="middle">{wedgeCount(w.id)}</text>
+        {/if}
       </g>
     {/each}
 
@@ -516,13 +573,47 @@
     {/if}
 
     <g class="hub" filter="url(#radialShadow)">
-      <circle class="hub-bg" cx={CX} cy={CY} r={INNER_R} />
-      <circle class="hub-portrait" cx={CX} cy={CY - 18} r="14" />
-      <text class="hub-initials" x={CX} y={CY - 14} text-anchor="middle">{hubInitials}</text>
-      <text class="hub-name" x={CX} y={CY + 8} text-anchor="middle">{combatantName}</text>
-      <text class="hub-hp" x={CX} y={CY + 22} text-anchor="middle">{combatantHpLabel}</text>
-      {#if combatantSubtitle}
-        <text class="hub-subtitle" x={CX} y={CY + 34} text-anchor="middle">{combatantSubtitle}</text>
+      {#if phase.kind === 'confirm-remove'}
+        <circle class="hub-bg hub-bg-danger" cx={CX} cy={CY} r={INNER_R} />
+        <text class="hub-confirm-prompt" x={CX} y={CY - 22} text-anchor="middle">REMOVE?</text>
+        <text class="hub-confirm-name" x={CX} y={CY - 6} text-anchor="middle">{combatantName}</text>
+        <g
+          class="confirm-btn confirm-cancel"
+          class:focused={phase.focus === 'cancel'}
+          role="button"
+          tabindex="-1"
+          aria-label="Cancel remove"
+          onpointerdown={(e) => {
+            e.stopPropagation();
+            cancelRemove();
+          }}
+        >
+          <rect x={CX - 44} y={CY + 8} width="40" height="22" rx="3" />
+          <text x={CX - 24} y={CY + 23} text-anchor="middle">Cancel</text>
+        </g>
+        <g
+          class="confirm-btn confirm-delete"
+          class:focused={phase.focus === 'confirm'}
+          role="button"
+          tabindex="-1"
+          aria-label="Confirm remove"
+          onpointerdown={(e) => {
+            e.stopPropagation();
+            commitRemove();
+          }}
+        >
+          <rect x={CX + 4} y={CY + 8} width="40" height="22" rx="3" />
+          <text x={CX + 24} y={CY + 23} text-anchor="middle">Delete</text>
+        </g>
+      {:else}
+        <circle class="hub-bg" cx={CX} cy={CY} r={INNER_R} />
+        <circle class="hub-portrait" cx={CX} cy={CY - 18} r="14" />
+        <text class="hub-initials" x={CX} y={CY - 14} text-anchor="middle">{hubInitials}</text>
+        <text class="hub-name" x={CX} y={CY + 8} text-anchor="middle">{combatantName}</text>
+        <text class="hub-hp" x={CX} y={CY + 22} text-anchor="middle">{combatantHpLabel}</text>
+        {#if combatantSubtitle}
+          <text class="hub-subtitle" x={CX} y={CY + 34} text-anchor="middle">{combatantSubtitle}</text>
+        {/if}
       {/if}
     </g>
   </svg>
@@ -730,5 +821,87 @@
     font-weight: 700;
     fill: var(--color-amber);
     letter-spacing: 0.08em;
+  }
+
+  .wedge-danger .wedge-icon {
+    fill: var(--color-red);
+  }
+
+  .wedge-danger .wedge-label {
+    fill: var(--color-red);
+    opacity: 0.75;
+  }
+
+  .wedge-danger.wedge-hover .wedge-fill,
+  .wedge-danger.wedge-selected .wedge-fill {
+    fill: var(--color-red);
+    filter: url(#radialShadow);
+  }
+
+  .wedge-danger.wedge-hover .wedge-icon,
+  .wedge-danger.wedge-hover .wedge-label,
+  .wedge-danger.wedge-selected .wedge-icon,
+  .wedge-danger.wedge-selected .wedge-label {
+    fill: var(--color-bg);
+    opacity: 1;
+  }
+
+  .hub-bg-danger {
+    stroke: var(--color-red);
+    stroke-width: 2;
+  }
+
+  .hub-confirm-prompt {
+    font-family: var(--font-sans);
+    font-size: 9px;
+    font-weight: 700;
+    fill: var(--color-red);
+    letter-spacing: 0.16em;
+  }
+
+  .hub-confirm-name {
+    font-family: var(--font-serif);
+    font-size: 11px;
+    font-weight: 600;
+    fill: var(--color-ink);
+  }
+
+  .confirm-btn {
+    cursor: pointer;
+  }
+
+  .confirm-btn rect {
+    fill: var(--color-bg);
+    stroke: var(--color-ink);
+    stroke-width: 1;
+  }
+
+  .confirm-btn text {
+    font-family: var(--font-sans);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    fill: var(--color-ink);
+    pointer-events: none;
+  }
+
+  .confirm-btn.focused rect {
+    stroke-width: 1.5;
+  }
+
+  .confirm-delete rect {
+    stroke: var(--color-red);
+  }
+
+  .confirm-delete text {
+    fill: var(--color-red);
+  }
+
+  .confirm-delete.focused rect {
+    fill: var(--color-red);
+  }
+
+  .confirm-delete.focused text {
+    fill: var(--color-bg);
   }
 </style>

--- a/src/components/RadialConditionMenu.test.ts
+++ b/src/components/RadialConditionMenu.test.ts
@@ -10,19 +10,20 @@ const GEOMETRY = {
   INNER_R: 56, // hub radius
   RING_R: 130, // outer ring radius
   SUB_LABEL_R: 165, // radius at which sub-arc labels sit
-  SLICE: 60, // 360 / WEDGE_COUNT (6)
+  SLICE: 360 / 7, // 360 / WEDGE_COUNT (7)
   // Mid-angle for the active radius band: inside (INNER_R + 4)..RING_R.
   ACTIVE_BAND_INSIDE: 60
 } as const;
 
-// Wedge order is load-bearing for keyboard navigation. Recent is index 0.
+// Wedge order is load-bearing for keyboard navigation. Recent is index 0; Remove is last.
 const WEDGE_LABELS: ReadonlyArray<string> = [
   'Recent',
   'Conditions',
   'Persistent',
   'Manage',
   'Effects',
-  'Afflictions'
+  'Afflictions',
+  'Remove'
 ];
 
 /**
@@ -73,13 +74,14 @@ function baseProps(overrides: Record<string, unknown> = {}) {
     wedgeCounts: { conditions: 28, persistent: 11, spells: 10, afflictions: 4 },
     onApply: vi.fn(),
     onOpenModal: vi.fn(),
+    onRemove: vi.fn(),
     onClose: vi.fn(),
     ...overrides
   };
 }
 
 describe('RadialConditionMenu', () => {
-  test('renders all six wedge labels', () => {
+  test('renders all seven wedge labels', () => {
     render(RadialConditionMenu, { props: baseProps() });
     for (const label of WEDGE_LABELS) {
       expect(screen.getByText(label.toUpperCase())).toBeInTheDocument();
@@ -89,7 +91,7 @@ describe('RadialConditionMenu', () => {
   test('all wedges are active (no aria-disabled)', () => {
     const { container } = render(RadialConditionMenu, { props: baseProps() });
     const wedges = container.querySelectorAll('g.wedge[role="menuitem"]');
-    expect(wedges.length).toBe(6);
+    expect(wedges.length).toBe(7);
     for (const wedge of Array.from(wedges)) {
       expect(wedge.getAttribute('aria-disabled')).toBeNull();
     }
@@ -214,5 +216,145 @@ describe('RadialConditionMenu', () => {
     expect(bubble).not.toBeNull();
     expect(bubble?.getAttribute('aria-label')).toBe(`R${targetIdx}`);
     expect(bubble?.getAttribute('aria-label')).not.toBe(`R${count - 1 - targetIdx}`);
+  });
+
+  test('Remove wedge: single keyboard activation enters confirm phase without calling onRemove', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    // Navigate to the Remove wedge (last, index 6 → 7 ArrowRight presses).
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+
+    // Confirm phase is open: the prompt and both buttons render.
+    expect(screen.getByText('REMOVE?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel remove' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm remove' })).toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('Remove confirm: Escape returns to hub without calling onRemove or onClose', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+    expect(screen.getByText('REMOVE?')).toBeInTheDocument();
+
+    await fireEvent.keyDown(svg, { key: 'Escape' });
+    expect(screen.queryByText('REMOVE?')).toBeNull();
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('Remove confirm: Enter on default-focused Cancel returns to hub (no commit)', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+
+    // Cancel is the initial focus. Pressing Enter cancels.
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByText('REMOVE?')).toBeNull();
+  });
+
+  test('Remove confirm: ArrowRight then Enter commits via onRemove + onClose', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+    await fireEvent.keyDown(svg, { key: 'ArrowRight' }); // flip focus to confirm
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Remove confirm: clicking Cancel button restores hub without onRemove', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel remove' });
+    await fireEvent.pointerDown(cancelBtn);
+
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByText('REMOVE?')).toBeNull();
+  });
+
+  test('Remove confirm: clicking Delete button calls onRemove and onClose once each', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+
+    for (let i = 0; i < WEDGE_LABELS.length; i++) {
+      await fireEvent.keyDown(svg, { key: 'ArrowRight' });
+    }
+    await fireEvent.keyDown(svg, { key: 'Enter' });
+
+    const deleteBtn = screen.getByRole('button', { name: 'Confirm remove' });
+    await fireEvent.pointerDown(deleteBtn);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Remove wedge: pointerdown inside the wedge enters confirm phase without committing', async () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(RadialConditionMenu, {
+      props: baseProps({ onRemove, onClose })
+    });
+    const svg = container.querySelector('svg.radial-svg') as SVGSVGElement;
+    stubSvgGeometry(svg);
+
+    // Remove wedge is index 6 (last). Its mid angle is 6 * SLICE.
+    const removeMid = 6 * GEOMETRY.SLICE;
+    await fireEvent.pointerDown(svg, pointAt(removeMid, 90));
+
+    expect(screen.getByText('REMOVE?')).toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -664,6 +664,15 @@
     closeRadial();
   }
 
+  function radialRemoveCombatant() {
+    const id = radialCombatantId;
+    if (!id) return;
+    const name = encounter.combatants[id]?.name ?? 'combatant';
+    runCommand(toCommand('REMOVE_COMBATANT', { combatantId: id }, nextCommandId()));
+    appendFeedback(nextFeedbackId('radial-remove'), `Removed ${name} from the encounter.`, 'success');
+    closeRadial();
+  }
+
   function modifyConditionValue(combatantId: string, instanceId: string, delta: number) {
     runCommand(
       toCommand('MODIFY_EFFECT_VALUE', { targetId: combatantId, instanceId, delta }, nextCommandId())
@@ -972,6 +981,7 @@
     {wedgeCounts}
     onApply={radialApply}
     onOpenModal={radialOpenModal}
+    onRemove={radialRemoveCombatant}
     onClose={closeRadial}
   />
 {/if}


### PR DESCRIPTION
## Summary
- Adds a 7th wedge to `RadialConditionMenu` with a red ✕ icon, matching the destructive wedge originally specified in `design/radial-menu.jsx`.
- Selecting Remove enters a new `confirm-remove` phase: the central hub swaps to "REMOVE? \<name\>" with inline Cancel / Delete SVG buttons. Commit dispatches the existing `REMOVE_COMBATANT` command and appends a `success` feedback toast.
- Wedge geometry: `WEDGE_COUNT 6 → 7` (SLICE 60° → ~51.43°). Existing tests parametrized on `WEDGE_LABELS.length` and the `SLICE` constant continue to pass.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test:run` — 1035 passed, 1 skipped (15 in the radial test file: 8 pre-existing + 7 new)
- [x] `npm run audit` — pre-existing low-severity cookie advisories only; gate is moderate, exit 0
- [x] `npm run build` — Cloudflare static build succeeds
- [x] Manual smoke (browser): right-click a combatant → click Remove wedge → hub shows Cancel/Delete → Cancel returns to hub; Delete removes the combatant and shows "Removed \<name\> from the encounter." toast in the drawer.
- [ ] Manual smoke: keyboard path — open radial, ArrowRight ×7, Enter (enter confirm), ArrowRight (focus Delete), Enter (commit).
- [ ] Manual smoke: removing the currently-active combatant during ACTIVE phase advances the turn pointer correctly (existing reducer behavior; just verifying this path triggers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)