### PR TITLE
fix(spells): address PR #125 review feedback

### DIFF
--- a/scripts/spell-index/transform.ts
+++ b/scripts/spell-index/transform.ts
@@ -209,7 +209,12 @@ function extractSummary(html: string | undefined): string {
   if (!stripped) return '';
   const firstSentenceMatch = stripped.match(/^.+?[.!?](?=\s|$)/);
   const summary = (firstSentenceMatch?.[0] ?? stripped.split('\n')[0]).trim();
-  return summary.length > 200 ? summary.slice(0, 197) + '...' : summary;
+  if (summary.length <= 200) return summary;
+  const head = summary.slice(0, 197);
+  const lastSpace = head.lastIndexOf(' ');
+  // Only break on whitespace when it's not absurdly close to the start.
+  const truncated = lastSpace > 100 ? head.slice(0, lastSpace) : head;
+  return truncated + '...';
 }
 
 function aonSearchUrl(name: string): string {

--- a/src/components/details/SpellRow.svelte
+++ b/src/components/details/SpellRow.svelte
@@ -2,6 +2,7 @@
   import type { SpellListEntry } from '../../domain';
   import { ensureSpellIndex, resolveAtLevel } from '$lib/spell-index';
   import type { SpellIndexEntry, SpellIndexState } from '$lib/spell-index';
+  import ActionGlyph from './ActionGlyph.svelte';
 
   export let entry: SpellListEntry;
   export let dc: number;
@@ -12,12 +13,14 @@
 
   $: countSuffix = entry.count && entry.count > 1 ? ` ×${entry.count}` : '';
 
+  // Expand first so the user sees immediate feedback (the "Loading…" panel)
+  // even on slow networks; the fetch resolves into the populated panel.
   async function toggleExpand() {
-    if (!expanded && indexState.status === 'idle') {
+    expanded = !expanded;
+    if (expanded && indexState.status === 'idle') {
       indexState = { status: 'loading' };
       indexState = await ensureSpellIndex();
     }
-    expanded = !expanded;
   }
 
   function resolvedEntry(state: SpellIndexState): SpellIndexEntry | undefined {
@@ -38,15 +41,6 @@
 
   function capitalize(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
-  }
-
-  function formatActionCost(cost: SpellIndexEntry['actionCost']): string {
-    if (cost === 1) return '◆';
-    if (cost === 2) return '◆◆';
-    if (cost === 3) return '◆◆◆';
-    if (cost === 'reaction') return '↺';
-    if (cost === 'free') return '◇';
-    return '—';
   }
 </script>
 
@@ -70,7 +64,11 @@
         {@const resolved = resolveAtLevel(spell, entry.level)}
         <div class="spell-row__panel">
           <div class="spell-row__line">
-            <span>{formatActionCost(spell.actionCost)}</span>
+            {#if spell.actionCost === 'varies'}
+              <span aria-label="Variable action cost">—</span>
+            {:else}
+              <ActionGlyph cost={spell.actionCost} />
+            {/if}
             {#if spell.range}<span>· Range {spell.range}</span>{/if}
             {#if spell.area}<span>· Area {spell.area}</span>{/if}
             {#if spell.targets}<span>· Targets {spell.targets}</span>{/if}

--- a/src/components/details/SpellRow.test.ts
+++ b/src/components/details/SpellRow.test.ts
@@ -77,7 +77,7 @@ describe('SpellRow', () => {
     await fireEvent.click(screen.getByRole('button', { name: /Fireball/ }));
 
     expect(await screen.findByText(/Reflex DC 22 \(basic\)/)).toBeTruthy();
-    expect(screen.getByText(/6d6 fire \+2d6 fire \+2d6 fire/)).toBeTruthy();
+    expect(screen.getByText(/10d6 fire/)).toBeTruthy();
     expect(screen.getByText(/heightened from rank 3/)).toBeTruthy();
     expect(screen.getByText(/Archives of Nethys/)).toBeTruthy();
   });

--- a/src/lib/spell-index/index.test.ts
+++ b/src/lib/spell-index/index.test.ts
@@ -68,6 +68,28 @@ describe('ensureSpellIndex', () => {
     warn.mockRestore();
   });
 
+  test('network error (fetch rejects) leaves index unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const state = await ensureSpellIndex();
+    expect(state.status).toBe('unavailable');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('unavailable state is sticky — no retry on subsequent calls', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('offline'));
+    vi.stubGlobal('fetch', fetchMock);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await ensureSpellIndex();
+    await ensureSpellIndex();
+    await ensureSpellIndex();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   test('concurrent calls share one fetch', async () => {
     const fetchMock = vi
       .fn()

--- a/src/lib/spell-index/index.ts
+++ b/src/lib/spell-index/index.ts
@@ -9,6 +9,10 @@ export type SpellIndexState =
 let inflight: Promise<SpellIndexState> | null = null;
 let cached: SpellIndexState = { status: 'idle' };
 
+// `unavailable` is sticky for the rest of the session — we don't retry. The
+// asset is a same-origin static file so a single failure is almost certainly
+// a build/deploy problem rather than a transient one; callers fall back to
+// the AoN search link in that case.
 export async function ensureSpellIndex(): Promise<SpellIndexState> {
   if (cached.status === 'ready' || cached.status === 'unavailable') {
     return cached;

--- a/src/lib/spell-index/resolve.test.ts
+++ b/src/lib/spell-index/resolve.test.ts
@@ -47,7 +47,7 @@ describe('resolveAtLevel', () => {
     expect(resolveAtLevel(entry, 9)).toEqual({ damage: '6d6 force' });
   });
 
-  test('interval mode adds delta per step', () => {
+  test('interval mode sums dice of the same type', () => {
     const fireball = spell({
       slug: 'fireball',
       name: 'Fireball',
@@ -60,8 +60,8 @@ describe('resolveAtLevel', () => {
       }
     });
     expect(resolveAtLevel(fireball, 3)).toEqual({ damage: '6d6 fire' });
-    expect(resolveAtLevel(fireball, 4)).toEqual({ damage: '6d6 fire +2d6 fire' });
-    expect(resolveAtLevel(fireball, 5)).toEqual({ damage: '6d6 fire +2d6 fire +2d6 fire' });
+    expect(resolveAtLevel(fireball, 4)).toEqual({ damage: '8d6 fire' });
+    expect(resolveAtLevel(fireball, 5)).toEqual({ damage: '10d6 fire' });
     expect(resolveAtLevel(fireball, 2)).toEqual({ damage: '6d6 fire' });
   });
 
@@ -79,7 +79,47 @@ describe('resolveAtLevel', () => {
       }
     });
     expect(resolveAtLevel(electricArc, 1)).toEqual({ damage: '1d4 electricity' });
-    expect(resolveAtLevel(electricArc, 3)).toEqual({ damage: '1d4 electricity +1d4 electricity' });
-    expect(resolveAtLevel(electricArc, 5)).toEqual({ damage: '1d4 electricity +1d4 electricity +1d4 electricity' });
+    expect(resolveAtLevel(electricArc, 3)).toEqual({ damage: '2d4 electricity' });
+    expect(resolveAtLevel(electricArc, 5)).toEqual({ damage: '3d4 electricity' });
+  });
+
+  test('interval preserves the base modifier when summing dice', () => {
+    const entry = spell({
+      base: { damage: '1d4+1 force' },
+      heightening: {
+        mode: 'interval',
+        per: 2,
+        delta: { damage: '+1d4 force' }
+      }
+    });
+    expect(resolveAtLevel(entry, 5)).toEqual({ damage: '3d4+1 force' });
+  });
+
+  test('interval falls back to verbose stacking when base is compound', () => {
+    const entry = spell({
+      baseLevel: 1,
+      base: { damage: '6d6 fire + 1d4 evil' },
+      heightening: {
+        mode: 'interval',
+        per: 1,
+        delta: { damage: '+2d6 fire' }
+      }
+    });
+    // One step at castLevel = baseLevel + 1; can't safely sum into a compound
+    // expression so the additive form is kept.
+    expect(resolveAtLevel(entry, 2).damage).toBe('6d6 fire + 1d4 evil +2d6 fire');
+  });
+
+  test('interval scales a typeless delta with no base damage', () => {
+    const entry = spell({
+      base: {},
+      heightening: {
+        mode: 'interval',
+        per: 1,
+        delta: { damage: '+1d6' }
+      },
+      baseLevel: 1
+    });
+    expect(resolveAtLevel(entry, 4)).toEqual({ damage: '3d6' });
   });
 });

--- a/src/lib/spell-index/resolve.ts
+++ b/src/lib/spell-index/resolve.ts
@@ -1,6 +1,30 @@
 // src/lib/spell-index/resolve.ts
 import type { SpellIndexEntry, SpellLevelData } from './types';
 
+// "NdM", "NdM+K", "NdM-K", optional damage type tail.
+const BASE_TERM = /^(\d+)d(\d+)(?:([+-]\d+))?(?:\s+(.+))?$/;
+// Heightening delta: leading "+" allowed; no modifier component (heightening
+// adds dice, not flat damage).
+const DELTA_TERM = /^\+?(\d+)d(\d+)(?:\s+(.+))?$/;
+
+function combineSameTypeDice(
+  base: string,
+  delta: string,
+  steps: number
+): string | null {
+  const b = base.trim().match(BASE_TERM);
+  const d = delta.trim().match(DELTA_TERM);
+  if (!b || !d) return null;
+  const [, bDice, bDie, bMod, bType] = b;
+  const [, dDice, dDie, dType] = d;
+  if (bDie !== dDie) return null;
+  if ((bType ?? '') !== (dType ?? '')) return null;
+  const total = Number(bDice) + Number(dDice) * steps;
+  const modSuffix = bMod ?? '';
+  const typeSuffix = bType ? ` ${bType}` : '';
+  return `${total}d${bDie}${modSuffix}${typeSuffix}`;
+}
+
 export function resolveAtLevel(
   entry: SpellIndexEntry,
   castLevel: number
@@ -22,9 +46,18 @@ export function resolveAtLevel(
   const result: SpellLevelData = { ...entry.base };
   const deltaDamage = entry.heightening.delta.damage;
   if (deltaDamage && entry.base.damage) {
-    result.damage = `${entry.base.damage}${` ${deltaDamage}`.repeat(steps)}`;
+    result.damage =
+      combineSameTypeDice(entry.base.damage, deltaDamage, steps) ??
+      `${entry.base.damage}${` ${deltaDamage}`.repeat(steps)}`;
   } else if (deltaDamage) {
-    result.damage = Array(steps).fill(deltaDamage.replace(/^\+/, '')).join(' +');
+    const stripped = deltaDamage.replace(/^\+/, '');
+    const m = stripped.match(DELTA_TERM);
+    if (m) {
+      const [, dice, die, type] = m;
+      result.damage = `${Number(dice) * steps}d${die}${type ? ` ${type}` : ''}`;
+    } else {
+      result.damage = Array(steps).fill(stripped).join(' +');
+    }
   }
   return result;
 }


### PR DESCRIPTION
Follow-up to the merged #125. Addresses code-review feedback on the spell-enrichment feature.

## Changes

- **`resolve.ts`** — Interval heightening now sums dice of the same type (e.g. Fireball at rank 5 → `10d6 fire` instead of `6d6 fire +2d6 fire +2d6 fire`). Preserves the base modifier, scales typeless deltas, and falls back to the additive form when the base damage is a compound expression that can't be safely combined.
- **`SpellRow.svelte`** — Reuses the shared `ActionGlyph` component for action cost instead of a local formatter. Expansion state is now set *before* the `await`, so the loading panel is visible on slow networks.
- **`transform.ts`** — Effect summaries are truncated at a word boundary rather than mid-word.
- **`index.ts`** — Documents that the `unavailable` state is intentionally sticky (no retry on a same-origin static asset).
- **Tests** — Added coverage for dice-summing, modifier preservation, compound-base fallback, typeless-delta scaling, the network-error path, and the sticky-`unavailable` behavior.

## Notes

The bundled `static/spell-index.json` was generated with the old truncation logic; the word-boundary `extractSummary` fix only takes effect on the next maintainer run of `npm run spells:import`.

## Pre-PR gate

`check` ✓ (0 errors) · `test:run` ✓ (1057 passed, 1 skipped) · `audit` ✓ (3 low, below moderate threshold) · `build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
