### PR TITLE
feat(hazards): support complex hazards as encounter participants

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,11 +79,17 @@ Tracking only. Captured in issue #49. Domain commands are stubbed in `src/domain
 - [ ] Wire `USE_INNATE_SPELL`, `RESTORE_INNATE_SPELL`, `SET_INNATE_USAGE`.
 - [ ] Add spellcasting block UI on combatant cards.
 
+## M7 Complex Hazards
+
+- [x] Add `Hazard` domain type, `HazardData`, and `createCombatantFromHazard` factory.
+- [x] Add Foundry pf2e `hazard` actor JSON importer + YAML hazard validator.
+- [x] Add IndexedDB hazard library (DB v5) with import/manage UI.
+- [x] Add hazard combatant rendering: stat block, Stealth/Hardness, free-form routine + disable text. (Spec: `pf2e-hazards-spec.md`.)
+
 ## Deferred milestones
 
 Specs are authoritative; tracking issues hold scope so the work is not lost. None of these are in the active backlog filter.
 
-- **Hazards** — issue #50, spec `pf2e-hazards-spec.md`. Hazards as initiative participants with reactions, triggers, and disables.
 - **Afflictions** — issue #51, spec `pf2e-afflictions-spec.md`. Poison/disease/curse staging, saves, and turn-boundary prompts.
 - **Party members** — issue #52, spec `pf2e-party-members-spec.md`. PCs as first-class persisted entities, not ad-hoc combatants.
 - **Creature types** — spec `pf2e-creature-types-spec.md`. Folds into #48 once the import-driven creature library lands.

--- a/pf2e-hazards-spec.md
+++ b/pf2e-hazards-spec.md
@@ -1,106 +1,57 @@
 # PF2e Encounter Tracker v2 — Complex Hazards Specification
 
-**Version:** 0.1 (draft)
-**Date:** 2026-04-22
-**Status:** Ready for review
+**Version:** 0.2
+**Date:** 2026-05-22
+**Status:** Implemented
+
+> **v0.2 supersedes v0.1.** v0.1 (2026-04-22) predated the Foundry NPC importer
+> and the `baseSnapshot: CreatureSnapshot` redesign, and assumed hand-authored
+> hazards with structured disable checks. v0.2 reflects what shipped: hazards
+> are imported from the Foundry pf2e module (same source as monsters), and a
+> hazard's routine and disable instructions are stored as **free-form text**
+> because that is all the Foundry data provides.
 
 ---
 
 ## 1. Overview
 
-Complex hazards are encounter participants. They occupy initiative slots, act on their turn via a fixed routine, can be damaged and destroyed, and can be disabled via skill checks. Simple hazards are not tracked — they are a GM note, not an encounter entity.
+Complex hazards are encounter participants. They occupy initiative slots, act
+on their turn via a fixed routine, can be damaged and destroyed, and can be
+disabled via skill checks. Simple hazards are not tracked — they are a GM note,
+not an encounter entity.
 
-Complex hazards are modeled as combatants. The domain treats them identically to creature combatants — same commands, same effects engine, same stat derivation. The differences are in the library type (what data is stored) and display (what the UI shows).
+Complex hazards are modeled as combatants. The domain treats them **identically
+to creature combatants** — same commands, same effects engine, same stat
+derivation, same initiative. The differences are in the library type (what data
+is stored) and display (what the UI shows). There are **no new domain commands
+and no new domain events.**
 
 ---
 
-## 2. Amendments to Existing Specs
+## 2. Source: the Foundry pf2e module
 
-### 2.1 CombatantState — Add `"hazard"` Source Type
+Hazards are imported from the Foundry VTT pf2e module — the same source as
+monsters. A Foundry complex hazard is an actor of `type: "hazard"`. The importer
+(`src/lib/foundry/hazard-mapper.ts`) reuses the NPC importer's item-level
+helpers (Strikes, actions, reactions) and rejects any document that is not a
+`hazard` or whose `system.details.isComplex` is not `true`.
 
-Amend the `sourceType` union (party members spec §2.1):
+Foundry stores a hazard's **routine and disable instructions as free-form HTML
+text**, not as machine-readable skill/DC/required-successes data. The importer
+HTML-strips them into plain text. The GM reads that text at the table and
+resolves outcomes with the standard command vocabulary. There is no structured
+disable-progress tracking — that was the v0.1 design and it has been dropped
+because the source data cannot populate it.
 
-```typescript
-interface CombatantState {
-  // ...
-  sourceType: "creature" | "partyMember" | "companion" | "hazard"
-  // ...
-}
-```
-
-No other changes to `CombatantState`. Hazard combatants use the same fields as creature combatants: `baseStats`, `attacks`, `abilities`, `appliedEffects`, etc.
-
-### 2.2 CreatureBaseStats — Add Hardness, Make Saves Optional
-
-Hardness is not hazard-specific — creatures can have it too (golems, animated objects, constructs). Add it to `CreatureBaseStats`. Additionally, some hazards lack certain saves. Make saves nullable.
-
-```typescript
-interface CreatureBaseStats {
-  ac: number
-  fortitude: number | null          // null = hazard/entity doesn't have this save
-  reflex: number | null
-  will: number | null
-  perception: number
-  hp: number
-  hardness?: number                 // flat damage reduction, display-only
-  skills: Record<string, number>
-  speed?: Record<string, number>
-  resistances?: { type: string; value: number }[]
-  weaknesses?: { type: string; value: number }[]
-  immunities?: string[]
-}
-```
-
-**Impact on `deriveStats()`:** When a save is `null`, the derivation skips it — no modifiers applied, no entry in `ComputedStats`. The UI displays "—" for missing saves. All existing creature and party member factories continue to set saves as numbers. Only hazard factories may produce `null`.
-
-**Impact on `ComputedStats`:** Save entries become optional:
-
-```typescript
-interface ComputedStats {
-  ac: { final: number; base: number; modifiers: AppliedModifier[] }
-  fortitude?: { final: number; base: number; modifiers: AppliedModifier[] }
-  reflex?: { final: number; base: number; modifiers: AppliedModifier[] }
-  will?: { final: number; base: number; modifiers: AppliedModifier[] }
-  // ... rest unchanged
-}
-```
-
-**Impact on `Creature` type:** Unchanged. All creatures have saves. The `Creature` interface keeps `fortitude: number`, etc. The nullable saves are a `CreatureBaseStats` concern — the factory that builds base stats from a `Hazard` is where `null` enters.
-
-**Impact on `PartyMember` and `Companion`:** Unchanged. PCs and companions always have all saves.
-
-**Hardness and APPLY_DAMAGE:** No change. `APPLY_DAMAGE` takes final numbers (command vocab spec §1.3). The GM subtracts hardness mentally before entering the damage amount, same as resistances and weaknesses. The UI displays hardness prominently so the GM remembers.
-
-### 2.3 Creature — Add Optional Hardness
-
-Some creatures (golems, animated objects) have hardness. Add it to the `Creature` interface alongside resistances/weaknesses:
-
-```typescript
-interface Creature {
-  // ... existing fields ...
-
-  // Defense
-  // ...
-  hardness?: number               // NEW
-  // ...
-}
-```
-
-The creature factory copies `hardness` into `CreatureBaseStats.hardness`.
-
-### 2.4 New IndexedDB Store
-
-Add `hazards` to the persistence spec (arch spec §13.1). Keyed by `hazard.id`. Same import/export treatment as creatures.
-
-### 2.5 YAML Import/Export
-
-Hazards are a new YAML entity type alongside creatures, encounters, party members, and effect definitions.
+YAML import (`kind: hazard`) is also supported for parity with creatures.
 
 ---
 
 ## 3. Data Model
 
-### 3.1 Hazard (Library Template)
+### 3.1 Hazard (library template)
+
+`Hazard` lives in `src/domain/types.ts`:
 
 ```typescript
 interface Hazard {
@@ -108,365 +59,155 @@ interface Hazard {
   name: string
   level: number
   traits: string[]
-  complexity: "complex"              // always complex — simple hazards aren't tracked
   rarity: "common" | "uncommon" | "rare" | "unique"
 
-  // Detection
-  stealth: number                    // Stealth DC (or initiative modifier for complex)
-  stealthNote?: string               // "trained in Perception" — minimum proficiency to notice
+  // Detection / initiative
+  stealth: number              // Stealth value — the initiative modifier
+  stealthNote?: string         // e.g. "DC 30 to detect; trained"
 
   // Defense
   ac: number
-  fortitude?: number                 // some hazards lack certain saves
-  reflex?: number
-  will?: number
+  fortitude: number
+  reflex: number
+  will: number
   hp: number
   hardness?: number
-  immunities?: string[]
-  resistances?: { type: string; value: number }[]
-  weaknesses?: { type: string; value: number }[]
+  immunities: CreatureImmunity[]
+  resistances: { type: string; value: number }[]
+  weaknesses: { type: string; value: number }[]
 
-  // Disable
-  disableChecks: DisableCheck[]      // one or more ways to disable
+  // Free-form text blocks (HTML stripped on import)
+  routine?: string             // what the hazard does each round
+  disable?: string             // how it can be disabled (skills, DCs)
+  reset?: string
+  description?: string
 
-  // Routine
-  routine: HazardRoutine
-
-  // Abilities
-  passiveAbilities: Ability[]        // e.g., "Darkness" aura
-  reactiveAbilities: Ability[]       // many hazards have reactions
-  activeAbilities: Ability[]         // beyond the routine, some have special actions
-
-  // Attacks — some hazards have listed Strikes
+  // Routine actions, reactions, and listed Strikes
   attacks: Attack[]
+  passiveAbilities: Ability[]
+  reactiveAbilities: Ability[]
+  activeAbilities: Ability[]
 
   // Meta
-  description?: string               // flavor text / GM notes
   source?: string
   tags: string[]
   notes?: string
 }
 ```
 
-### 3.2 DisableCheck
+**Defensive stats are plain numbers, never null.** v0.1 proposed nullable
+`ac`/saves to model "AC —" hazards; that rippled guard clauses through
+`deriveStats`, `getAdjustedView`, and the UI for a rare edge case. Complex
+hazards in practice always have AC, HP, saves, and (usually) hardness. The
+importer maps whatever Foundry provides, defaulting a genuinely-absent value to
+`0` with an import warning.
+
+### 3.2 HazardData (combatant display bag)
+
+Hazard-specific display data rides on `CombatantState` in an optional bag.
+Creature, party-member, and companion combatants leave it `undefined`; the
+domain reducer never reads it.
 
 ```typescript
-interface DisableCheck {
-  skill: string                      // "thievery", "religion", "athletics"
-  dc: number
-  requiredSuccesses: number          // how many successes needed (typically 1-3)
-  note?: string                      // "requires master proficiency", "only while adjacent"
+interface HazardData {
+  stealth: number
+  stealthNote?: string
+  hardness?: number
+  routine?: string
+  disable?: string
+  reset?: string
+  description?: string
+}
+
+interface CombatantState {
+  // ... existing fields ...
+  hazardData?: HazardData
 }
 ```
 
-**Design notes:**
-
-- Multiple entries = multiple ways to disable (OR logic). "Thievery DC 22 or Religion DC 26" is two entries.
-- `requiredSuccesses > 1` models "Thievery DC 22 (×2)" — two separate successful checks needed.
-- Disable check tracking during encounter is mutable state (§4.3).
-
-### 3.3 HazardRoutine
-
-```typescript
-interface HazardRoutine {
-  actions: number                    // how many actions per turn (typically 1-2)
-  description: string                // full text: what the hazard does each turn
-}
-```
-
-The routine is display-only. The GM reads it at the start of the hazard's turn and dispatches commands (APPLY_DAMAGE, APPLY_EFFECT) based on the outcome. No automation — same as creature abilities.
+`SourceType` includes `"hazard"`.
 
 ---
 
 ## 4. Encounter Integration
 
-### 4.1 Adding Hazards to an Encounter
+### 4.1 Factory
 
-Same pattern as creatures. Factory function creates a `CombatantState` from a `Hazard` library entry.
+`createCombatantFromHazard(hazard): CombatantState` (`src/domain/hazards/factory.ts`)
+mirrors `createCombatantFromCreature`:
 
-```typescript
-function createCombatantFromHazard(
-  hazard: Hazard
-): CombatantState
-```
+- `sourceType: "hazard"`, `sourceId: hazard.id`, `templateAdjustment: "normal"`
+- `currentHp` = `hazard.hp`
+- copies `attacks` and the three ability arrays; `spellcasting: undefined`
+- builds `hazardData` from the hazard's text/stealth/hardness fields
+- `baseSnapshot.perception` = `hazard.stealth` — a complex hazard rolls Stealth
+  for initiative, and `perception` is the snapshot slot the initiative logic
+  reads. The UI labels that stat **"Stealth"** for `sourceType === "hazard"`.
 
-The factory:
+### 4.2 Initiative
 
-1. Generates a unique `CombatantId`
-2. Builds `baseStats` from the hazard's defensive stats (`null` for missing saves)
-3. Sets `currentHp` to `hazard.hp`
-4. Sets `sourceType: "hazard"`, `sourceId: hazard.id`
-5. Copies `attacks`, `passiveAbilities`, `reactiveAbilities`, `activeAbilities`
-6. Copies hazard-specific display data (§4.2)
-7. No `masterId` — hazards are independent combatants in initiative
+Complex hazards roll Stealth for initiative. The GM rolls and enters the score
+like any other combatant; the snapshot carries the Stealth value so the
+roll-all-initiative helper works unchanged.
 
-The GM dispatches `ADD_COMBATANT` with the result. Standard flow.
+### 4.3 Turn flow, damage, disable, destruction
 
-### 4.2 CombatantState — Hazard-Specific Display Data
-
-Hazards need a few display fields that creatures don't have. Rather than polluting `CombatantState` with hazard-specific required fields, these go in an optional bag:
-
-```typescript
-interface CombatantState {
-  // ... existing fields ...
-
-  // Hazard-specific display data (only populated for sourceType: "hazard")
-  hazardData?: {
-    routine: HazardRoutine
-    disableChecks: DisableCheck[]
-    disableProgress: DisableProgress[]   // mutable — tracks successes during encounter
-    stealth: number
-    stealthNote?: string
-  }
-}
-```
-
-This keeps the hazard-specific data contained. The domain ignores `hazardData` entirely — it's display data for the UI and mutable state for disable tracking. Creatures, party members, and companions have `hazardData: undefined`.
-
-### 4.3 Disable Progress Tracking
-
-```typescript
-interface DisableProgress {
-  checkIndex: number                 // index into disableChecks array
-  successesRemaining: number         // starts at requiredSuccesses, decremented on success
-}
-```
-
-Initialized by the factory from `disableChecks`:
-
-```typescript
-disableProgress: hazard.disableChecks.map((check, i) => ({
-  checkIndex: i,
-  successesRemaining: check.requiredSuccesses,
-}))
-```
-
-**Tracking is manual.** The GM rolls, tells the system the result. No dedicated command — the GM uses SET_NOTE or a UI action that decrements `successesRemaining` directly (orchestrator-level mutation, not a domain command).
-
-**Why not a domain command?** Disable progress isn't domain state in the command-sourcing sense. It doesn't interact with effects, HP, initiative, or any other domain concept. It's a counter the GM ticks down. Putting it in the domain would require a new command type for minimal benefit. The orchestrator can handle the mutation and persist it as part of the combatant state snapshot.
-
-**Full disable:** When all `disableProgress` entries have `successesRemaining === 0`, the hazard is fully disabled. The UI indicates this. The GM dispatches `MARK_DEAD` or `REMOVE_COMBATANT` to take it out of initiative. The domain doesn't auto-remove — GM authority.
-
-### 4.4 Initiative
-
-Complex hazards roll Stealth for initiative (the PCs' Perception determines if they act before or after the hazard). The GM places the hazard in initiative via `SET_INITIATIVE_ORDER` like any other combatant.
-
-### 4.5 Turn Flow
-
-Hazard turns work identically to creature turns. `turn-started` fires, effects are processed, the GM reads the routine and resolves it, `END_TURN` fires when done.
-
-The UI could display the routine text prominently at turn start — a UI concern, not a domain concern.
-
-### 4.6 Destruction and Disable
-
-Two ways a hazard leaves combat:
-
-1. **Destroyed:** HP reaches 0. GM dispatches `MARK_DEAD` (or the `hp-reached-zero` event triggers the GM to decide). Same as creatures.
-2. **Disabled:** All disable checks complete. GM dispatches `MARK_DEAD` or `REMOVE_COMBATANT`. The hazard stops acting.
-
-No new commands needed for either path.
-
----
-
-## 5. Edge Cases
-
-### 5.1 Hazards Without AC
-
-Some complex hazards can't be targeted by attacks — they have no AC. In PF2e this is represented as "AC —" in the statblock.
-
-Handle the same way as missing saves: make AC nullable on `Hazard`.
-
-```typescript
-interface Hazard {
-  // ...
-  ac?: number                         // undefined = can't be targeted by attacks
-  // ...
-}
-```
-
-`CreatureBaseStats.ac` stays required (`number`). If a hazard lacks AC, the factory sets it to... actually, this is a problem. `deriveStats()` expects `ac: number`.
-
-**Resolution:** Make `CreatureBaseStats.ac` nullable too: `ac: number | null`. Same treatment as saves. `deriveStats()` skips null AC. The UI displays "—". This is a rare edge case (most complex hazards have AC) but the type system should handle it cleanly.
-
-Updated `CreatureBaseStats`:
-
-```typescript
-interface CreatureBaseStats {
-  ac: number | null                  // null for hazards that can't be targeted
-  fortitude: number | null
-  reflex: number | null
-  will: number | null
-  perception: number
-  hp: number
-  hardness?: number
-  skills: Record<string, number>
-  speed?: Record<string, number>
-  resistances?: { type: string; value: number }[]
-  weaknesses?: { type: string; value: number }[]
-  immunities?: string[]
-}
-```
-
-**For creatures, party members, and companions:** factories always set AC and saves to numbers. The `null` path only activates for hazards. Existing code that reads `baseStats.ac` needs a null check — but since this stat is consumed in exactly one place (`deriveStats`), the blast radius is small.
-
-### 5.2 Hazards With Multiple HP Pools
-
-Some complex hazards have separately destroyable components (e.g., a hallway of spinning blades where each blade segment has its own HP). PF2e represents these as "Blade HP 40 (4 segments)" with per-segment hardness.
-
-**V2 approach:** Model each segment as a separate combatant (same `sourceId`, different `CombatantId`, names like "Blade Trap — Segment 1"). The GM adds as many combatants as segments. Each has its own HP, hardness, AC. They share a routine (copy the routine text to each).
-
-This isn't elegant but it works without new data structures. A "grouped display" UI enhancement could cluster them visually — that's a UI concern for later.
-
-### 5.3 Effects on Hazards
-
-Most conditions don't make sense on hazards (a spinning blade can't be Frightened). But some do — a hazard could be Slowed by a spell, or have a condition applied by a player ability. The effects engine handles this mechanically; the GM decides what's narratively appropriate.
-
-No filtering or restriction on which effects can be applied to hazards. GM authority.
-
-### 5.4 Hazards Without HP
-
-Some hazards can only be disabled, not destroyed (no HP listed). Set `hp` to 0 and hardness to undefined. The UI displays "—" for HP. Damage commands are technically valid but do nothing meaningful — `currentHp` is already 0. The GM disables the hazard via skill checks.
-
-Actually, `hp: 0` would trigger `hp-reached-zero` on creation. Better approach: make `hp` optional on `Hazard`:
-
-```typescript
-interface Hazard {
-  // ...
-  hp?: number                         // undefined = can't be destroyed by damage
-  // ...
-}
-```
-
-The factory sets `baseStats.hp` and `currentHp` to 0 if `hp` is undefined, and sets `isAlive` to true. APPLY_DAMAGE to a 0-HP combatant floors at 0 and emits no `hp-reached-zero` (already at 0, not transitioning to 0). This works without changes to the domain.
-
-Wait — APPLY_DAMAGE only emits `hp-reached-zero` when `currentHp` reaches 0 *and* was previously above 0. So dispatching damage against a 0-HP hazard just does nothing. Correct.
-
----
-
-## 6. Hazard YAML Example
-
-```yaml
-id: poisoned-dart-gallery
-name: Poisoned Dart Gallery
-level: 8
-traits: [mechanical, trap]
-complexity: complex
-rarity: common
-
-stealth: 28
-stealthNote: "expert"
-
-ac: 27
-fortitude: 13
-reflex: 17
-hp: 100
-hardness: 10
-immunities: [critical-hits, object-immunities, precision]
-
-disableChecks:
-  - skill: thievery
-    dc: 26
-    requiredSuccesses: 3
-    note: "at a control panel on the far wall"
-  - skill: athletics
-    dc: 22
-    requiredSuccesses: 1
-    note: "to jam a single dart launcher (disables one attack)"
-
-routine:
-  actions: 2
-  description: |
-    The trap fires a volley of poisoned darts. It uses each action 
-    to make a poisoned dart Strike against a random creature in the 
-    gallery. It cannot target the same creature twice per round.
-
-attacks:
-  - name: poisoned dart
-    type: ranged
-    modifier: 21
-    traits: [range-60]
-    damage:
-      - dice: 3
-        dieSize: 4
-        bonus: 2
-        type: piercing
-    effects: [poisoned-dart-gallery-poison]
-
-reactiveAbilities:
-  - name: Dart Volley
-    actions: reaction
-    trigger: "A creature enters the gallery"
-    description: "The trap makes a poisoned dart Strike against the triggering creature."
-
-passiveAbilities: []
-activeAbilities: []
-
-source: "Extinction Curse #3"
-tags: [extinction-curse]
-```
-
----
-
-## 7. No New Commands
-
-Complex hazards use the existing command vocabulary entirely:
+Hazards use the existing command vocabulary entirely:
 
 | Action | Command |
 |---|---|
-| Add to encounter | ADD_COMBATANT |
-| Place in initiative | SET_INITIATIVE_ORDER / REORDER_COMBATANT |
-| Take damage | APPLY_DAMAGE (GM subtracts hardness) |
-| Apply effect | APPLY_EFFECT |
-| Advance turn | END_TURN |
-| Destroy | MARK_DEAD |
-| Remove from encounter | REMOVE_COMBATANT |
-| Track disable progress | Orchestrator-level mutation (not a domain command) |
+| Add to encounter | `ADD_COMBATANT` |
+| Place in initiative | `SET_INITIATIVE_ORDER` / `SET_INITIATIVE_SCORES` |
+| Take damage | `APPLY_DAMAGE` (GM subtracts hardness first) |
+| Apply effect | `APPLY_EFFECT` |
+| Advance turn | `END_TURN` |
+| Destroy / fully disable | `MARK_DEAD` |
+| Remove from encounter | `REMOVE_COMBATANT` |
 
-No new domain commands. No new domain events.
+At the hazard's turn the GM reads the routine text and resolves it. To disable a
+hazard the GM reads the disable text, rolls the relevant checks, and then
+dispatches `MARK_DEAD` (or `REMOVE_COMBATANT`) once the hazard is neutralized —
+GM authority, no automation.
 
 ---
 
-## 8. Summary
+## 5. Hardness
 
-### 8.1 New Types
+Hardness is display-only. `APPLY_DAMAGE` takes final numbers; the GM subtracts
+hardness mentally before entering the damage amount, exactly as with
+resistances. The details panel surfaces hardness prominently (in the slot a
+creature uses for Speed) so the GM remembers.
 
-| Type | Location | Purpose |
-|---|---|---|
-| `Hazard` | `domain/types/hazard.ts` | Library template for complex hazards |
-| `DisableCheck` | `domain/types/hazard.ts` | Skill + DC + required successes to disable |
-| `HazardRoutine` | `domain/types/hazard.ts` | Fixed actions per turn with description |
-| `DisableProgress` | `domain/types/hazard.ts` | Mutable encounter tracking for disable checks |
+---
 
-### 8.2 Modified Types
+## 6. Persistence
 
-| Type | Change |
-|---|---|
-| `CombatantState.sourceType` | Add `"hazard"` to union |
-| `CombatantState` | Add optional `hazardData?` field |
-| `CreatureBaseStats` | Add `hardness?`. Make `ac`, `fortitude`, `reflex`, `will` nullable (`number \| null`). |
-| `ComputedStats` | Make `ac`, `fortitude`, `reflex`, `will` entries optional. |
-| `Creature` | Add optional `hardness?` field. |
+The `hazardLibrary` IndexedDB object store (database v5) holds imported hazards,
+keyed by `hazard.id`, with the same load/add/remove/dedupe treatment as the
+creature library (`src/lib/storage/hazard-library.ts`).
 
-### 8.3 New IndexedDB Store
+---
 
-`hazards` — keyed by `hazard.id`.
+## 7. UI
 
-### 8.4 New Factory Function
+- **Library pane** — a Hazards section (`HazardsSection.svelte`) parallel to the
+  Bestiary section, with import (`.json` / `.yaml`) and search. No weak/elite
+  toggle: hazards take no template adjustment.
+- **Manage modal** — `LibraryManageModal` lists creatures and hazards in
+  separate sections.
+- **Combatant card** — hazards already render with the `hazard` faction badge.
+- **Details panel** — for `sourceType === "hazard"`: the initiative stat is
+  labelled "Stealth", Speed is replaced by Hardness, and a Hazard section
+  (`details/HazardStatBlock.svelte`) renders the Detection / Routine / Disable /
+  Reset / Description text blocks. The template-adjustment toggle is hidden.
 
-`createCombatantFromHazard(hazard: Hazard): CombatantState` — in `domain/creatures/` or new `domain/hazards/`.
+---
 
-### 8.5 No New Commands
+## 8. Out of Scope
 
-Zero. Existing command vocabulary handles all hazard interactions.
-
-### 8.6 Orchestrator Logic
-
-- Disable progress tracking: orchestrator-level mutation, not domain command
-- Hazard factory invocation on "Add Hazard" UI action
-
-### 8.7 Test Priority
-
-1. **CreatureBaseStats nullability** — `deriveStats()` with null AC, null saves. Verify modifiers targeting null stats are skipped, ComputedStats entries omitted.
-2. **Hardness display** — verify it appears in the stat display and isn't consumed by any automated logic.
-3. **Hazard factory** — produces correct CombatantState from Hazard library entry. Handles missing AC, missing saves, missing HP.
-4. **Disable progress** — initialization from DisableCheck[], decrement, full-disable detection.
+- **Structured disable tracking** — dropped (see §2).
+- **Multi-segment hazards** — model each destroyable segment as a separate
+  combatant sharing the routine text.
+- **Simple hazards** — not tracked.
+- **Routine automation** — the GM resolves the routine manually, as with
+  creature abilities.

--- a/src/components/CombatantDetailsPanel.svelte
+++ b/src/components/CombatantDetailsPanel.svelte
@@ -15,6 +15,7 @@
   import StatRollButton from './ui/StatRollButton.svelte';
   import AbilityCard from './details/AbilityCard.svelte';
   import AttackRow from './details/AttackRow.svelte';
+  import HazardStatBlock from './details/HazardStatBlock.svelte';
   import SpellcastingBlockView from './details/SpellcastingBlockView.svelte';
 
   type SaveKey = 'fortitude' | 'reflex' | 'will';
@@ -70,6 +71,7 @@
     : '';
 
   $: computed = combatant ? computeCombatantStats(combatant) : null;
+  $: isHazard = combatant?.sourceType === 'hazard';
   $: adjustment = combatant?.templateAdjustment ?? 'normal';
   $: adjustedAttacks = combatant ? combatant.attacks.map((a) => adjustedAttack(a, adjustment)) : [];
   $: adjustedPassive = combatant
@@ -156,15 +158,21 @@
           </dd>
         </div>
         <div class="stat">
-          <SectionLabel>Perception</SectionLabel>
+          <SectionLabel>{isHazard ? 'Stealth' : 'Perception'}</SectionLabel>
           <dd
             title={computed ? statTooltip(computed.perception) : ''}
             class:modified={computed && computed.perception.final !== computed.perception.base}
           >{formatModifier(computed ? computed.perception.final : adjustedView!.perception)}</dd>
         </div>
         <div class="stat">
-          <SectionLabel>Speed</SectionLabel>
-          <dd>{adjustedView!.speed} ft</dd>
+          <SectionLabel>{isHazard ? 'Hardness' : 'Speed'}</SectionLabel>
+          <dd>
+            {#if isHazard}
+              {combatant.hazardData?.hardness ?? '—'}
+            {:else}
+              {adjustedView!.speed} ft
+            {/if}
+          </dd>
         </div>
       </dl>
       <div class="saves-grid">
@@ -197,6 +205,13 @@
         />
       </div>
     </section>
+
+    {#if isHazard && combatant.hazardData}
+      <section class="details__section" aria-label="Hazard">
+        <SectionLabel as="h3">Hazard</SectionLabel>
+        <HazardStatBlock data={combatant.hazardData} />
+      </section>
+    {/if}
 
     {#if adjustedPassive.length > 0}
       <section class="details__section" aria-label="Passive Abilities">

--- a/src/components/CombatantDetailsPanel.test.ts
+++ b/src/components/CombatantDetailsPanel.test.ts
@@ -375,4 +375,45 @@ describe('CombatantDetailsPanel', () => {
     expect(onSetNote).toHaveBeenCalledTimes(1);
     expect(onSetNote).toHaveBeenCalledWith('goblin-1', 'Watch the door.');
   });
+
+  describe('hazard combatants', () => {
+    function hazardCombatant() {
+      return combatant('dart-gallery-1', {
+        name: 'Poisoned Dart Gallery',
+        sourceType: 'hazard',
+        hazardData: {
+          stealth: 28,
+          stealthNote: 'DC 30 to detect; trained',
+          hardness: 10,
+          routine: 'The trap fires a volley of poisoned darts.',
+          disable: 'Thievery DC 26 to disarm a launcher.'
+        }
+      });
+    }
+
+    test('renders the Hazard section with routine and disable text', () => {
+      renderPanel(hazardCombatant());
+      const hazard = screen.getByLabelText('Hazard');
+      expect(hazard).toHaveTextContent('The trap fires a volley of poisoned darts.');
+      expect(hazard).toHaveTextContent('Thievery DC 26 to disarm a launcher.');
+    });
+
+    test('labels the initiative stat "Stealth" and shows Hardness instead of Speed', () => {
+      renderPanel(hazardCombatant());
+      const defenses = screen.getByLabelText('Defenses');
+      expect(defenses).toHaveTextContent('Stealth');
+      expect(defenses).toHaveTextContent('Hardness');
+      expect(defenses).not.toHaveTextContent('Speed');
+    });
+
+    test('hides the template adjustment toggle for hazards', () => {
+      renderPanel(hazardCombatant());
+      expect(screen.queryByRole('group', { name: 'Template adjustment' })).toBeNull();
+    });
+
+    test('does not render a Hazard section for creature combatants', () => {
+      renderPanel(combatant('goblin-1'));
+      expect(screen.queryByLabelText('Hazard')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/HazardsSection.svelte
+++ b/src/components/HazardsSection.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import type { Hazard } from '../domain';
+  import Button from './ui/Button.svelte';
+  import IconButton from './ui/IconButton.svelte';
+  import Input from './ui/Input.svelte';
+  import SectionLabel from './ui/SectionLabel.svelte';
+
+  export let hazards: Hazard[];
+  export let encounterCounts: Record<string, number> = {};
+  export let onAddToEncounter: (hazard: Hazard) => void;
+  export let onRemoveOneFromEncounter: (hazardId: string) => void;
+  export let onImportHazardFiles: ((files: File[]) => void) | undefined = undefined;
+  export let onOpenManageLibrary: (() => void) | undefined = undefined;
+
+  let query = '';
+  let fileInput: HTMLInputElement | undefined;
+
+  $: needle = query.trim().toLowerCase();
+  $: filtered = needle
+    ? hazards.filter((hazard) => {
+        if (hazard.name.toLowerCase().includes(needle)) return true;
+        return hazard.traits.some((t) => t.toLowerCase().includes(needle));
+      })
+    : hazards;
+
+  function handleFileChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    if (files.length > 0) {
+      onImportHazardFiles?.(files);
+    }
+    input.value = '';
+  }
+</script>
+
+<section class="hazards" aria-labelledby="hazards-label">
+  <header class="hazards__header">
+    <SectionLabel as="h3" id="hazards-label">Hazards</SectionLabel>
+    <span class="count">{hazards.length}</span>
+  </header>
+
+  <div class="hazards__actions">
+    {#if onImportHazardFiles}
+      <Button variant="secondary" size="sm" onclick={() => fileInput?.click()}>Import…</Button>
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept=".yaml,.yml,.json,application/yaml,text/yaml,application/json"
+        multiple
+        hidden
+        onchange={handleFileChange}
+      />
+    {/if}
+    {#if onOpenManageLibrary}
+      <Button variant="secondary" size="sm" onclick={onOpenManageLibrary}>Manage…</Button>
+    {/if}
+  </div>
+
+  <div class="hazards__search">
+    <Input ariaLabel="Search hazards" type="search" placeholder="Search…" bind:value={query}>
+      <span slot="leading" aria-hidden="true">⌕</span>
+    </Input>
+  </div>
+
+  {#if hazards.length === 0}
+    <p class="empty">Import a Foundry hazard JSON or YAML file to add complex hazards.</p>
+  {:else if filtered.length === 0}
+    <p class="empty">No matching hazards.</p>
+  {:else}
+    <ul class="rows">
+      {#each filtered as hazard (hazard.id)}
+        {@const count = encounterCounts[hazard.id] ?? 0}
+        <li class="row">
+          <button
+            type="button"
+            class="row__add"
+            aria-label="Add {hazard.name} to encounter"
+            title="Add to encounter"
+            onclick={() => onAddToEncounter(hazard)}
+          >
+            <span class="row__level" aria-label="Level {hazard.level}">{hazard.level}</span>
+            <span class="row__body">
+              <span class="row__name">{hazard.name}</span>
+              <span class="row__traits">{hazard.traits.join(' · ')}</span>
+            </span>
+          </button>
+          {#if count > 0}
+            <span class="row__count" aria-label="{count} in encounter">×{count}</span>
+            <IconButton
+              ariaLabel="Remove one {hazard.name} from encounter"
+              title="Remove one from encounter"
+              variant="default"
+              size={22}
+              onclick={() => onRemoveOneFromEncounter(hazard.id)}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                <path d="M2 6h8" />
+              </svg>
+            </IconButton>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .hazards {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-top: var(--border-thin);
+  }
+
+  .hazards__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+
+  .hazards__actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-ink-mute);
+  }
+
+  .empty {
+    margin: var(--space-2) 0 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0;
+    max-height: 320px;
+    overflow: auto;
+    border-top: var(--border-thin);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: var(--space-2);
+    align-items: center;
+    padding: 0;
+    border-bottom: 1px dashed var(--color-rule);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .row__add {
+    all: unset;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 48px 1fr;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) var(--space-2);
+    min-width: 0;
+    transition: background 0.08s;
+  }
+
+  .row__add:hover {
+    background: var(--color-panel-2);
+  }
+
+  .row__add:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: -2px;
+  }
+
+  .row__level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-serif);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--color-ink);
+  }
+
+  .row__body {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .row__name {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__traits {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row__count {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    color: var(--color-ink);
+    padding: 0 6px;
+  }
+</style>

--- a/src/components/HazardsSection.test.ts
+++ b/src/components/HazardsSection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Hazard } from '../domain';
+import HazardsSection from './HazardsSection.svelte';
+
+function hazard(id: string, name: string, traits: string[] = [], level = 5): Hazard {
+  return {
+    id,
+    name,
+    level,
+    traits,
+    rarity: 'common',
+    stealth: 20,
+    ac: 22,
+    fortitude: 10,
+    reflex: 14,
+    will: 8,
+    hp: 60,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    tags: []
+  };
+}
+
+function defaultProps(overrides: Record<string, unknown> = {}) {
+  return {
+    hazards: [],
+    encounterCounts: {},
+    onAddToEncounter: vi.fn(),
+    onRemoveOneFromEncounter: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('HazardsSection', () => {
+  test('renders one row per hazard with name and level', () => {
+    const hazards = [
+      hazard('a', 'Poisoned Dart Gallery', ['mechanical', 'trap'], 8),
+      hazard('b', 'Collapsing Ceiling', ['environmental'], 4)
+    ];
+    render(HazardsSection, { props: defaultProps({ hazards }) });
+    expect(screen.getByText('Poisoned Dart Gallery')).toBeInTheDocument();
+    expect(screen.getByText('Collapsing Ceiling')).toBeInTheDocument();
+  });
+
+  test('search filters hazards by name (case-insensitive)', async () => {
+    const hazards = [
+      hazard('a', 'Poisoned Dart Gallery', ['trap'], 8),
+      hazard('b', 'Collapsing Ceiling', ['environmental'], 4)
+    ];
+    render(HazardsSection, { props: defaultProps({ hazards }) });
+    const search = screen.getByRole('searchbox', { name: 'Search hazards' });
+    await fireEvent.input(search, { target: { value: 'CEILING' } });
+    expect(screen.getByText('Collapsing Ceiling')).toBeInTheDocument();
+    expect(screen.queryByText('Poisoned Dart Gallery')).not.toBeInTheDocument();
+  });
+
+  test('search also matches on hazard traits', async () => {
+    const hazards = [
+      hazard('a', 'Poisoned Dart Gallery', ['mechanical', 'trap'], 8),
+      hazard('b', 'Collapsing Ceiling', ['environmental'], 4)
+    ];
+    render(HazardsSection, { props: defaultProps({ hazards }) });
+    const search = screen.getByRole('searchbox', { name: 'Search hazards' });
+    await fireEvent.input(search, { target: { value: 'environmental' } });
+    expect(screen.getByText('Collapsing Ceiling')).toBeInTheDocument();
+    expect(screen.queryByText('Poisoned Dart Gallery')).not.toBeInTheDocument();
+  });
+
+  test('clicking a row calls onAddToEncounter with the hazard', async () => {
+    const onAddToEncounter = vi.fn();
+    const h = hazard('a', 'Poisoned Dart Gallery', ['trap'], 8);
+    render(HazardsSection, { props: defaultProps({ hazards: [h], onAddToEncounter }) });
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Add Poisoned Dart Gallery to encounter' })
+    );
+    expect(onAddToEncounter).toHaveBeenCalledWith(h);
+  });
+
+  test('renders the empty-library message when the library is empty', () => {
+    render(HazardsSection, { props: defaultProps() });
+    expect(
+      screen.getByText('Import a Foundry hazard JSON or YAML file to add complex hazards.')
+    ).toBeInTheDocument();
+  });
+
+  test('renders the empty-state message when the search filters everything out', async () => {
+    render(HazardsSection, { props: defaultProps({ hazards: [hazard('a', 'Pit Trap')] }) });
+    const search = screen.getByRole('searchbox', { name: 'Search hazards' });
+    await fireEvent.input(search, { target: { value: 'dragon' } });
+    expect(screen.getByText('No matching hazards.')).toBeInTheDocument();
+  });
+
+  test('shows a count badge and minus button when the hazard is in the encounter', async () => {
+    const onRemoveOneFromEncounter = vi.fn();
+    const h = hazard('a', 'Poisoned Dart Gallery', ['trap'], 8);
+    render(HazardsSection, {
+      props: defaultProps({
+        hazards: [h],
+        encounterCounts: { a: 2 },
+        onRemoveOneFromEncounter
+      })
+    });
+    expect(screen.getByText('×2')).toBeInTheDocument();
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove one Poisoned Dart Gallery from encounter' })
+    );
+    expect(onRemoveOneFromEncounter).toHaveBeenCalledWith('a');
+  });
+
+  test('does not render an adjustment toggle — hazards have no weak/elite template', () => {
+    render(HazardsSection, { props: defaultProps({ hazards: [hazard('a', 'Pit Trap')] }) });
+    expect(screen.queryByRole('button', { name: 'Elite' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Weak' })).not.toBeInTheDocument();
+  });
+
+  test('renders Manage… and Import… buttons only when their handlers are provided', async () => {
+    const onOpenManageLibrary = vi.fn();
+    render(HazardsSection, { props: defaultProps({ onOpenManageLibrary }) });
+    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    expect(onOpenManageLibrary).toHaveBeenCalled();
+  });
+});

--- a/src/components/LibraryManageModal.svelte
+++ b/src/components/LibraryManageModal.svelte
@@ -1,25 +1,44 @@
 <script lang="ts">
-  import type { Creature } from '../domain';
+  import type { Creature, Hazard } from '../domain';
   import Button from './ui/Button.svelte';
   import IconButton from './ui/IconButton.svelte';
 
   export let creatures: Creature[];
+  export let hazards: Hazard[] = [];
   export let onRemove: (creatureId: string) => void;
+  export let onRemoveHazard: (hazardId: string) => void = () => {};
   export let onClose: () => void;
 
-  let pendingRemoveId: string | null = null;
+  type EntryKind = 'creature' | 'hazard';
+  interface LibraryEntry {
+    id: string;
+    name: string;
+    level: number;
+    traits: string[];
+  }
 
-  function startRemove(id: string) {
-    pendingRemoveId = id;
+  // `creature` and `hazard` ids share no namespace, so a pending removal must
+  // track which library the id belongs to.
+  let pendingRemove: { kind: EntryKind; id: string } | null = null;
+
+  $: sections = [
+    { kind: 'creature' as EntryKind, label: 'Creatures', entries: creatures as LibraryEntry[] },
+    { kind: 'hazard' as EntryKind, label: 'Hazards', entries: hazards as LibraryEntry[] }
+  ];
+  $: isEmpty = creatures.length === 0 && hazards.length === 0;
+
+  function startRemove(kind: EntryKind, id: string) {
+    pendingRemove = { kind, id };
   }
 
   function cancelRemove() {
-    pendingRemoveId = null;
+    pendingRemove = null;
   }
 
-  function confirmRemove(id: string) {
-    pendingRemoveId = null;
-    onRemove(id);
+  function confirmRemove(kind: EntryKind, id: string) {
+    pendingRemove = null;
+    if (kind === 'creature') onRemove(id);
+    else onRemoveHazard(id);
   }
 
   function handleBackdropClick(event: MouseEvent) {
@@ -28,16 +47,12 @@
 
   function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
-      if (pendingRemoveId !== null) {
+      if (pendingRemove !== null) {
         cancelRemove();
         return;
       }
       onClose();
     }
-  }
-
-  function formatTraits(creature: Creature): string {
-    return creature.traits.join(' · ');
   }
 </script>
 
@@ -55,40 +70,49 @@
     </header>
 
     <div class="modal__body">
-      {#if creatures.length === 0}
-        <p class="empty">Your library is empty. Import a YAML file to add creatures.</p>
+      {#if isEmpty}
+        <p class="empty">Your library is empty. Import a YAML or Foundry JSON file to add creatures or hazards.</p>
       {:else}
-        <ul class="rows">
-          {#each creatures as creature (creature.id)}
-            <li class="row">
-              <span class="row__level" aria-label="Level {creature.level}">{creature.level}</span>
-              <span class="row__body">
-                <span class="row__name">{creature.name}</span>
-                {#if creature.traits.length > 0}
-                  <span class="row__traits">{formatTraits(creature)}</span>
-                {/if}
-              </span>
-              {#if pendingRemoveId === creature.id}
-                <span class="row__confirm">
-                  <span class="row__confirm-text">Delete?</span>
-                  <Button variant="ghost" size="sm" onclick={cancelRemove}>Cancel</Button>
-                  <Button variant="destructive" size="sm" onclick={() => confirmRemove(creature.id)}>
-                    Delete
-                  </Button>
-                </span>
-              {:else}
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onclick={() => startRemove(creature.id)}
-                  ariaLabel="Remove {creature.name} from library"
-                >
-                  Remove
-                </Button>
-              {/if}
-            </li>
-          {/each}
-        </ul>
+        {#each sections as section (section.kind)}
+          {#if section.entries.length > 0}
+            <h3 class="section-label">{section.label}</h3>
+            <ul class="rows">
+              {#each section.entries as entry (entry.id)}
+                <li class="row">
+                  <span class="row__level" aria-label="Level {entry.level}">{entry.level}</span>
+                  <span class="row__body">
+                    <span class="row__name">{entry.name}</span>
+                    {#if entry.traits.length > 0}
+                      <span class="row__traits">{entry.traits.join(' · ')}</span>
+                    {/if}
+                  </span>
+                  {#if pendingRemove?.kind === section.kind && pendingRemove.id === entry.id}
+                    <span class="row__confirm">
+                      <span class="row__confirm-text">Delete?</span>
+                      <Button variant="ghost" size="sm" onclick={cancelRemove}>Cancel</Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onclick={() => confirmRemove(section.kind, entry.id)}
+                      >
+                        Delete
+                      </Button>
+                    </span>
+                  {:else}
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onclick={() => startRemove(section.kind, entry.id)}
+                      ariaLabel="Remove {entry.name} from library"
+                    >
+                      Remove
+                    </Button>
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        {/each}
       {/if}
     </div>
 
@@ -155,6 +179,20 @@
     color: var(--color-ink-mute);
     font-size: var(--text-base);
     font-style: italic;
+  }
+
+  .section-label {
+    margin: var(--space-3) 0 var(--space-1);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-widest);
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+  }
+
+  .section-label:first-child {
+    margin-top: 0;
   }
 
   .rows {

--- a/src/components/LibraryManageModal.test.ts
+++ b/src/components/LibraryManageModal.test.ts
@@ -52,8 +52,52 @@ describe('LibraryManageModal', () => {
       props: { creatures: [], onRemove: vi.fn(), onClose: vi.fn() }
     });
     expect(
-      screen.getByText('Your library is empty. Import a YAML file to add creatures.')
+      screen.getByText(
+        'Your library is empty. Import a YAML or Foundry JSON file to add creatures or hazards.'
+      )
     ).toBeInTheDocument();
+  });
+
+  test('lists hazards in their own section and confirms removal via onRemoveHazard', async () => {
+    const onRemoveHazard = vi.fn();
+    render(LibraryManageModal, {
+      props: {
+        creatures: [],
+        hazards: [
+          {
+            id: 'dart-gallery',
+            name: 'Dart Gallery',
+            level: 8,
+            traits: ['trap'],
+            rarity: 'common',
+            stealth: 28,
+            ac: 27,
+            fortitude: 13,
+            reflex: 17,
+            will: 8,
+            hp: 100,
+            immunities: [],
+            resistances: [],
+            weaknesses: [],
+            attacks: [],
+            passiveAbilities: [],
+            reactiveAbilities: [],
+            activeAbilities: [],
+            tags: []
+          }
+        ],
+        onRemove: vi.fn(),
+        onRemoveHazard,
+        onClose: vi.fn()
+      }
+    });
+    expect(screen.getByText('Hazards')).toBeInTheDocument();
+    expect(screen.getByText('Dart Gallery')).toBeInTheDocument();
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Dart Gallery from library' })
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onRemoveHazard).toHaveBeenCalledWith('dart-gallery');
   });
 
   test('Remove button does not immediately call onRemove — requires inline confirm', async () => {

--- a/src/components/LibraryPane.svelte
+++ b/src/components/LibraryPane.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
-  import type { Creature, PartyMember } from '../domain';
+  import type { Creature, Hazard, PartyMember } from '../domain';
   import type {
     ConditionOption,
     ManualCombatantInput,
     TemplateAdjustmentChoice
   } from '$lib/encounter-app';
   import BestiarySection from './BestiarySection.svelte';
+  import HazardsSection from './HazardsSection.svelte';
   import LibraryManageModal from './LibraryManageModal.svelte';
   import PartySection from './PartySection.svelte';
   import SetupPanel from './SetupPanel.svelte';
 
   export let canStart: boolean;
   export let creatures: Creature[];
+  export let hazards: Hazard[];
   export let partyMembers: PartyMember[];
   export let conditionOptions: ConditionOption[];
   export let encounterCounts: Record<string, number>;
@@ -20,6 +22,10 @@
   export let onAddManual: (input: Omit<ManualCombatantInput, 'id'>) => void;
   export let onImportCreatureFiles: (files: File[]) => void;
   export let onRemoveCreature: (id: string) => void;
+  export let onAddOneFromHazards: (hazard: Hazard) => void;
+  export let onRemoveOneFromHazardsCount: (hazardId: string) => void;
+  export let onImportHazardFiles: (files: File[]) => void;
+  export let onRemoveHazard: (id: string) => void;
   export let onAddPartyMemberToEncounter: (partyMember: PartyMember) => void;
   export let onRemovePartyMember: (id: string) => void;
   export let onSavePartyMember: (partyMember: PartyMember) => void;
@@ -50,6 +56,14 @@
     {onImportCreatureFiles}
     onOpenManageLibrary={openManage}
   />
+  <HazardsSection
+    {hazards}
+    {encounterCounts}
+    onAddToEncounter={onAddOneFromHazards}
+    onRemoveOneFromEncounter={onRemoveOneFromHazardsCount}
+    {onImportHazardFiles}
+    onOpenManageLibrary={openManage}
+  />
   <PartySection
     {partyMembers}
     {conditionOptions}
@@ -64,7 +78,13 @@
 </aside>
 
 {#if manageOpen}
-  <LibraryManageModal {creatures} onRemove={onRemoveCreature} onClose={closeManage} />
+  <LibraryManageModal
+    {creatures}
+    {hazards}
+    onRemove={onRemoveCreature}
+    {onRemoveHazard}
+    onClose={closeManage}
+  />
 {/if}
 
 <style>

--- a/src/components/LibraryPane.test.ts
+++ b/src/components/LibraryPane.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import type { Creature, PartyMember } from '../domain';
+import type { Creature, Hazard, PartyMember } from '../domain';
 import LibraryPane from './LibraryPane.svelte';
 
 function creature(id: string, name: string): Creature {
@@ -31,10 +31,35 @@ function creature(id: string, name: string): Creature {
   };
 }
 
+function hazard(id: string, name: string): Hazard {
+  return {
+    id,
+    name,
+    level: 5,
+    traits: ['trap'],
+    rarity: 'common',
+    stealth: 20,
+    ac: 22,
+    fortitude: 10,
+    reflex: 14,
+    will: 8,
+    hp: 60,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    tags: []
+  };
+}
+
 function baseProps(overrides: Record<string, unknown> = {}) {
   return {
     canStart: false,
     creatures: [] as Creature[],
+    hazards: [] as Hazard[],
     partyMembers: [] as PartyMember[],
     conditionOptions: [],
     encounterCounts: {},
@@ -43,6 +68,10 @@ function baseProps(overrides: Record<string, unknown> = {}) {
     onAddManual: vi.fn(),
     onImportCreatureFiles: vi.fn(),
     onRemoveCreature: vi.fn(),
+    onAddOneFromHazards: vi.fn(),
+    onRemoveOneFromHazardsCount: vi.fn(),
+    onImportHazardFiles: vi.fn(),
+    onRemoveHazard: vi.fn(),
     onAddPartyMemberToEncounter: vi.fn(),
     onRemovePartyMember: vi.fn(),
     onSavePartyMember: vi.fn(),
@@ -51,6 +80,12 @@ function baseProps(overrides: Record<string, unknown> = {}) {
     onReset: vi.fn(),
     ...overrides
   };
+}
+
+// The Bestiary and Hazards sections each render their own "Manage…" button;
+// both open the same modal, so the first is a fine handle.
+function openManage() {
+  return fireEvent.click(screen.getAllByRole('button', { name: 'Manage…' })[0]);
 }
 
 describe('LibraryPane', () => {
@@ -66,14 +101,14 @@ describe('LibraryPane', () => {
 
   test('clicking "Manage…" from the bestiary section opens the manage modal', async () => {
     render(LibraryPane, { props: baseProps({ creatures: [creature('goblin-1', 'Goblin')] }) });
-    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    await openManage();
     // Manage modal shows a "Done" button — the cheapest non-ambiguous handle.
     expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
   });
 
   test('closing the manage modal hides it again', async () => {
     render(LibraryPane, { props: baseProps({ creatures: [creature('goblin-1', 'Goblin')] }) });
-    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    await openManage();
     await fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
   });
@@ -86,11 +121,27 @@ describe('LibraryPane', () => {
         onRemoveCreature
       })
     });
-    await fireEvent.click(screen.getByRole('button', { name: 'Manage…' }));
+    await openManage();
     await fireEvent.click(
       screen.getByRole('button', { name: 'Remove Goblin Warrior from library' })
     );
     await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
     expect(onRemoveCreature).toHaveBeenCalledWith('goblin-1');
+  });
+
+  test('manage modal forwards remove-hazard events through onRemoveHazard', async () => {
+    const onRemoveHazard = vi.fn();
+    render(LibraryPane, {
+      props: baseProps({
+        hazards: [hazard('dart-gallery', 'Dart Gallery')],
+        onRemoveHazard
+      })
+    });
+    await openManage();
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Dart Gallery from library' })
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onRemoveHazard).toHaveBeenCalledWith('dart-gallery');
   });
 });

--- a/src/components/details/HazardStatBlock.svelte
+++ b/src/components/details/HazardStatBlock.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type { HazardData } from '../../domain';
+  import SectionLabel from '../ui/SectionLabel.svelte';
+
+  export let data: HazardData;
+
+  // Routine and disable text is read aloud by the GM each turn — order the
+  // blocks the way a printed statblock does: Routine first, then Disable.
+  $: blocks = [
+    { label: 'Detection', text: data.stealthNote },
+    { label: 'Routine', text: data.routine },
+    { label: 'Disable', text: data.disable },
+    { label: 'Reset', text: data.reset },
+    { label: 'Description', text: data.description }
+  ].filter((b): b is { label: string; text: string } => Boolean(b.text));
+</script>
+
+{#if blocks.length > 0}
+  <div class="hazard">
+    {#each blocks as block (block.label)}
+      <div class="hazard__block">
+        <SectionLabel>{block.label}</SectionLabel>
+        <p class="hazard__text">{block.text}</p>
+      </div>
+    {/each}
+  </div>
+{:else}
+  <p class="hazard__empty">No routine or disable text was imported for this hazard.</p>
+{/if}
+
+<style>
+  .hazard {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .hazard__block {
+    display: grid;
+    gap: 2px;
+  }
+
+  .hazard__text {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+    white-space: pre-line;
+  }
+
+  .hazard__empty {
+    margin: 0;
+    color: var(--color-ink-mute);
+    font-size: var(--text-base);
+    font-style: italic;
+  }
+</style>

--- a/src/components/details/HazardStatBlock.test.ts
+++ b/src/components/details/HazardStatBlock.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { HazardData } from '../../domain';
+import HazardStatBlock from './HazardStatBlock.svelte';
+
+function data(overrides: Partial<HazardData> = {}): HazardData {
+  return {
+    stealth: 28,
+    stealthNote: 'DC 30 to detect; trained',
+    hardness: 10,
+    routine: 'The trap fires a volley of poisoned darts.',
+    disable: 'Thievery DC 26 to disarm a launcher.',
+    reset: 'The trap resets after one hour.',
+    description: 'A gallery lined with hidden dart launchers.',
+    ...overrides
+  };
+}
+
+describe('HazardStatBlock', () => {
+  test('renders the routine, disable, reset, and detection text blocks', () => {
+    render(HazardStatBlock, { props: { data: data() } });
+    expect(screen.getByText('The trap fires a volley of poisoned darts.')).toBeInTheDocument();
+    expect(screen.getByText('Thievery DC 26 to disarm a launcher.')).toBeInTheDocument();
+    expect(screen.getByText('The trap resets after one hour.')).toBeInTheDocument();
+    expect(screen.getByText('DC 30 to detect; trained')).toBeInTheDocument();
+  });
+
+  test('labels each block', () => {
+    render(HazardStatBlock, { props: { data: data() } });
+    expect(screen.getByText('Routine')).toBeInTheDocument();
+    expect(screen.getByText('Disable')).toBeInTheDocument();
+    expect(screen.getByText('Detection')).toBeInTheDocument();
+  });
+
+  test('omits blocks whose text is absent', () => {
+    render(HazardStatBlock, {
+      props: { data: data({ disable: undefined, reset: undefined, description: undefined }) }
+    });
+    expect(screen.queryByText('Disable')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reset')).not.toBeInTheDocument();
+    expect(screen.getByText('Routine')).toBeInTheDocument();
+  });
+
+  test('shows a fallback message when no text blocks were imported', () => {
+    render(HazardStatBlock, {
+      props: {
+        data: {
+          stealth: 20,
+          stealthNote: undefined,
+          routine: undefined,
+          disable: undefined,
+          reset: undefined,
+          description: undefined
+        }
+      }
+    });
+    expect(
+      screen.getByText('No routine or disable text was imported for this hazard.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/domain/hazards/factory.test.ts
+++ b/src/domain/hazards/factory.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'vitest';
+import { expectSerializable } from '../test-support';
+import type { Hazard } from '../types';
+import { createCombatantFromHazard } from './factory';
+
+describe('createCombatantFromHazard', () => {
+  test('creates a hazard combatant from a hazard template', () => {
+    const hazard = hazardTemplate();
+
+    const combatant = createCombatantFromHazard({
+      hazard,
+      combatantId: 'dart-gallery-1',
+      name: 'Poisoned Dart Gallery 1'
+    });
+
+    expect(combatant).toMatchObject({
+      id: 'dart-gallery-1',
+      sourceId: 'poisoned-dart-gallery',
+      name: 'Poisoned Dart Gallery 1',
+      sourceType: 'hazard',
+      baseSnapshot: {
+        level: 8,
+        ac: 27,
+        fortitude: 13,
+        reflex: 17,
+        will: 8,
+        hp: 100,
+        speed: 0,
+        skills: {}
+      },
+      templateAdjustment: 'normal',
+      currentHp: 100,
+      tempHp: 0,
+      appliedEffects: [],
+      isAlive: true,
+      traits: ['mechanical', 'trap']
+    });
+    expect(combatant.spellcasting).toBeUndefined();
+    expectSerializable(combatant);
+  });
+
+  test('stores the stealth value in the snapshot perception slot for initiative', () => {
+    const combatant = createCombatantFromHazard({
+      hazard: hazardTemplate(),
+      combatantId: 'dart-gallery-1'
+    });
+
+    expect(combatant.baseSnapshot.perception).toBe(28);
+    expect(combatant.hazardData?.stealth).toBe(28);
+  });
+
+  test('populates hazardData with the free-form text blocks', () => {
+    const combatant = createCombatantFromHazard({
+      hazard: hazardTemplate(),
+      combatantId: 'dart-gallery-1'
+    });
+
+    expect(combatant.hazardData).toEqual({
+      stealth: 28,
+      stealthNote: 'expert',
+      hardness: 10,
+      routine: 'The trap fires a volley of poisoned darts.',
+      disable: 'Thievery DC 26 to disarm a launcher.',
+      reset: 'The trap resets after one hour.',
+      description: 'A gallery lined with hidden dart launchers.'
+    });
+  });
+
+  test('omits absent optional hazardData fields', () => {
+    const combatant = createCombatantFromHazard({
+      hazard: hazardTemplate({
+        stealthNote: undefined,
+        hardness: undefined,
+        routine: undefined,
+        disable: undefined,
+        reset: undefined,
+        description: undefined
+      }),
+      combatantId: 'dart-gallery-1'
+    });
+
+    expect(combatant.hazardData).toEqual({ stealth: 28 });
+  });
+
+  test('defaults the combatant name to the hazard name', () => {
+    const combatant = createCombatantFromHazard({
+      hazard: hazardTemplate(),
+      combatantId: 'dart-gallery-1'
+    });
+
+    expect(combatant.name).toBe('Poisoned Dart Gallery');
+  });
+
+  test('deep-clones hazard attacks and abilities', () => {
+    const hazard = hazardTemplate();
+
+    const combatant = createCombatantFromHazard({
+      hazard,
+      combatantId: 'dart-gallery-1'
+    });
+
+    combatant.traits?.push('elite');
+    combatant.attacks[0].traits.push('range-60');
+    combatant.reactiveAbilities[0].description = 'Changed on combatant only';
+
+    expect(hazard.traits).toEqual(['mechanical', 'trap']);
+    expect(hazard.attacks[0].traits).toEqual([]);
+    expect(hazard.reactiveAbilities[0].description).toBe('Strike the triggering creature.');
+  });
+});
+
+function hazardTemplate(overrides: Partial<Hazard> = {}): Hazard {
+  return {
+    id: 'poisoned-dart-gallery',
+    name: 'Poisoned Dart Gallery',
+    level: 8,
+    traits: ['mechanical', 'trap'],
+    rarity: 'common',
+    stealth: 28,
+    stealthNote: 'expert',
+    ac: 27,
+    fortitude: 13,
+    reflex: 17,
+    will: 8,
+    hp: 100,
+    hardness: 10,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    routine: 'The trap fires a volley of poisoned darts.',
+    disable: 'Thievery DC 26 to disarm a launcher.',
+    reset: 'The trap resets after one hour.',
+    description: 'A gallery lined with hidden dart launchers.',
+    attacks: [
+      {
+        name: 'poisoned dart',
+        type: 'ranged',
+        modifier: 21,
+        traits: [],
+        damage: [{ dice: 3, dieSize: 4, bonus: 2, type: 'piercing' }]
+      }
+    ],
+    passiveAbilities: [],
+    reactiveAbilities: [
+      {
+        name: 'Dart Volley',
+        actions: 'reaction',
+        trigger: 'A creature enters the gallery.',
+        description: 'Strike the triggering creature.'
+      }
+    ],
+    activeAbilities: [],
+    source: 'Test Source',
+    tags: [],
+    ...overrides
+  };
+}

--- a/src/domain/hazards/factory.ts
+++ b/src/domain/hazards/factory.ts
@@ -1,0 +1,71 @@
+import type { CombatantState, CreatureSnapshot, Hazard, HazardData } from '../types';
+
+export interface CreateCombatantFromHazardInput {
+  hazard: Hazard;
+  combatantId: string;
+  name?: string;
+}
+
+/**
+ * Builds a hazard combatant from a library `Hazard`. The result is a plain
+ * `CombatantState` — the domain reducer, effects engine, initiative, and HP
+ * tracking treat it identically to a creature combatant.
+ *
+ * A complex hazard rolls Stealth for initiative, so the hazard's `stealth`
+ * value occupies the snapshot `perception` slot (the slot the initiative
+ * logic reads). The UI labels that stat "Stealth" for hazards. Hazards never
+ * receive weak/elite templates, so `templateAdjustment` stays `'normal'`.
+ */
+export function createCombatantFromHazard({
+  hazard,
+  combatantId,
+  name
+}: CreateCombatantFromHazardInput): CombatantState {
+  const baseSnapshot: CreatureSnapshot = {
+    level: hazard.level,
+    ac: hazard.ac,
+    fortitude: hazard.fortitude,
+    reflex: hazard.reflex,
+    will: hazard.will,
+    perception: hazard.stealth,
+    hp: hazard.hp,
+    speed: 0,
+    skills: {}
+  };
+
+  return {
+    id: combatantId,
+    sourceId: hazard.id,
+    name: name ?? hazard.name,
+    sourceType: 'hazard',
+    baseSnapshot,
+    templateAdjustment: 'normal',
+    currentHp: hazard.hp,
+    tempHp: 0,
+    appliedEffects: [],
+    reactionUsedThisRound: false,
+    isAlive: true,
+    attacks: cloneValue(hazard.attacks),
+    passiveAbilities: cloneValue(hazard.passiveAbilities),
+    reactiveAbilities: cloneValue(hazard.reactiveAbilities),
+    activeAbilities: cloneValue(hazard.activeAbilities),
+    spellcasting: undefined,
+    traits: cloneValue(hazard.traits),
+    hazardData: buildHazardData(hazard)
+  };
+}
+
+function buildHazardData(hazard: Hazard): HazardData {
+  const data: HazardData = { stealth: hazard.stealth };
+  if (hazard.stealthNote !== undefined) data.stealthNote = hazard.stealthNote;
+  if (hazard.hardness !== undefined) data.hardness = hazard.hardness;
+  if (hazard.routine !== undefined) data.routine = hazard.routine;
+  if (hazard.disable !== undefined) data.disable = hazard.disable;
+  if (hazard.reset !== undefined) data.reset = hazard.reset;
+  if (hazard.description !== undefined) data.description = hazard.description;
+  return data;
+}
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,6 +1,7 @@
 export { applyCommand } from './reducer';
 export { createCombatantFromCreature } from './creatures/clone';
 export { createCombatantFromPartyMember } from './party/factory';
+export { createCombatantFromHazard } from './hazards/factory';
 export { applyEliteWeak, adjustedLevel } from './creatures/templates';
 export {
   adjustedAbility,
@@ -63,6 +64,8 @@ export type {
   EffectLibrary,
   EncounterPhase,
   EncounterState,
+  Hazard,
+  HazardData,
   InitiativeState,
   Languages,
   LogEntry,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -156,6 +156,79 @@ export interface Creature {
   notes?: string;
 }
 
+/**
+ * Display-only data carried by hazard combatants. The domain reducer never
+ * reads these fields — they exist purely so the UI can render a hazard's
+ * statblock. Creature, party-member, and companion combatants leave this
+ * `undefined`.
+ *
+ * `routine` and `disable` are free-form text (HTML stripped on import). The GM
+ * reads them at the hazard's turn and resolves outcomes via the standard
+ * command vocabulary — there is no structured disable-progress tracking.
+ */
+export interface HazardData {
+  /** Stealth value — a complex hazard's initiative modifier. */
+  stealth: number;
+  /** Detection note, e.g. "DC 30 to detect; trained". */
+  stealthNote?: string;
+  /** Flat damage reduction. Display-only — the GM subtracts it before APPLY_DAMAGE. */
+  hardness?: number;
+  /** What the hazard does each round. */
+  routine?: string;
+  /** How the hazard can be disabled (skills, DCs). */
+  disable?: string;
+  /** How the hazard resets after being triggered. */
+  reset?: string;
+  /** Flavor text / GM notes. */
+  description?: string;
+}
+
+/**
+ * A complex hazard as stored in the hazard library. Hazards become combatants
+ * via `createCombatantFromHazard` and are then treated identically to creature
+ * combatants by the domain. Simple hazards are not modeled — they are a GM
+ * note, not an encounter entity.
+ */
+export interface Hazard {
+  id: string;
+  name: string;
+  level: number;
+  traits: string[];
+  rarity: CreatureRarity;
+
+  // Detection / initiative
+  stealth: number;
+  stealthNote?: string;
+
+  // Defense
+  ac: number;
+  fortitude: number;
+  reflex: number;
+  will: number;
+  hp: number;
+  hardness?: number;
+  immunities: CreatureImmunity[];
+  resistances: { type: string; value: number }[];
+  weaknesses: { type: string; value: number }[];
+
+  // Free-form text blocks
+  routine?: string;
+  disable?: string;
+  reset?: string;
+  description?: string;
+
+  // Routine actions, reactions, and listed Strikes
+  attacks: Attack[];
+  passiveAbilities: Ability[];
+  reactiveAbilities: Ability[];
+  activeAbilities: Ability[];
+
+  // Meta
+  source?: string;
+  tags: string[];
+  notes?: string;
+}
+
 export interface PartyMember {
   id: string;
   name: string;
@@ -253,6 +326,8 @@ export interface CombatantState {
   spellcasting?: CombatantSpellcasting[];
   traits?: string[];
   size?: CreatureSize;
+  /** Hazard-specific display data. Populated only when `sourceType === 'hazard'`. */
+  hazardData?: HazardData;
 }
 
 export type PromptBoundary = { type: 'turnStart' | 'turnEnd'; ownerId: CombatantId };

--- a/src/lib/encounter-app.ts
+++ b/src/lib/encounter-app.ts
@@ -1,6 +1,7 @@
 import {
   applyCommand,
   createCombatantFromCreature,
+  createCombatantFromHazard,
   createCombatantFromPartyMember,
   deriveStats,
   effectLibrary,
@@ -19,6 +20,7 @@ import type {
   Duration,
   EffectDefinition,
   EncounterState,
+  Hazard,
   LogEntry,
   PartyMember
 } from '../domain';
@@ -115,6 +117,20 @@ export function makeCreatureCombatant(input: CreatureCombatantInput): CombatantS
     combatantId: input.combatantId,
     name: input.name,
     adjustment: input.adjustment === 'normal' ? undefined : input.adjustment
+  });
+}
+
+export interface HazardCombatantInput {
+  hazard: Hazard;
+  combatantId: string;
+  name?: string;
+}
+
+export function makeHazardCombatant(input: HazardCombatantInput): CombatantState {
+  return createCombatantFromHazard({
+    hazard: input.hazard,
+    combatantId: input.combatantId,
+    name: input.name
   });
 }
 

--- a/src/lib/foundry/hazard-mapper.test.ts
+++ b/src/lib/foundry/hazard-mapper.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest';
+import { mapFoundryHazardToHazard } from './hazard-mapper';
+import type { FoundryHazard } from './hazard-types';
+
+describe('mapFoundryHazardToHazard', () => {
+  test('maps a complex Foundry hazard actor to a domain Hazard', () => {
+    const result = mapFoundryHazardToHazard(sampleHazard());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toMatchObject({
+      id: 'poisoned-dart-gallery',
+      name: 'Poisoned Dart Gallery',
+      level: 8,
+      traits: ['mechanical', 'trap'],
+      rarity: 'common',
+      stealth: 28,
+      stealthNote: 'DC 30 to detect; trained',
+      ac: 27,
+      fortitude: 13,
+      reflex: 17,
+      will: 8,
+      hp: 100,
+      hardness: 10,
+      source: 'Extinction Curse'
+    });
+  });
+
+  test('HTML-strips the routine and disable text blocks', () => {
+    const result = mapFoundryHazardToHazard(sampleHazard());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.routine).toBe('The trap fires a volley of poisoned darts.');
+    expect(result.value.disable).toBe('Thievery DC 26 to disarm a launcher.');
+    expect(result.value.routine).not.toContain('<');
+  });
+
+  test('maps Strike items and reaction items', () => {
+    const result = mapFoundryHazardToHazard(sampleHazard());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.attacks).toHaveLength(1);
+    expect(result.value.attacks[0]).toMatchObject({ name: 'Dart', type: 'ranged', modifier: 21 });
+    expect(result.value.reactiveAbilities).toHaveLength(1);
+    expect(result.value.reactiveAbilities[0].name).toBe('Dart Volley');
+  });
+
+  test('rejects a non-hazard document', () => {
+    const result = mapFoundryHazardToHazard({ ...sampleHazard(), type: 'npc' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain('Expected document type "hazard"');
+  });
+
+  test('rejects a simple (non-complex) hazard', () => {
+    const doc = sampleHazard();
+    doc.system!.details!.isComplex = false;
+    const result = mapFoundryHazardToHazard(doc);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain('not complex');
+  });
+
+  test('rejects a hazard missing its level', () => {
+    const doc = sampleHazard();
+    delete doc.system!.details!.level;
+    const result = mapFoundryHazardToHazard(doc);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain('level');
+  });
+
+  test('warns and defaults when AC, HP, or Stealth are absent', () => {
+    const doc = sampleHazard();
+    delete doc.system!.attributes!.ac;
+    delete doc.system!.attributes!.hp;
+    delete doc.system!.attributes!.stealth;
+    const result = mapFoundryHazardToHazard(doc);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ac).toBe(0);
+    expect(result.value.hp).toBe(0);
+    expect(result.value.stealth).toBe(0);
+    expect(result.warnings).toHaveLength(3);
+  });
+
+  test('accepts hardness stored as a bare number', () => {
+    const doc = sampleHazard();
+    doc.system!.attributes!.hardness = 14;
+    const result = mapFoundryHazardToHazard(doc);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hardness).toBe(14);
+  });
+});
+
+function sampleHazard(): FoundryHazard {
+  return {
+    name: 'Poisoned Dart Gallery',
+    type: 'hazard',
+    system: {
+      details: {
+        level: { value: 8 },
+        isComplex: true,
+        routine: '<p>The trap fires a volley of poisoned darts.</p>',
+        disable: '<p>Thievery DC 26 to disarm a launcher.</p>',
+        reset: '<p>The trap resets after one hour.</p>',
+        description: '<p>A gallery lined with hidden dart launchers.</p>',
+        publication: { title: 'Extinction Curse' }
+      },
+      attributes: {
+        ac: { value: 27 },
+        hp: { max: 100, value: 100 },
+        hardness: { value: 10 },
+        stealth: { value: 28, details: 'DC 30 to detect; trained' },
+        immunities: [{ type: 'object-immunities' }],
+        weaknesses: [],
+        resistances: []
+      },
+      saves: {
+        fortitude: { value: 13 },
+        reflex: { value: 17 },
+        will: { value: 8 }
+      },
+      traits: {
+        value: ['mechanical', 'trap'],
+        rarity: 'common'
+      }
+    },
+    items: [
+      {
+        type: 'melee',
+        name: 'Dart',
+        system: {
+          bonus: { value: 21 },
+          damageRolls: { a: { damage: '3d4+2', damageType: 'piercing' } },
+          range: { increment: 60 },
+          traits: { value: [] }
+        }
+      },
+      {
+        type: 'action',
+        name: 'Dart Volley',
+        system: {
+          actionType: { value: 'reaction' },
+          description: { value: '<p>The trap Strikes the triggering creature.</p>' }
+        }
+      }
+    ]
+  };
+}

--- a/src/lib/foundry/hazard-mapper.ts
+++ b/src/lib/foundry/hazard-mapper.ts
@@ -1,0 +1,134 @@
+import type { Hazard } from '../../domain';
+import { stripFoundryMarkup } from './text';
+import {
+  type MapResult,
+  type Warn,
+  mapAttacks,
+  mapDamageTypeArray,
+  mapImmunities,
+  mapRarity,
+  partitionAbilities,
+  requireNum,
+  slugifyName
+} from './shared';
+import type { FoundryHazard, FoundryHazardSystem } from './hazard-types';
+
+function mapHardness(raw: number | { value?: number } | undefined): number | undefined {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (raw && typeof raw === 'object' && typeof raw.value === 'number' && Number.isFinite(raw.value)) {
+    return raw.value;
+  }
+  return undefined;
+}
+
+/** Maps a non-empty stripped text block, or undefined when the source is blank. */
+function textBlock(raw: string | undefined): string | undefined {
+  const stripped = stripFoundryMarkup(raw);
+  return stripped === '' ? undefined : stripped;
+}
+
+/**
+ * Maps a single Foundry pf2e `hazard` actor document to a domain `Hazard`.
+ *
+ * Only complex hazards are tracked — simple hazards are a GM note, not an
+ * encounter entity — so a non-complex document is rejected. Foundry stores the
+ * routine and disable instructions as free-form HTML; they are HTML-stripped
+ * into plain text the GM reads at the table.
+ */
+export function mapFoundryHazardToHazard(doc: unknown): MapResult<Hazard> {
+  if (typeof doc !== 'object' || doc === null || Array.isArray(doc)) {
+    return { ok: false, error: 'Foundry document must be a JSON object' };
+  }
+  const hazardDoc = doc as FoundryHazard;
+  if (hazardDoc.type !== 'hazard') {
+    return {
+      ok: false,
+      error: `Expected document type "hazard", got ${JSON.stringify(hazardDoc.type)}`
+    };
+  }
+  if (typeof hazardDoc.name !== 'string' || hazardDoc.name.trim() === '') {
+    return { ok: false, error: 'Foundry hazard is missing a name' };
+  }
+
+  const sys: FoundryHazardSystem = hazardDoc.system ?? {};
+  const details = sys.details ?? {};
+  const attributes = sys.attributes ?? {};
+
+  if (details.isComplex !== true) {
+    return {
+      ok: false,
+      error: `Foundry hazard "${hazardDoc.name}" is not complex — only complex hazards are tracked as encounter participants`
+    };
+  }
+
+  const level = requireNum(details.level?.value);
+  if (level === null) {
+    return {
+      ok: false,
+      error: `Foundry hazard "${hazardDoc.name}" is missing required field: system.details.level.value`
+    };
+  }
+
+  const warnings: string[] = [];
+  const warn: Warn = (msg) => warnings.push(msg);
+
+  const stealth = requireNum(attributes.stealth?.value);
+  if (stealth === null) {
+    warn('Hazard has no Stealth value — defaulted to 0 (set the initiative modifier manually)');
+  }
+  const ac = requireNum(attributes.ac?.value);
+  if (ac === null) warn('Hazard has no AC — defaulted to 0');
+  const hp = requireNum(attributes.hp?.max) ?? requireNum(attributes.hp?.value);
+  if (hp === null) warn('Hazard has no HP — defaulted to 0');
+
+  const items = Array.isArray(hazardDoc.items) ? hazardDoc.items : [];
+  const attacks = mapAttacks(items);
+  const { passive, reactive, active } = partitionAbilities(items, warn);
+
+  const hazard: Hazard = {
+    id: slugifyName(hazardDoc.name),
+    name: hazardDoc.name,
+    level,
+    traits: Array.isArray(sys.traits?.value)
+      ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+      : [],
+    rarity: mapRarity(sys.traits?.rarity),
+    stealth: stealth ?? 0,
+    ac: ac ?? 0,
+    fortitude: requireNum(sys.saves?.fortitude?.value) ?? 0,
+    reflex: requireNum(sys.saves?.reflex?.value) ?? 0,
+    will: requireNum(sys.saves?.will?.value) ?? 0,
+    hp: hp ?? 0,
+    immunities: mapImmunities(attributes.immunities),
+    resistances: mapDamageTypeArray(attributes.resistances),
+    weaknesses: mapDamageTypeArray(attributes.weaknesses),
+    attacks,
+    passiveAbilities: passive,
+    reactiveAbilities: reactive,
+    activeAbilities: active,
+    tags: []
+  };
+
+  const stealthNote = textBlock(attributes.stealth?.details);
+  if (stealthNote !== undefined) hazard.stealthNote = stealthNote;
+
+  const hardness = mapHardness(attributes.hardness);
+  if (hardness !== undefined) hazard.hardness = hardness;
+
+  const routine = textBlock(details.routine);
+  if (routine !== undefined) hazard.routine = routine;
+
+  const disable = textBlock(details.disable);
+  if (disable !== undefined) hazard.disable = disable;
+
+  const reset = textBlock(details.reset);
+  if (reset !== undefined) hazard.reset = reset;
+
+  const description = textBlock(details.description);
+  if (description !== undefined) hazard.description = description;
+
+  const source = details.publication?.title;
+  if (typeof source === 'string' && source.trim() !== '') hazard.source = source.trim();
+
+  return { ok: true, value: hazard, warnings };
+}

--- a/src/lib/foundry/hazard-types.ts
+++ b/src/lib/foundry/hazard-types.ts
@@ -1,0 +1,52 @@
+/**
+ * Narrow TypeScript types for the subset of the Foundry pf2e `hazard` actor
+ * JSON schema the hazard mapper reads. Like `types.ts` (the NPC schema), every
+ * field is optional unless the mapper truly requires it — Foundry's real
+ * schema is sprawling and adventure hazards carry edge cases.
+ *
+ * Hazard `items` are the same shape as NPC items (`action`, `melee`, …), so we
+ * reuse `FoundryItem` / `FoundrySaves` / `FoundryTraits` from `types.ts`.
+ */
+import type { FoundryItem, FoundrySaves, FoundryTraits } from './types';
+
+export interface FoundryHazardDetails {
+  level?: { value?: number };
+  /** Complex hazards act in initiative; simple hazards are not tracked. */
+  isComplex?: boolean;
+  /** Free-form HTML — what the hazard does each round. */
+  routine?: string;
+  /** Free-form HTML — how the hazard is disabled. */
+  disable?: string;
+  /** Free-form HTML — how the hazard resets. */
+  reset?: string;
+  /** Free-form HTML — flavor text. */
+  description?: string;
+  publication?: { title?: string };
+}
+
+export interface FoundryHazardAttributes {
+  ac?: { value?: number };
+  hp?: { max?: number; value?: number };
+  /** Newer schema stores a bare number; older data nests it under `value`. */
+  hardness?: number | { value?: number };
+  /** Stealth `value` is the complex hazard's initiative modifier. */
+  stealth?: { value?: number; details?: string };
+  immunities?: { type?: string; exceptions?: string[] }[];
+  weaknesses?: { type?: string; value?: number; exceptions?: string[] }[];
+  resistances?: { type?: string; value?: number; exceptions?: string[] }[];
+}
+
+export interface FoundryHazardSystem {
+  details?: FoundryHazardDetails;
+  attributes?: FoundryHazardAttributes;
+  saves?: FoundrySaves;
+  traits?: FoundryTraits;
+}
+
+export interface FoundryHazard {
+  _id?: string;
+  name?: string;
+  type?: string;
+  system?: FoundryHazardSystem;
+  items?: FoundryItem[];
+}

--- a/src/lib/foundry/index.ts
+++ b/src/lib/foundry/index.ts
@@ -1,11 +1,14 @@
-import type { Creature } from '../../domain';
+import type { Creature, Hazard } from '../../domain';
 import { validateCreature } from '../yaml/creature-validator';
-import type { CreatureImportResult } from '../yaml';
+import { validateHazard } from '../yaml/hazard-validator';
+import type { CreatureImportResult, HazardImportResult } from '../yaml';
 import { mapFoundryNpcToCreature } from './mapper';
+import { mapFoundryHazardToHazard } from './hazard-mapper';
 
 export { mapFoundryNpcToCreature, slugifyName } from './mapper';
+export { mapFoundryHazardToHazard } from './hazard-mapper';
 export { stripFoundryMarkup } from './text';
-export type { MapResult } from './mapper';
+export type { MapResult } from './shared';
 
 /**
  * Imports a single Foundry pf2e NPC JSON document and maps it to a domain
@@ -56,4 +59,53 @@ export function importCreatureFoundryJson(text: string): CreatureImportResult {
 
   const creatures: Creature[] = [validation.value];
   return { creatures, issues: [...warningIssues, ...validation.issues], skipped: [] };
+}
+
+/**
+ * Imports a single Foundry pf2e `hazard` actor JSON document and maps it to a
+ * domain `Hazard`. Mirrors `importCreatureFoundryJson` — returns the same
+ * `HazardImportResult` shape as the YAML path so call sites branch on
+ * extension only. Non-complex hazards are reported as an issue (not skipped),
+ * since a single-document JSON file has no notion of a multi-doc stream.
+ */
+export function importHazardFoundryJson(text: string): HazardImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return {
+      hazards: [],
+      issues: [
+        {
+          documentIndex: 0,
+          path: '',
+          message: `JSON parse error: ${err instanceof Error ? err.message : String(err)}`
+        }
+      ],
+      skipped: []
+    };
+  }
+
+  const mapped = mapFoundryHazardToHazard(parsed);
+  if (!mapped.ok) {
+    return {
+      hazards: [],
+      issues: [{ documentIndex: 0, path: '', message: mapped.error }],
+      skipped: []
+    };
+  }
+
+  const warningIssues = mapped.warnings.map((message) => ({
+    documentIndex: 0,
+    path: '',
+    message: `Note: ${message}`
+  }));
+
+  const validation = validateHazard(mapped.value, 0);
+  if (!validation.ok) {
+    return { hazards: [], issues: [...warningIssues, ...validation.issues], skipped: [] };
+  }
+
+  const hazards: Hazard[] = [validation.value];
+  return { hazards, issues: [...warningIssues, ...validation.issues], skipped: [] };
 }

--- a/src/lib/foundry/mapper.ts
+++ b/src/lib/foundry/mapper.ts
@@ -1,13 +1,6 @@
 import type {
-  Ability,
-  AbilitySave,
   AbilityScores,
-  ActionCost,
-  Attack,
-  AttackType,
   Creature,
-  CreatureImmunity,
-  CreatureRarity,
   CreatureSize,
   DamageComponent,
   Languages,
@@ -20,12 +13,20 @@ import type {
   SpellcastingType
 } from '../../domain';
 import { stripFoundryMarkup } from './text';
+import {
+  type MapResult,
+  type Warn,
+  mapAttacks,
+  mapDamageTypeArray,
+  mapImmunities,
+  mapRarity,
+  parseDamageString,
+  partitionAbilities,
+  requireNum,
+  slugifyName
+} from './shared';
 import type {
-  FoundryActionItem,
-  FoundryActionSystem,
   FoundryItem,
-  FoundryMeleeItem,
-  FoundryMeleeSystem,
   FoundryNpc,
   FoundrySpellItem,
   FoundrySpellSystem,
@@ -33,11 +34,8 @@ import type {
   FoundrySpellcastingEntrySystem
 } from './types';
 
-export type MapResult =
-  | { ok: true; value: Creature; warnings: string[] }
-  | { ok: false; error: string };
-
-type Warn = (msg: string) => void;
+export { slugifyName, parseDamageString } from './shared';
+export type { MapResult } from './shared';
 
 const SIZE_MAP: Record<string, CreatureSize> = {
   tiny: 'tiny',
@@ -52,7 +50,6 @@ const SIZE_MAP: Record<string, CreatureSize> = {
   gargantuan: 'gargantuan'
 };
 
-const RARITIES: ReadonlySet<CreatureRarity> = new Set(['common', 'uncommon', 'rare', 'unique']);
 const TRADITIONS: ReadonlySet<SpellTradition> = new Set(['arcane', 'divine', 'occult', 'primal']);
 const SPELLCASTING_TYPES: ReadonlySet<SpellcastingType> = new Set([
   'prepared',
@@ -61,45 +58,10 @@ const SPELLCASTING_TYPES: ReadonlySet<SpellcastingType> = new Set([
   'focus'
 ]);
 const SENSE_ACUITIES: ReadonlySet<SenseAcuity> = new Set(['precise', 'imprecise', 'vague']);
-const THROWN_TRAIT = /^thrown(-\d+)?$/;
-const PHYSICAL_DAMAGE: ReadonlySet<string> = new Set(['slashing', 'piercing', 'bludgeoning']);
-
-export function slugifyName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/['']/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-export function parseDamageString(raw: string): DamageComponent | null {
-  // Examples: "1d6+1", "2d8", "1d4-1", "+5"
-  const m = /^\s*(?:(\d+)d(\d+))?\s*(?:([+\-])\s*(\d+))?\s*$/.exec(raw);
-  if (!m) return null;
-  const dice = m[1] ? Number(m[1]) : undefined;
-  const dieSize = m[2] ? Number(m[2]) : undefined;
-  const sign = m[3] === '-' ? -1 : 1;
-  const bonusAbs = m[4] !== undefined ? Number(m[4]) : undefined;
-  if (dice === undefined && bonusAbs === undefined) return null;
-  const out: { dice?: number; dieSize?: number; bonus?: number } = {};
-  if (dice !== undefined) out.dice = dice;
-  if (dieSize !== undefined) out.dieSize = dieSize;
-  if (bonusAbs !== undefined) out.bonus = sign * bonusAbs;
-  return { ...out, type: 'untyped' };
-}
-
-function requireNum(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
 
 function mapSize(raw: string | undefined): CreatureSize {
   if (!raw) return 'medium';
   return SIZE_MAP[raw.toLowerCase()] ?? 'medium';
-}
-
-function mapRarity(raw: string | undefined): CreatureRarity {
-  if (raw && RARITIES.has(raw as CreatureRarity)) return raw as CreatureRarity;
-  return 'common';
 }
 
 function mapSpeed(npc: FoundryNpc): Record<string, number> {
@@ -110,30 +72,6 @@ function mapSpeed(npc: FoundryNpc): Record<string, number> {
     if (typeof other?.value === 'number' && typeof other?.type === 'string') {
       out[other.type] = other.value;
     }
-  }
-  return out;
-}
-
-function mapImmunities(npc: FoundryNpc): CreatureImmunity[] {
-  const out: CreatureImmunity[] = [];
-  for (const im of npc.system?.attributes?.immunities ?? []) {
-    if (typeof im?.type !== 'string') continue;
-    const entry: CreatureImmunity = { type: im.type };
-    if (Array.isArray(im.exceptions) && im.exceptions.length > 0) {
-      entry.exceptions = im.exceptions.filter((e): e is string => typeof e === 'string');
-    }
-    out.push(entry);
-  }
-  return out;
-}
-
-function mapDamageTypeArray(
-  raw: { type?: string; value?: number; exceptions?: string[] }[] | undefined
-): { type: string; value: number }[] {
-  const out: { type: string; value: number }[] = [];
-  for (const r of raw ?? []) {
-    if (typeof r?.type !== 'string' || typeof r?.value !== 'number') continue;
-    out.push({ type: r.type, value: r.value });
   }
   return out;
 }
@@ -188,135 +126,6 @@ function mapSkills(npc: FoundryNpc): Record<string, number> {
     if (val && typeof val.base === 'number') out[key] = val.base;
   }
   return out;
-}
-
-function isRangedAttack(range: FoundryMeleeSystem['range']): boolean {
-  if (range == null) return false;
-  if (typeof range === 'string') return range.trim() !== '';
-  return typeof range.increment === 'number' && range.increment > 0;
-}
-
-function mapAttack(item: FoundryMeleeItem): Attack | null {
-  if (typeof item.name !== 'string') return null;
-  const sys: FoundryMeleeSystem = item.system ?? {};
-  const modifier = typeof sys.bonus?.value === 'number' ? sys.bonus.value : 0;
-  const traits = Array.isArray(sys.traits?.value)
-    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
-    : [];
-  // Foundry stores thrown melee weapons (javelin, dagger) as type:"melee" with a
-  // positive range.increment so the engine can resolve both modes. Bestiary
-  // statblocks render these as melee Strikes, so prefer melee when the trait
-  // says thrown.
-  const thrown = traits.some((t) => THROWN_TRAIT.test(t));
-  const type: AttackType = thrown ? 'melee' : isRangedAttack(sys.range) ? 'ranged' : 'melee';
-
-  const damage: DamageComponent[] = [];
-  for (const roll of Object.values(sys.damageRolls ?? {})) {
-    if (!roll) continue;
-    const parsed = typeof roll.damage === 'string' ? parseDamageString(roll.damage) : null;
-    if (!parsed) continue;
-    parsed.type = typeof roll.damageType === 'string' && roll.damageType !== '' ? roll.damageType : 'untyped';
-    if (roll.category === 'persistent') parsed.persistent = true;
-    damage.push(parsed);
-  }
-
-  const effects = Array.isArray(sys.attackEffects?.value)
-    ? sys.attackEffects.value.filter((e): e is string => typeof e === 'string')
-    : [];
-
-  const out: Attack = {
-    name: item.name,
-    type,
-    modifier,
-    traits,
-    damage
-  };
-  if (effects.length > 0) out.effects = effects;
-  const physicalIndex = damage.findIndex((d) => PHYSICAL_DAMAGE.has(d.type));
-  if (physicalIndex > 0) out.primaryDamageIndex = physicalIndex;
-  return out;
-}
-
-function mapAbility(item: FoundryActionItem): Ability | null {
-  if (typeof item.name !== 'string') return null;
-  const sys: FoundryActionSystem = item.system ?? {};
-  const description = stripFoundryMarkup(sys.description?.value);
-  const traits = Array.isArray(sys.traits?.value)
-    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
-    : undefined;
-
-  let actions: ActionCost | undefined;
-  const actionType = sys.actionType?.value;
-  if (actionType === 'reaction') actions = 'reaction';
-  else if (actionType === 'free') actions = 'free';
-  else if (actionType === 'action') {
-    const n = sys.actions?.value;
-    if (n === 1 || n === 2 || n === 3) actions = n;
-  }
-
-  let frequency: string | undefined;
-  if (sys.frequency && typeof sys.frequency.max === 'number' && typeof sys.frequency.per === 'string') {
-    frequency = `${sys.frequency.max} per ${sys.frequency.per}`;
-  }
-  const isLimitedUse = frequency !== undefined ? true : undefined;
-
-  const damage: DamageComponent[] = [];
-  for (const roll of Object.values(sys.damageRolls ?? {})) {
-    if (!roll) continue;
-    const parsed = typeof roll.damage === 'string' ? parseDamageString(roll.damage) : null;
-    if (!parsed) continue;
-    parsed.type = typeof roll.damageType === 'string' && roll.damageType !== '' ? roll.damageType : 'untyped';
-    if (roll.category === 'persistent') parsed.persistent = true;
-    damage.push(parsed);
-  }
-
-  let save: AbilitySave | undefined;
-  if (
-    sys.savingThrow &&
-    typeof sys.savingThrow.statistic === 'string' &&
-    typeof sys.savingThrow.dc === 'number'
-  ) {
-    save = { defense: sys.savingThrow.statistic, dc: sys.savingThrow.dc };
-    if (sys.savingThrow.basic === true) save.basic = true;
-  }
-
-  const ability: Ability = { name: item.name, description };
-  if (actions !== undefined) ability.actions = actions;
-  if (traits !== undefined && traits.length > 0) ability.traits = traits;
-  if (frequency !== undefined) ability.frequency = frequency;
-  if (damage.length > 0) ability.damage = damage;
-  if (save !== undefined) ability.save = save;
-  if (isLimitedUse !== undefined) ability.isLimitedUse = isLimitedUse;
-  return ability;
-}
-
-function partitionAbilities(
-  actions: FoundryItem[],
-  warn: Warn
-): {
-  passive: Ability[];
-  reactive: Ability[];
-  active: Ability[];
-} {
-  const passive: Ability[] = [];
-  const reactive: Ability[] = [];
-  const active: Ability[] = [];
-  for (const item of actions) {
-    if (item.type !== 'action') continue;
-    const actionItem = item as FoundryActionItem;
-    const sys = actionItem.system;
-    const ability = mapAbility(actionItem);
-    if (!ability) continue;
-    const kind = sys?.actionType?.value ?? 'passive';
-    if (kind === 'passive') passive.push(ability);
-    else if (kind === 'reaction' || kind === 'free') reactive.push(ability);
-    else if (kind === 'action') active.push(ability);
-    else {
-      warn(`Ability "${ability.name}": unknown actionType "${kind}", treated as active`);
-      active.push(ability);
-    }
-  }
-  return { passive, reactive, active };
 }
 
 function mapSpellListEntry(
@@ -436,7 +245,7 @@ function mapSpellcasting(items: FoundryItem[], warn: Warn): SpellcastingBlock[] 
   return out;
 }
 
-export function mapFoundryNpcToCreature(npc: unknown): MapResult {
+export function mapFoundryNpcToCreature(npc: unknown): MapResult<Creature> {
   if (typeof npc !== 'object' || npc === null || Array.isArray(npc)) {
     return { ok: false, error: 'Foundry document must be a JSON object' };
   }
@@ -478,13 +287,7 @@ export function mapFoundryNpcToCreature(npc: unknown): MapResult {
   const warn: Warn = (msg) => warnings.push(msg);
   const items = Array.isArray(doc.items) ? doc.items : [];
 
-  const attacks: Attack[] = [];
-  for (const item of items) {
-    if (item.type !== 'melee') continue;
-    const a = mapAttack(item as FoundryMeleeItem);
-    if (a) attacks.push(a);
-  }
-
+  const attacks = mapAttacks(items);
   const { passive, reactive, active } = partitionAbilities(items, warn);
   const spellcasting = mapSpellcasting(items, warn);
 
@@ -506,7 +309,7 @@ export function mapFoundryNpcToCreature(npc: unknown): MapResult {
     will: will!,
     perception: perception!,
     hp: hp!,
-    immunities: mapImmunities(doc),
+    immunities: mapImmunities(sys.attributes?.immunities),
     resistances: mapDamageTypeArray(sys.attributes?.resistances),
     weaknesses: mapDamageTypeArray(sys.attributes?.weaknesses),
     speed: mapSpeed(doc),

--- a/src/lib/foundry/shared.ts
+++ b/src/lib/foundry/shared.ts
@@ -1,0 +1,232 @@
+/**
+ * Helpers shared by the Foundry NPC mapper (`mapper.ts`) and the Foundry
+ * hazard mapper (`hazard-mapper.ts`). Foundry stores Strikes, actions, and
+ * reactions identically on `npc` and `hazard` actors, so the item-level
+ * mapping is reused verbatim by both.
+ */
+import type {
+  Ability,
+  AbilitySave,
+  ActionCost,
+  Attack,
+  AttackType,
+  CreatureImmunity,
+  CreatureRarity,
+  DamageComponent
+} from '../../domain';
+import { stripFoundryMarkup } from './text';
+import type {
+  FoundryActionItem,
+  FoundryActionSystem,
+  FoundryItem,
+  FoundryMeleeItem,
+  FoundryMeleeSystem
+} from './types';
+
+export type MapResult<T> =
+  | { ok: true; value: T; warnings: string[] }
+  | { ok: false; error: string };
+
+export type Warn = (msg: string) => void;
+
+const RARITIES: ReadonlySet<CreatureRarity> = new Set(['common', 'uncommon', 'rare', 'unique']);
+const THROWN_TRAIT = /^thrown(-\d+)?$/;
+const PHYSICAL_DAMAGE: ReadonlySet<string> = new Set(['slashing', 'piercing', 'bludgeoning']);
+
+export function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/['']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function parseDamageString(raw: string): DamageComponent | null {
+  // Examples: "1d6+1", "2d8", "1d4-1", "+5"
+  const m = /^\s*(?:(\d+)d(\d+))?\s*(?:([+\-])\s*(\d+))?\s*$/.exec(raw);
+  if (!m) return null;
+  const dice = m[1] ? Number(m[1]) : undefined;
+  const dieSize = m[2] ? Number(m[2]) : undefined;
+  const sign = m[3] === '-' ? -1 : 1;
+  const bonusAbs = m[4] !== undefined ? Number(m[4]) : undefined;
+  if (dice === undefined && bonusAbs === undefined) return null;
+  const out: { dice?: number; dieSize?: number; bonus?: number } = {};
+  if (dice !== undefined) out.dice = dice;
+  if (dieSize !== undefined) out.dieSize = dieSize;
+  if (bonusAbs !== undefined) out.bonus = sign * bonusAbs;
+  return { ...out, type: 'untyped' };
+}
+
+export function requireNum(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function mapRarity(raw: string | undefined): CreatureRarity {
+  if (raw && RARITIES.has(raw as CreatureRarity)) return raw as CreatureRarity;
+  return 'common';
+}
+
+export function mapImmunities(
+  raw: { type?: string; exceptions?: string[] }[] | undefined
+): CreatureImmunity[] {
+  const out: CreatureImmunity[] = [];
+  for (const im of raw ?? []) {
+    if (typeof im?.type !== 'string') continue;
+    const entry: CreatureImmunity = { type: im.type };
+    if (Array.isArray(im.exceptions) && im.exceptions.length > 0) {
+      entry.exceptions = im.exceptions.filter((e): e is string => typeof e === 'string');
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+export function mapDamageTypeArray(
+  raw: { type?: string; value?: number; exceptions?: string[] }[] | undefined
+): { type: string; value: number }[] {
+  const out: { type: string; value: number }[] = [];
+  for (const r of raw ?? []) {
+    if (typeof r?.type !== 'string' || typeof r?.value !== 'number') continue;
+    out.push({ type: r.type, value: r.value });
+  }
+  return out;
+}
+
+function isRangedAttack(range: FoundryMeleeSystem['range']): boolean {
+  if (range == null) return false;
+  if (typeof range === 'string') return range.trim() !== '';
+  return typeof range.increment === 'number' && range.increment > 0;
+}
+
+export function mapAttack(item: FoundryMeleeItem): Attack | null {
+  if (typeof item.name !== 'string') return null;
+  const sys: FoundryMeleeSystem = item.system ?? {};
+  const modifier = typeof sys.bonus?.value === 'number' ? sys.bonus.value : 0;
+  const traits = Array.isArray(sys.traits?.value)
+    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+    : [];
+  // Foundry stores thrown melee weapons (javelin, dagger) as type:"melee" with a
+  // positive range.increment so the engine can resolve both modes. Bestiary
+  // statblocks render these as melee Strikes, so prefer melee when the trait
+  // says thrown.
+  const thrown = traits.some((t) => THROWN_TRAIT.test(t));
+  const type: AttackType = thrown ? 'melee' : isRangedAttack(sys.range) ? 'ranged' : 'melee';
+
+  const damage: DamageComponent[] = [];
+  for (const roll of Object.values(sys.damageRolls ?? {})) {
+    if (!roll) continue;
+    const parsed = typeof roll.damage === 'string' ? parseDamageString(roll.damage) : null;
+    if (!parsed) continue;
+    parsed.type = typeof roll.damageType === 'string' && roll.damageType !== '' ? roll.damageType : 'untyped';
+    if (roll.category === 'persistent') parsed.persistent = true;
+    damage.push(parsed);
+  }
+
+  const effects = Array.isArray(sys.attackEffects?.value)
+    ? sys.attackEffects.value.filter((e): e is string => typeof e === 'string')
+    : [];
+
+  const out: Attack = {
+    name: item.name,
+    type,
+    modifier,
+    traits,
+    damage
+  };
+  if (effects.length > 0) out.effects = effects;
+  const physicalIndex = damage.findIndex((d) => PHYSICAL_DAMAGE.has(d.type));
+  if (physicalIndex > 0) out.primaryDamageIndex = physicalIndex;
+  return out;
+}
+
+function mapAbility(item: FoundryActionItem): Ability | null {
+  if (typeof item.name !== 'string') return null;
+  const sys: FoundryActionSystem = item.system ?? {};
+  const description = stripFoundryMarkup(sys.description?.value);
+  const traits = Array.isArray(sys.traits?.value)
+    ? sys.traits.value.filter((t): t is string => typeof t === 'string')
+    : undefined;
+
+  let actions: ActionCost | undefined;
+  const actionType = sys.actionType?.value;
+  if (actionType === 'reaction') actions = 'reaction';
+  else if (actionType === 'free') actions = 'free';
+  else if (actionType === 'action') {
+    const n = sys.actions?.value;
+    if (n === 1 || n === 2 || n === 3) actions = n;
+  }
+
+  let frequency: string | undefined;
+  if (sys.frequency && typeof sys.frequency.max === 'number' && typeof sys.frequency.per === 'string') {
+    frequency = `${sys.frequency.max} per ${sys.frequency.per}`;
+  }
+  const isLimitedUse = frequency !== undefined ? true : undefined;
+
+  const damage: DamageComponent[] = [];
+  for (const roll of Object.values(sys.damageRolls ?? {})) {
+    if (!roll) continue;
+    const parsed = typeof roll.damage === 'string' ? parseDamageString(roll.damage) : null;
+    if (!parsed) continue;
+    parsed.type = typeof roll.damageType === 'string' && roll.damageType !== '' ? roll.damageType : 'untyped';
+    if (roll.category === 'persistent') parsed.persistent = true;
+    damage.push(parsed);
+  }
+
+  let save: AbilitySave | undefined;
+  if (
+    sys.savingThrow &&
+    typeof sys.savingThrow.statistic === 'string' &&
+    typeof sys.savingThrow.dc === 'number'
+  ) {
+    save = { defense: sys.savingThrow.statistic, dc: sys.savingThrow.dc };
+    if (sys.savingThrow.basic === true) save.basic = true;
+  }
+
+  const ability: Ability = { name: item.name, description };
+  if (actions !== undefined) ability.actions = actions;
+  if (traits !== undefined && traits.length > 0) ability.traits = traits;
+  if (frequency !== undefined) ability.frequency = frequency;
+  if (damage.length > 0) ability.damage = damage;
+  if (save !== undefined) ability.save = save;
+  if (isLimitedUse !== undefined) ability.isLimitedUse = isLimitedUse;
+  return ability;
+}
+
+export function partitionAbilities(
+  items: FoundryItem[],
+  warn: Warn
+): {
+  passive: Ability[];
+  reactive: Ability[];
+  active: Ability[];
+} {
+  const passive: Ability[] = [];
+  const reactive: Ability[] = [];
+  const active: Ability[] = [];
+  for (const item of items) {
+    if (item.type !== 'action') continue;
+    const actionItem = item as FoundryActionItem;
+    const sys = actionItem.system;
+    const ability = mapAbility(actionItem);
+    if (!ability) continue;
+    const kind = sys?.actionType?.value ?? 'passive';
+    if (kind === 'passive') passive.push(ability);
+    else if (kind === 'reaction' || kind === 'free') reactive.push(ability);
+    else if (kind === 'action') active.push(ability);
+    else {
+      warn(`Ability "${ability.name}": unknown actionType "${kind}", treated as active`);
+      active.push(ability);
+    }
+  }
+  return { passive, reactive, active };
+}
+
+export function mapAttacks(items: FoundryItem[]): Attack[] {
+  const attacks: Attack[] = [];
+  for (const item of items) {
+    if (item.type !== 'melee') continue;
+    const a = mapAttack(item as FoundryMeleeItem);
+    if (a) attacks.push(a);
+  }
+  return attacks;
+}

--- a/src/lib/storage/db.test.ts
+++ b/src/lib/storage/db.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIVE_ENCOUNTER_STORE,
   CREATURE_LIBRARY_STORE,
   DB_NAME,
+  HAZARD_LIBRARY_STORE,
   PARTY_MEMBER_STORE,
   SETTINGS_STORE
 } from './db';
@@ -52,14 +53,20 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [
+        ACTIVE_ENCOUNTER_STORE,
+        SETTINGS_STORE,
+        CREATURE_LIBRARY_STORE,
+        PARTY_MEMBER_STORE,
+        HAZARD_LIBRARY_STORE
+      ].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v1-data'
     });
   });
 
-  it('preserves prior records when upgrading from v3 to v4 and adds the partyMembers store', async () => {
+  it('preserves prior records when upgrading from v3 and adds the partyMembers + hazardLibrary stores', async () => {
     const v3 = await openDB(DB_NAME, 3, {
       upgrade(db) {
         db.createObjectStore(ACTIVE_ENCOUNTER_STORE);
@@ -77,7 +84,13 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [
+        ACTIVE_ENCOUNTER_STORE,
+        SETTINGS_STORE,
+        CREATURE_LIBRARY_STORE,
+        PARTY_MEMBER_STORE,
+        HAZARD_LIBRARY_STORE
+      ].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v3-active'
@@ -85,6 +98,38 @@ describe('IndexedDB schema migration', () => {
     expect(await db.get(SETTINGS_STORE, 'llmApiKey')).toBe('sk-test');
     expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([{ id: 'goblin', name: 'Goblin' }]);
     expect(await db.getAll(PARTY_MEMBER_STORE)).toEqual([]);
+    expect(await db.getAll(HAZARD_LIBRARY_STORE)).toEqual([]);
+  });
+
+  it('preserves prior records when upgrading from v4 to v5 and adds the hazardLibrary store', async () => {
+    const v4 = await openDB(DB_NAME, 4, {
+      upgrade(db) {
+        db.createObjectStore(ACTIVE_ENCOUNTER_STORE);
+        db.createObjectStore(SETTINGS_STORE);
+        db.createObjectStore(CREATURE_LIBRARY_STORE);
+        db.createObjectStore(PARTY_MEMBER_STORE);
+      }
+    });
+    await v4.put(CREATURE_LIBRARY_STORE, { id: 'goblin', name: 'Goblin' }, 'goblin');
+    await v4.put(PARTY_MEMBER_STORE, { id: 'hero', name: 'Hero' }, 'hero');
+    v4.close();
+
+    const { getDb } = await import('./db');
+    const db = await getDb()!;
+    openConnections.push(db);
+
+    expect(Array.from(db.objectStoreNames).sort()).toEqual(
+      [
+        ACTIVE_ENCOUNTER_STORE,
+        SETTINGS_STORE,
+        CREATURE_LIBRARY_STORE,
+        PARTY_MEMBER_STORE,
+        HAZARD_LIBRARY_STORE
+      ].sort()
+    );
+    expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([{ id: 'goblin', name: 'Goblin' }]);
+    expect(await db.getAll(PARTY_MEMBER_STORE)).toEqual([{ id: 'hero', name: 'Hero' }]);
+    expect(await db.getAll(HAZARD_LIBRARY_STORE)).toEqual([]);
   });
 
   it('preserves prior activeEncounter + settings records when upgrading from v2 to v3', async () => {
@@ -104,7 +149,13 @@ describe('IndexedDB schema migration', () => {
     openConnections.push(db);
 
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [
+        ACTIVE_ENCOUNTER_STORE,
+        SETTINGS_STORE,
+        CREATURE_LIBRARY_STORE,
+        PARTY_MEMBER_STORE,
+        HAZARD_LIBRARY_STORE
+      ].sort()
     );
     expect(await db.get(ACTIVE_ENCOUNTER_STORE, 'current')).toEqual({
       sentinel: 'v2-active'
@@ -113,12 +164,18 @@ describe('IndexedDB schema migration', () => {
     expect(await db.getAll(CREATURE_LIBRARY_STORE)).toEqual([]);
   });
 
-  it('creates all three stores on a fresh install (no prior database)', async () => {
+  it('creates all stores on a fresh install (no prior database)', async () => {
     const { getDb } = await import('./db');
     const db = await getDb()!;
     openConnections.push(db);
     expect(Array.from(db.objectStoreNames).sort()).toEqual(
-      [ACTIVE_ENCOUNTER_STORE, SETTINGS_STORE, CREATURE_LIBRARY_STORE, PARTY_MEMBER_STORE].sort()
+      [
+        ACTIVE_ENCOUNTER_STORE,
+        SETTINGS_STORE,
+        CREATURE_LIBRARY_STORE,
+        PARTY_MEMBER_STORE,
+        HAZARD_LIBRARY_STORE
+      ].sort()
     );
   });
 });

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,11 +1,12 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 export const DB_NAME = 'pf2e-tracker-v2';
-export const DB_VERSION = 4;
+export const DB_VERSION = 5;
 export const ACTIVE_ENCOUNTER_STORE = 'activeEncounter';
 export const SETTINGS_STORE = 'settings';
 export const CREATURE_LIBRARY_STORE = 'creatureLibrary';
 export const PARTY_MEMBER_STORE = 'partyMembers';
+export const HAZARD_LIBRARY_STORE = 'hazardLibrary';
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -32,6 +33,9 @@ export function getDb(): Promise<IDBPDatabase> | null {
         }
         if (!db.objectStoreNames.contains(PARTY_MEMBER_STORE)) {
           db.createObjectStore(PARTY_MEMBER_STORE);
+        }
+        if (!db.objectStoreNames.contains(HAZARD_LIBRARY_STORE)) {
+          db.createObjectStore(HAZARD_LIBRARY_STORE);
         }
       }
     }).catch((err) => {

--- a/src/lib/storage/hazard-library.test.ts
+++ b/src/lib/storage/hazard-library.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Hazard } from '../../domain';
+import { addHazards, clearHazards, loadHazards, removeHazard } from './hazard-library';
+
+function makeHazard(overrides: Partial<Hazard> = {}): Hazard {
+  return {
+    id: 'test-hazard',
+    name: 'Test Hazard',
+    level: 5,
+    traits: ['trap'],
+    rarity: 'common',
+    stealth: 20,
+    ac: 22,
+    fortitude: 10,
+    reflex: 14,
+    will: 8,
+    hp: 60,
+    hardness: 8,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    tags: [],
+    ...overrides
+  };
+}
+
+async function loadOrThrow(): Promise<Hazard[]> {
+  const result = await loadHazards();
+  if (!result.ok) throw new Error(`loadHazards failed: ${result.reason}`);
+  return result.hazards;
+}
+
+beforeEach(async () => {
+  await clearHazards();
+});
+
+afterEach(async () => {
+  await clearHazards();
+});
+
+describe('hazard library storage', () => {
+  it('returns an empty list when nothing has been imported', async () => {
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('round-trips an imported hazard', async () => {
+    const gallery = makeHazard({ id: 'dart-gallery', name: 'Dart Gallery' });
+    const result = await addHazards([gallery]);
+    expect(result).toEqual({ ok: true, added: [gallery], rejected: [] });
+    expect(await loadOrThrow()).toEqual([gallery]);
+  });
+
+  it('rejects hazards whose id is already present, accepting the rest', async () => {
+    await addHazards([makeHazard({ id: 'dart-gallery', name: 'Original' })]);
+
+    const collision = makeHazard({ id: 'dart-gallery', name: 'Different' });
+    const fresh = makeHazard({ id: 'pit-trap', name: 'Pit Trap' });
+    const result = await addHazards([collision, fresh]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.added).toEqual([fresh]);
+      expect(result.rejected).toEqual([collision]);
+    }
+
+    const stored = await loadOrThrow();
+    expect(stored.find((h) => h.id === 'dart-gallery')?.name).toBe('Original');
+  });
+
+  it('rejects internal duplicates within a single import batch', async () => {
+    const a = makeHazard({ id: 'dart-gallery', name: 'First' });
+    const b = makeHazard({ id: 'dart-gallery', name: 'Second' });
+    const result = await addHazards([a, b]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.added).toEqual([a]);
+      expect(result.rejected).toEqual([b]);
+    }
+  });
+
+  it('removeHazard deletes a single record without touching siblings', async () => {
+    await addHazards([makeHazard({ id: 'dart-gallery' }), makeHazard({ id: 'pit-trap' })]);
+    expect(await removeHazard('dart-gallery')).toEqual({ ok: true, existed: true });
+    expect((await loadOrThrow()).map((h) => h.id)).toEqual(['pit-trap']);
+  });
+
+  it('removeHazard reports existed: false for unknown ids', async () => {
+    expect(await removeHazard('does-not-exist')).toEqual({ ok: true, existed: false });
+  });
+
+  it('clearHazards empties the store', async () => {
+    await addHazards([makeHazard({ id: 'a' }), makeHazard({ id: 'b' })]);
+    expect(await clearHazards()).toEqual({ ok: true });
+    expect(await loadOrThrow()).toEqual([]);
+  });
+
+  it('persists hazards across a simulated page reload', async () => {
+    await addHazards([makeHazard({ id: 'dart-gallery', name: 'Dart Gallery' })]);
+
+    vi.resetModules();
+    const { loadHazards: load } = await import('./hazard-library');
+    const result = await load();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.hazards.map((h) => h.id)).toEqual(['dart-gallery']);
+    }
+  });
+});
+
+describe('hazard library storage when indexedDB is unavailable', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loadHazards returns ok: false / unavailable', async () => {
+    const { loadHazards: load } = await import('./hazard-library');
+    expect(await load()).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('addHazards returns ok: false / unavailable', async () => {
+    const { addHazards: add } = await import('./hazard-library');
+    expect(await add([makeHazard({ id: 'x' })])).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('removeHazard returns ok: false / unavailable', async () => {
+    const { removeHazard: remove } = await import('./hazard-library');
+    expect(await remove('any')).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('clearHazards returns ok: false / unavailable', async () => {
+    const { clearHazards: clear } = await import('./hazard-library');
+    expect(await clear()).toEqual({ ok: false, reason: 'unavailable' });
+  });
+});

--- a/src/lib/storage/hazard-library.ts
+++ b/src/lib/storage/hazard-library.ts
@@ -1,0 +1,82 @@
+import type { Hazard } from '../../domain';
+import { dedupeNewHazards } from '../yaml';
+import { HAZARD_LIBRARY_STORE, getDb } from './db';
+
+export type StorageFailureReason = 'unavailable' | 'failed';
+
+export type LoadHazardsResult =
+  | { ok: true; hazards: Hazard[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type AddHazardsResult =
+  | { ok: true; added: Hazard[]; rejected: Hazard[] }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type RemoveHazardResult =
+  | { ok: true; existed: boolean }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export type ClearHazardsResult =
+  | { ok: true }
+  | { ok: false; reason: StorageFailureReason; error?: unknown };
+
+export async function loadHazards(): Promise<LoadHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const hazards = (await db.getAll(HAZARD_LIBRARY_STORE)) as Hazard[];
+    return { ok: true, hazards };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function addHazards(hazards: readonly Hazard[]): Promise<AddHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    // Snapshot existing ids and write new records inside one readwrite tx so
+    // two rapid imports cannot both decide to write the same id against a
+    // stale snapshot — IDB serializes overlapping readwrite txns on the same
+    // store, which is what makes the dedupe contract racy-safe.
+    const tx = db.transaction(HAZARD_LIBRARY_STORE, 'readwrite');
+    const existingIds = new Set((await tx.store.getAllKeys()) as string[]);
+    const { accepted, rejected } = dedupeNewHazards(existingIds, hazards);
+    for (const hazard of accepted) {
+      tx.store.put(hazard, hazard.id);
+    }
+    await tx.done;
+    return { ok: true, added: accepted, rejected };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function removeHazard(id: string): Promise<RemoveHazardResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    const tx = db.transaction(HAZARD_LIBRARY_STORE, 'readwrite');
+    const existed = (await tx.store.getKey(id)) !== undefined;
+    await tx.store.delete(id);
+    await tx.done;
+    return { ok: true, existed };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}
+
+export async function clearHazards(): Promise<ClearHazardsResult> {
+  const promise = getDb();
+  if (!promise) return { ok: false, reason: 'unavailable' };
+  try {
+    const db = await promise;
+    await db.clear(HAZARD_LIBRARY_STORE);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: 'failed', error };
+  }
+}

--- a/src/lib/yaml/creature-validator.ts
+++ b/src/lib/yaml/creature-validator.ts
@@ -40,7 +40,7 @@ export type ParseOutcome<T> =
   | { ok: true; value: T; issues: ValidationIssue[] }
   | { ok: false; issues: ValidationIssue[] };
 
-class IssueBag {
+export class IssueBag {
   readonly issues: ValidationIssue[] = [];
   constructor(private readonly documentIndex: number) {}
 
@@ -57,7 +57,7 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === 'string');
 }
 
-function requireNumber(bag: IssueBag, path: string, value: unknown): number | null {
+export function requireNumber(bag: IssueBag, path: string, value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     bag.add(path, 'must be a finite number');
     return null;
@@ -65,7 +65,7 @@ function requireNumber(bag: IssueBag, path: string, value: unknown): number | nu
   return value;
 }
 
-function requireString(bag: IssueBag, path: string, value: unknown): string | null {
+export function requireString(bag: IssueBag, path: string, value: unknown): string | null {
   if (typeof value !== 'string') {
     bag.add(path, 'must be a string');
     return null;
@@ -73,7 +73,7 @@ function requireString(bag: IssueBag, path: string, value: unknown): string | nu
   return value;
 }
 
-function requireStringArray(bag: IssueBag, path: string, value: unknown): string[] | null {
+export function requireStringArray(bag: IssueBag, path: string, value: unknown): string[] | null {
   if (!isStringArray(value)) {
     bag.add(path, 'must be an array of strings');
     return null;
@@ -81,7 +81,7 @@ function requireStringArray(bag: IssueBag, path: string, value: unknown): string
   return value;
 }
 
-function requireArray(bag: IssueBag, path: string, value: unknown): unknown[] | null {
+export function requireArray(bag: IssueBag, path: string, value: unknown): unknown[] | null {
   if (!Array.isArray(value)) {
     bag.add(path, 'must be an array');
     return null;
@@ -89,7 +89,7 @@ function requireArray(bag: IssueBag, path: string, value: unknown): unknown[] | 
   return value;
 }
 
-function requireObject(bag: IssueBag, path: string, value: unknown): Record<string, unknown> | null {
+export function requireObject(bag: IssueBag, path: string, value: unknown): Record<string, unknown> | null {
   if (!isPlainObject(value)) {
     bag.add(path, 'must be a mapping (object)');
     return null;
@@ -117,7 +117,7 @@ function validateRecordOfNumbers(
   return ok ? out : null;
 }
 
-function validateDamageType(bag: IssueBag, path: string, raw: unknown): { type: string; value: number } | null {
+export function validateDamageType(bag: IssueBag, path: string, raw: unknown): { type: string; value: number } | null {
   const obj = requireObject(bag, path, raw);
   if (!obj) return null;
   const type = requireString(bag, `${path}.type`, obj.type);
@@ -227,7 +227,7 @@ function validateSpellEntrySave(bag: IssueBag, path: string, raw: unknown): Spel
   return out;
 }
 
-function validateAttack(bag: IssueBag, path: string, raw: unknown): Attack | null {
+export function validateAttack(bag: IssueBag, path: string, raw: unknown): Attack | null {
   const obj = requireObject(bag, path, raw);
   if (!obj) return null;
   let ok = true;
@@ -537,7 +537,7 @@ function validateSpellcastingBlock(bag: IssueBag, path: string, raw: unknown): S
   return block;
 }
 
-function validateCreatureImmunity(bag: IssueBag, path: string, raw: unknown): CreatureImmunity | null {
+export function validateCreatureImmunity(bag: IssueBag, path: string, raw: unknown): CreatureImmunity | null {
   const obj = requireObject(bag, path, raw);
   if (!obj) return null;
   let ok = true;
@@ -613,7 +613,7 @@ function validateLanguages(bag: IssueBag, path: string, raw: unknown): Languages
   return out;
 }
 
-function validateAbilityArray(bag: IssueBag, path: string, raw: unknown): Ability[] | null {
+export function validateAbilityArray(bag: IssueBag, path: string, raw: unknown): Ability[] | null {
   const arr = requireArray(bag, path, raw);
   if (arr === null) return null;
   const out: Ability[] = [];

--- a/src/lib/yaml/hazard-validator.test.ts
+++ b/src/lib/yaml/hazard-validator.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+import type { Hazard } from '../../domain';
+import { validateHazard } from './hazard-validator';
+
+describe('validateHazard', () => {
+  test('accepts a well-formed hazard document', () => {
+    const result = validateHazard(validHazardData(), 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.id).toBe('poisoned-dart-gallery');
+    expect(result.value.hardness).toBe(10);
+    expect(result.value.routine).toContain('darts');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  test('omits absent optional fields from the result', () => {
+    const data = validHazardData();
+    delete data.hardness;
+    delete data.routine;
+    delete data.stealthNote;
+    const result = validateHazard(data, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).not.toHaveProperty('hardness');
+    expect(result.value).not.toHaveProperty('routine');
+    expect(result.value).not.toHaveProperty('stealthNote');
+  });
+
+  test('reports missing required fields with paths', () => {
+    const data = validHazardData();
+    delete data.stealth;
+    delete data.level;
+    const result = validateHazard(data, 0);
+    expect(result.ok).toBe(false);
+    const paths = result.issues.map((i) => i.path);
+    expect(paths).toContain('stealth');
+    expect(paths).toContain('level');
+  });
+
+  test('rejects an invalid rarity', () => {
+    const data = { ...validHazardData(), rarity: 'legendary' };
+    const result = validateHazard(data, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'rarity')).toBe(true);
+  });
+
+  test('rejects a non-string routine', () => {
+    const data = { ...validHazardData(), routine: 42 };
+    const result = validateHazard(data, 0);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === 'routine')).toBe(true);
+  });
+});
+
+function validHazardData(): Record<string, unknown> & Partial<Hazard> {
+  return {
+    id: 'poisoned-dart-gallery',
+    name: 'Poisoned Dart Gallery',
+    level: 8,
+    traits: ['mechanical', 'trap'],
+    rarity: 'common',
+    stealth: 28,
+    stealthNote: 'expert',
+    ac: 27,
+    fortitude: 13,
+    reflex: 17,
+    will: 8,
+    hp: 100,
+    hardness: 10,
+    immunities: [],
+    resistances: [],
+    weaknesses: [],
+    routine: 'The trap fires a volley of poisoned darts.',
+    disable: 'Thievery DC 26.',
+    attacks: [],
+    passiveAbilities: [],
+    reactiveAbilities: [],
+    activeAbilities: [],
+    tags: []
+  };
+}

--- a/src/lib/yaml/hazard-validator.ts
+++ b/src/lib/yaml/hazard-validator.ts
@@ -1,0 +1,194 @@
+import type { Attack, CreatureImmunity, CreatureRarity, Hazard } from '../../domain';
+import {
+  IssueBag,
+  type ParseOutcome,
+  requireArray,
+  requireNumber,
+  requireObject,
+  requireString,
+  requireStringArray,
+  validateAbilityArray,
+  validateAttack,
+  validateCreatureImmunity,
+  validateDamageType
+} from './creature-validator';
+
+const RARITIES: ReadonlySet<CreatureRarity> = new Set(['common', 'uncommon', 'rare', 'unique']);
+
+export function validateHazard(raw: unknown, documentIndex: number): ParseOutcome<Hazard> {
+  const bag = new IssueBag(documentIndex);
+
+  const obj = requireObject(bag, '', raw);
+  if (!obj) return { ok: false, issues: bag.issues };
+
+  let ok = true;
+
+  const id = requireString(bag, 'id', obj.id);
+  if (id === null) ok = false;
+  const name = requireString(bag, 'name', obj.name);
+  if (name === null) ok = false;
+  const level = requireNumber(bag, 'level', obj.level);
+  if (level === null) ok = false;
+  const traits = requireStringArray(bag, 'traits', obj.traits);
+  if (traits === null) ok = false;
+
+  let rarity: CreatureRarity | null = null;
+  if (typeof obj.rarity !== 'string' || !RARITIES.has(obj.rarity as CreatureRarity)) {
+    bag.add('rarity', 'must be one of: common, uncommon, rare, unique');
+    ok = false;
+  } else rarity = obj.rarity as CreatureRarity;
+
+  const stealth = requireNumber(bag, 'stealth', obj.stealth);
+  if (stealth === null) ok = false;
+  const ac = requireNumber(bag, 'ac', obj.ac);
+  if (ac === null) ok = false;
+  const fortitude = requireNumber(bag, 'fortitude', obj.fortitude);
+  if (fortitude === null) ok = false;
+  const reflex = requireNumber(bag, 'reflex', obj.reflex);
+  if (reflex === null) ok = false;
+  const will = requireNumber(bag, 'will', obj.will);
+  if (will === null) ok = false;
+  const hp = requireNumber(bag, 'hp', obj.hp);
+  if (hp === null) ok = false;
+
+  let hardness: number | undefined;
+  if (obj.hardness !== undefined) {
+    const n = requireNumber(bag, 'hardness', obj.hardness);
+    if (n === null) ok = false;
+    else hardness = n;
+  }
+
+  const immunitiesRaw = requireArray(bag, 'immunities', obj.immunities);
+  const immunities: CreatureImmunity[] = [];
+  if (immunitiesRaw === null) ok = false;
+  else {
+    for (let i = 0; i < immunitiesRaw.length; i++) {
+      const im = validateCreatureImmunity(bag, `immunities[${i}]`, immunitiesRaw[i]);
+      if (im === null) ok = false;
+      else immunities.push(im);
+    }
+  }
+
+  const resistancesRaw = requireArray(bag, 'resistances', obj.resistances);
+  const resistances: { type: string; value: number }[] = [];
+  if (resistancesRaw === null) ok = false;
+  else {
+    for (let i = 0; i < resistancesRaw.length; i++) {
+      const r = validateDamageType(bag, `resistances[${i}]`, resistancesRaw[i]);
+      if (r === null) ok = false;
+      else resistances.push(r);
+    }
+  }
+
+  const weaknessesRaw = requireArray(bag, 'weaknesses', obj.weaknesses);
+  const weaknesses: { type: string; value: number }[] = [];
+  if (weaknessesRaw === null) ok = false;
+  else {
+    for (let i = 0; i < weaknessesRaw.length; i++) {
+      const w = validateDamageType(bag, `weaknesses[${i}]`, weaknessesRaw[i]);
+      if (w === null) ok = false;
+      else weaknesses.push(w);
+    }
+  }
+
+  const attacksRaw = requireArray(bag, 'attacks', obj.attacks);
+  const attacks: Attack[] = [];
+  if (attacksRaw === null) ok = false;
+  else {
+    for (let i = 0; i < attacksRaw.length; i++) {
+      const a = validateAttack(bag, `attacks[${i}]`, attacksRaw[i]);
+      if (a === null) ok = false;
+      else attacks.push(a);
+    }
+  }
+
+  const passive = validateAbilityArray(bag, 'passiveAbilities', obj.passiveAbilities);
+  if (passive === null) ok = false;
+  const reactive = validateAbilityArray(bag, 'reactiveAbilities', obj.reactiveAbilities);
+  if (reactive === null) ok = false;
+  const active = validateAbilityArray(bag, 'activeAbilities', obj.activeAbilities);
+  if (active === null) ok = false;
+
+  const tags = requireStringArray(bag, 'tags', obj.tags);
+  if (tags === null) ok = false;
+
+  const optionalText: Record<
+    'stealthNote' | 'routine' | 'disable' | 'reset' | 'description' | 'source' | 'notes',
+    string | undefined
+  > = {
+    stealthNote: undefined,
+    routine: undefined,
+    disable: undefined,
+    reset: undefined,
+    description: undefined,
+    source: undefined,
+    notes: undefined
+  };
+  for (const key of [
+    'stealthNote',
+    'routine',
+    'disable',
+    'reset',
+    'description',
+    'source',
+    'notes'
+  ] as const) {
+    if (obj[key] !== undefined) {
+      const s = requireString(bag, key, obj[key]);
+      if (s === null) ok = false;
+      else optionalText[key] = s;
+    }
+  }
+
+  if (
+    !ok ||
+    id === null ||
+    name === null ||
+    level === null ||
+    traits === null ||
+    rarity === null ||
+    stealth === null ||
+    ac === null ||
+    fortitude === null ||
+    reflex === null ||
+    will === null ||
+    hp === null ||
+    passive === null ||
+    reactive === null ||
+    active === null ||
+    tags === null
+  ) {
+    return { ok: false, issues: bag.issues };
+  }
+
+  const hazard: Hazard = {
+    id,
+    name,
+    level,
+    traits,
+    rarity,
+    stealth,
+    ac,
+    fortitude,
+    reflex,
+    will,
+    hp,
+    immunities,
+    resistances,
+    weaknesses,
+    attacks,
+    passiveAbilities: passive,
+    reactiveAbilities: reactive,
+    activeAbilities: active,
+    tags,
+    ...(hardness !== undefined ? { hardness } : {}),
+    ...(optionalText.stealthNote !== undefined ? { stealthNote: optionalText.stealthNote } : {}),
+    ...(optionalText.routine !== undefined ? { routine: optionalText.routine } : {}),
+    ...(optionalText.disable !== undefined ? { disable: optionalText.disable } : {}),
+    ...(optionalText.reset !== undefined ? { reset: optionalText.reset } : {}),
+    ...(optionalText.description !== undefined ? { description: optionalText.description } : {}),
+    ...(optionalText.source !== undefined ? { source: optionalText.source } : {}),
+    ...(optionalText.notes !== undefined ? { notes: optionalText.notes } : {})
+  };
+  return { ok: true, value: hazard, issues: bag.issues };
+}

--- a/src/lib/yaml/index.ts
+++ b/src/lib/yaml/index.ts
@@ -1,6 +1,7 @@
-import type { Creature } from '../../domain';
+import type { Creature, Hazard } from '../../domain';
 import { parseYamlEnvelopes, type ValidationIssue, type YamlDocumentKind } from './envelope';
 import { validateCreature } from './creature-validator';
+import { validateHazard } from './hazard-validator';
 
 export type { ValidationIssue } from './envelope';
 export type { ParseOutcome } from './creature-validator';
@@ -61,6 +62,62 @@ export function dedupeNewCreatures(
     } else {
       seen.add(creature.id);
       accepted.push(creature);
+    }
+  }
+  return { accepted, rejected };
+}
+
+export interface HazardSkippedDocument {
+  documentIndex: number;
+  kind: Exclude<YamlDocumentKind, 'hazard'>;
+}
+
+export interface HazardImportResult {
+  hazards: Hazard[];
+  issues: ValidationIssue[];
+  skipped: HazardSkippedDocument[];
+}
+
+export function importHazardYaml(text: string): HazardImportResult {
+  const { envelopes, issues } = parseYamlEnvelopes(text);
+  const hazards: Hazard[] = [];
+  const skipped: HazardSkippedDocument[] = [];
+  const allIssues: ValidationIssue[] = [...issues];
+
+  for (const envelope of envelopes) {
+    if (envelope.kind !== 'hazard') {
+      skipped.push({ documentIndex: envelope.documentIndex, kind: envelope.kind });
+      continue;
+    }
+
+    const result = validateHazard(envelope.data, envelope.documentIndex);
+    if (result.ok) {
+      hazards.push(result.value);
+    }
+    allIssues.push(...result.issues);
+  }
+
+  return { hazards, issues: allIssues, skipped };
+}
+
+export interface DedupeHazardsResult {
+  accepted: Hazard[];
+  rejected: Hazard[];
+}
+
+export function dedupeNewHazards(
+  existingIds: ReadonlySet<string>,
+  incoming: readonly Hazard[]
+): DedupeHazardsResult {
+  const accepted: Hazard[] = [];
+  const rejected: Hazard[] = [];
+  const seen = new Set(existingIds);
+  for (const hazard of incoming) {
+    if (seen.has(hazard.id)) {
+      rejected.push(hazard);
+    } else {
+      seen.add(hazard.id);
+      accepted.push(hazard);
     }
   }
   return { accepted, rejected };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -283,7 +283,130 @@
     runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
   }
 
-  async function handleImportCreatureFiles(files: File[]) {
+  /**
+   * Persists imported creatures and surfaces per-file feedback. Skip notices
+   * are emitted for document kinds this build doesn't import, except `hazard`
+   * — a hazard document in the same file is handled by the hazard importer, so
+   * reporting it as "skipped" would be misleading. Returns true if the file
+   * produced any creature-related outcome.
+   */
+  async function persistImportedCreatures(
+    file: File,
+    result: ReturnType<typeof importCreatureYaml>
+  ): Promise<boolean> {
+    const { creatures, issues, skipped } = result;
+    const persistResult = await addCreatures(creatures);
+    if (!persistResult.ok) {
+      appendFeedback(
+        nextFeedbackId('import-persist-fail'),
+        persistResult.reason === 'unavailable'
+          ? `Could not save creatures from "${file.name}": storage is unavailable (common causes: private-browsing mode or browser policy).`
+          : `Could not save creatures from "${file.name}": storage write failed. Common causes: full storage, or another tab using a newer version.`
+      );
+      return true;
+    }
+
+    for (const creature of persistResult.rejected) {
+      appendFeedback(
+        nextFeedbackId('import-dup'),
+        `Skipped "${creature.name}" from "${file.name}": id "${creature.id}" is already in your library.`
+      );
+    }
+
+    if (persistResult.added.length > 0) {
+      storedCreatures = [...storedCreatures, ...persistResult.added];
+      appendFeedback(
+        nextFeedbackId('import-ok'),
+        `Imported ${persistResult.added.length} creature${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
+        'success'
+      );
+    }
+
+    const reportableSkips = skipped.filter((skip) => skip.kind !== 'hazard');
+    for (const skip of reportableSkips) {
+      appendFeedback(
+        nextFeedbackId('import-skip'),
+        `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not yet imported by this build.`,
+        'info'
+      );
+    }
+
+    for (const issue of issues) {
+      const where = issue.path ? ` at "${issue.path}"` : '';
+      const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
+      appendFeedback(
+        nextFeedbackId('import-issue'),
+        `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
+      );
+    }
+
+    return (
+      persistResult.added.length > 0 ||
+      persistResult.rejected.length > 0 ||
+      issues.length > 0 ||
+      reportableSkips.length > 0
+    );
+  }
+
+  /**
+   * Persists imported hazards and surfaces per-file feedback. Skipped non-hazard
+   * documents are left to persistImportedCreatures so a mixed YAML file reports
+   * each skipped kind exactly once. Returns true if the file produced any
+   * hazard-related outcome.
+   */
+  async function persistImportedHazards(
+    file: File,
+    result: ReturnType<typeof importHazardYaml>
+  ): Promise<boolean> {
+    const { hazards, issues } = result;
+    const persistResult = await addHazards(hazards);
+    if (!persistResult.ok) {
+      appendFeedback(
+        nextFeedbackId('hz-import-persist-fail'),
+        persistResult.reason === 'unavailable'
+          ? `Could not save hazards from "${file.name}": storage is unavailable (common causes: private-browsing mode or browser policy).`
+          : `Could not save hazards from "${file.name}": storage write failed. Common causes: full storage, or another tab using a newer version.`
+      );
+      return true;
+    }
+
+    for (const hazard of persistResult.rejected) {
+      appendFeedback(
+        nextFeedbackId('hz-import-dup'),
+        `Skipped "${hazard.name}" from "${file.name}": id "${hazard.id}" is already in your library.`
+      );
+    }
+
+    if (persistResult.added.length > 0) {
+      storedHazards = [...storedHazards, ...persistResult.added];
+      appendFeedback(
+        nextFeedbackId('hz-import-ok'),
+        `Imported ${persistResult.added.length} hazard${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
+        'success'
+      );
+    }
+
+    for (const issue of issues) {
+      const where = issue.path ? ` at "${issue.path}"` : '';
+      const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
+      appendFeedback(
+        nextFeedbackId('hz-import-issue'),
+        `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
+      );
+    }
+
+    return (
+      persistResult.added.length > 0 || persistResult.rejected.length > 0 || issues.length > 0
+    );
+  }
+
+  /**
+   * Imports creature and hazard library files. A Foundry actor JSON is routed
+   * by its `type` field, so it lands in the right library regardless of which
+   * "Import…" button was used. A YAML file may carry both creature and hazard
+   * documents; both kinds are imported from a single file.
+   */
+  async function handleImportLibraryFiles(files: File[]) {
     for (const file of files) {
       let text: string;
       try {
@@ -307,13 +430,34 @@
         continue;
       }
 
-      let creatures: Creature[];
-      let issues: ReturnType<typeof importCreatureYaml>['issues'];
-      let skipped: ReturnType<typeof importCreatureYaml>['skipped'];
+      if (isJson) {
+        // Route a Foundry actor JSON by its declared `type`. A parse failure
+        // falls through to the creature importer, which reports it as an issue.
+        let actorType: unknown;
+        try {
+          actorType = (JSON.parse(text) as { type?: unknown }).type;
+        } catch {
+          actorType = undefined;
+        }
+        const did =
+          actorType === 'hazard'
+            ? await persistImportedHazards(file, importHazardFoundryJson(text))
+            : await persistImportedCreatures(file, importCreatureFoundryJson(text));
+        if (!did) {
+          appendFeedback(
+            nextFeedbackId('import-empty'),
+            `"${file.name}" contained no importable creature or hazard.`
+          );
+        }
+        continue;
+      }
+
+      // A single YAML file may declare creature and/or hazard documents.
+      let didCreatures: boolean;
+      let didHazards: boolean;
       try {
-        ({ creatures, issues, skipped } = isJson
-          ? importCreatureFoundryJson(text)
-          : importCreatureYaml(text));
+        didCreatures = await persistImportedCreatures(file, importCreatureYaml(text));
+        didHazards = await persistImportedHazards(file, importHazardYaml(text));
       } catch (err) {
         appendFeedback(
           nextFeedbackId('import-fail'),
@@ -321,62 +465,10 @@
         );
         continue;
       }
-
-      const persistResult = await addCreatures(creatures);
-
-      if (!persistResult.ok) {
-        appendFeedback(
-          nextFeedbackId('import-persist-fail'),
-          persistResult.reason === 'unavailable'
-            ? `Could not save creatures from "${file.name}": storage is unavailable (common causes: private-browsing mode or browser policy).`
-            : `Could not save creatures from "${file.name}": storage write failed. Common causes: full storage, or another tab using a newer version.`
-        );
-        continue;
-      }
-
-      for (const creature of persistResult.rejected) {
-        appendFeedback(
-          nextFeedbackId('import-dup'),
-          `Skipped "${creature.name}" from "${file.name}": id "${creature.id}" is already in your library.`
-        );
-      }
-
-      if (persistResult.added.length > 0) {
-        storedCreatures = [...storedCreatures, ...persistResult.added];
-        appendFeedback(
-          nextFeedbackId('import-ok'),
-          `Imported ${persistResult.added.length} creature${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
-          'success'
-        );
-      }
-
-      for (const skip of skipped) {
-        appendFeedback(
-          nextFeedbackId('import-skip'),
-          `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not yet imported by this build.`,
-          'info'
-        );
-      }
-
-      for (const issue of issues) {
-        const where = issue.path ? ` at "${issue.path}"` : '';
-        const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
-        appendFeedback(
-          nextFeedbackId('import-issue'),
-          `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
-        );
-      }
-
-      if (
-        persistResult.added.length === 0 &&
-        persistResult.rejected.length === 0 &&
-        issues.length === 0 &&
-        skipped.length === 0 &&
-        creatures.length === 0
-      ) {
+      if (!didCreatures && !didHazards) {
         appendFeedback(
           nextFeedbackId('import-empty'),
-          `"${file.name}" contained no creature documents.`
+          `"${file.name}" contained no creature or hazard documents.`
         );
       }
     }
@@ -426,105 +518,6 @@
     }
     if (!target) return;
     runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
-  }
-
-  async function handleImportHazardFiles(files: File[]) {
-    for (const file of files) {
-      let text: string;
-      try {
-        text = await file.text();
-      } catch (err) {
-        appendFeedback(
-          nextFeedbackId('hz-import-read-fail'),
-          `Could not read "${file.name}": ${err instanceof Error ? err.message : String(err)}`
-        );
-        continue;
-      }
-
-      const lower = file.name.toLowerCase();
-      const isJson = lower.endsWith('.json');
-      const isYaml = lower.endsWith('.yaml') || lower.endsWith('.yml');
-      if (!isJson && !isYaml) {
-        appendFeedback(
-          nextFeedbackId('hz-import-bad-ext'),
-          `"${file.name}": unsupported file type. Use .yaml, .yml, or .json.`
-        );
-        continue;
-      }
-
-      let hazards: Hazard[];
-      let issues: ReturnType<typeof importHazardYaml>['issues'];
-      let skipped: ReturnType<typeof importHazardYaml>['skipped'];
-      try {
-        ({ hazards, issues, skipped } = isJson
-          ? importHazardFoundryJson(text)
-          : importHazardYaml(text));
-      } catch (err) {
-        appendFeedback(
-          nextFeedbackId('hz-import-fail'),
-          `Could not import "${file.name}": ${err instanceof Error ? err.message : String(err)}`
-        );
-        continue;
-      }
-
-      const persistResult = await addHazards(hazards);
-
-      if (!persistResult.ok) {
-        appendFeedback(
-          nextFeedbackId('hz-import-persist-fail'),
-          persistResult.reason === 'unavailable'
-            ? `Could not save hazards from "${file.name}": storage is unavailable (common causes: private-browsing mode or browser policy).`
-            : `Could not save hazards from "${file.name}": storage write failed. Common causes: full storage, or another tab using a newer version.`
-        );
-        continue;
-      }
-
-      for (const hazard of persistResult.rejected) {
-        appendFeedback(
-          nextFeedbackId('hz-import-dup'),
-          `Skipped "${hazard.name}" from "${file.name}": id "${hazard.id}" is already in your library.`
-        );
-      }
-
-      if (persistResult.added.length > 0) {
-        storedHazards = [...storedHazards, ...persistResult.added];
-        appendFeedback(
-          nextFeedbackId('hz-import-ok'),
-          `Imported ${persistResult.added.length} hazard${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
-          'success'
-        );
-      }
-
-      for (const skip of skipped) {
-        appendFeedback(
-          nextFeedbackId('hz-import-skip'),
-          `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not a hazard document.`,
-          'info'
-        );
-      }
-
-      for (const issue of issues) {
-        const where = issue.path ? ` at "${issue.path}"` : '';
-        const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
-        appendFeedback(
-          nextFeedbackId('hz-import-issue'),
-          `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
-        );
-      }
-
-      if (
-        persistResult.added.length === 0 &&
-        persistResult.rejected.length === 0 &&
-        issues.length === 0 &&
-        skipped.length === 0 &&
-        hazards.length === 0
-      ) {
-        appendFeedback(
-          nextFeedbackId('hz-import-empty'),
-          `"${file.name}" contained no hazard documents.`
-        );
-      }
-    }
   }
 
   async function handleRemoveHazard(id: string) {
@@ -1042,11 +1035,11 @@
         onAddOneFromBestiary={handleAddOneFromBestiary}
         onRemoveOneFromBestiaryCount={handleRemoveOneFromBestiaryCount}
         onAddManual={handleAddManual}
-        onImportCreatureFiles={handleImportCreatureFiles}
+        onImportCreatureFiles={handleImportLibraryFiles}
         onRemoveCreature={handleRemoveCreature}
         onAddOneFromHazards={handleAddOneFromHazards}
         onRemoveOneFromHazardsCount={handleRemoveOneFromHazardsCount}
-        onImportHazardFiles={handleImportHazardFiles}
+        onImportHazardFiles={handleImportLibraryFiles}
         onRemoveHazard={handleRemoveHazard}
         onAddPartyMemberToEncounter={handleAddPartyMemberToEncounter}
         onRemovePartyMember={handleRemovePartyMember}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Command, CombatantState, Creature, Duration, LogEntry, PartyMember, PromptResolution } from '../domain';
+  import type { Command, CombatantState, Creature, Duration, Hazard, LogEntry, PartyMember, PromptResolution } from '../domain';
   import { computeEncounterXP, getAdjustedView } from '../domain';
   import EncounterDifficultyMeter from '../components/EncounterDifficultyMeter.svelte';
   import TopBar from '../components/TopBar.svelte';
@@ -28,6 +28,7 @@
     listSpellEffectOptions,
     makeCombatant,
     makeCreatureCombatant,
+    makeHazardCombatant,
     makePartyMemberCombatant,
     newEncounterState,
     toCommand,
@@ -65,14 +66,19 @@
     removeCreature
   } from '$lib/storage/creature-library';
   import {
+    addHazards,
+    loadHazards,
+    removeHazard
+  } from '$lib/storage/hazard-library';
+  import {
     addPartyMembers,
     loadPartyMembers,
     removePartyMember,
     savePartyMember
   } from '$lib/storage/party-members';
   import { createPersistenceController } from '$lib/storage/persistence-controller';
-  import { importCreatureYaml, importPartyMemberYaml } from '$lib/yaml';
-  import { importCreatureFoundryJson } from '$lib/foundry';
+  import { importCreatureYaml, importHazardYaml, importPartyMemberYaml } from '$lib/yaml';
+  import { importCreatureFoundryJson, importHazardFoundryJson } from '$lib/foundry';
   import {
     COMMAND_ID_PREFIX,
     computeEncounterCounts,
@@ -101,6 +107,7 @@
   let feedbackCounter = 1;
   let selection: Selection = emptySelection;
   let storedCreatures: Creature[] = [];
+  let storedHazards: Hazard[] = [];
   let storedPartyMembers: PartyMember[] = [];
 
   $: availableCreatures = storedCreatures;
@@ -182,9 +189,10 @@
   }
 
   onMount(async () => {
-    const [restored, loadResult, partyResult] = await Promise.all([
+    const [restored, loadResult, hazardResult, partyResult] = await Promise.all([
       persistence.restore(),
       loadCreatures(),
+      loadHazards(),
       loadPartyMembers()
     ]);
     if (restored) {
@@ -208,6 +216,16 @@
         loadResult.reason === 'unavailable'
           ? 'Could not load your creature library: storage is unavailable. Imports this session will not survive a reload.'
           : 'Could not load your creature library from storage. Try reloading the page; if it persists, your saved data may be inaccessible (another tab on a newer version, full storage, or browser policy).'
+      );
+    }
+    if (hazardResult.ok) {
+      storedHazards = hazardResult.hazards;
+    } else {
+      appendFeedback(
+        nextFeedbackId('hazard-load-fail'),
+        hazardResult.reason === 'unavailable'
+          ? 'Could not load your hazard library: storage is unavailable. Imports this session will not survive a reload.'
+          : 'Could not load your hazard library from storage. Try reloading the page; if it persists, your saved data may be inaccessible.'
       );
     }
     if (partyResult.ok) {
@@ -376,6 +394,151 @@
       return;
     }
     storedCreatures = storedCreatures.filter((c) => c.id !== id);
+  }
+
+  function handleAddOneFromHazards(hazard: Hazard) {
+    const existing = encounterCounts[hazard.id] ?? 0;
+    const name = existing > 0 ? `${hazard.name} ${existing + 1}` : hazard.name;
+    const combatant = makeHazardCombatant({
+      hazard,
+      combatantId: `${hazard.id}-${combatantCounter++}`,
+      name
+    });
+    addCombatant(combatant);
+  }
+
+  function handleRemoveOneFromHazardsCount(hazardId: string) {
+    let target: CombatantState | undefined;
+    for (const id of [...encounter.initiative.order].reverse()) {
+      const c = encounter.combatants[id];
+      if (c && c.sourceType === 'hazard' && c.sourceId === hazardId) {
+        target = c;
+        break;
+      }
+    }
+    if (!target) {
+      for (const c of Object.values(encounter.combatants)) {
+        if (c.sourceType === 'hazard' && c.sourceId === hazardId) {
+          target = c;
+          break;
+        }
+      }
+    }
+    if (!target) return;
+    runCommand(toCommand('REMOVE_COMBATANT', { combatantId: target.id }, nextCommandId()));
+  }
+
+  async function handleImportHazardFiles(files: File[]) {
+    for (const file of files) {
+      let text: string;
+      try {
+        text = await file.text();
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('hz-import-read-fail'),
+          `Could not read "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      const lower = file.name.toLowerCase();
+      const isJson = lower.endsWith('.json');
+      const isYaml = lower.endsWith('.yaml') || lower.endsWith('.yml');
+      if (!isJson && !isYaml) {
+        appendFeedback(
+          nextFeedbackId('hz-import-bad-ext'),
+          `"${file.name}": unsupported file type. Use .yaml, .yml, or .json.`
+        );
+        continue;
+      }
+
+      let hazards: Hazard[];
+      let issues: ReturnType<typeof importHazardYaml>['issues'];
+      let skipped: ReturnType<typeof importHazardYaml>['skipped'];
+      try {
+        ({ hazards, issues, skipped } = isJson
+          ? importHazardFoundryJson(text)
+          : importHazardYaml(text));
+      } catch (err) {
+        appendFeedback(
+          nextFeedbackId('hz-import-fail'),
+          `Could not import "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      const persistResult = await addHazards(hazards);
+
+      if (!persistResult.ok) {
+        appendFeedback(
+          nextFeedbackId('hz-import-persist-fail'),
+          persistResult.reason === 'unavailable'
+            ? `Could not save hazards from "${file.name}": storage is unavailable (common causes: private-browsing mode or browser policy).`
+            : `Could not save hazards from "${file.name}": storage write failed. Common causes: full storage, or another tab using a newer version.`
+        );
+        continue;
+      }
+
+      for (const hazard of persistResult.rejected) {
+        appendFeedback(
+          nextFeedbackId('hz-import-dup'),
+          `Skipped "${hazard.name}" from "${file.name}": id "${hazard.id}" is already in your library.`
+        );
+      }
+
+      if (persistResult.added.length > 0) {
+        storedHazards = [...storedHazards, ...persistResult.added];
+        appendFeedback(
+          nextFeedbackId('hz-import-ok'),
+          `Imported ${persistResult.added.length} hazard${persistResult.added.length === 1 ? '' : 's'} from "${file.name}".`,
+          'success'
+        );
+      }
+
+      for (const skip of skipped) {
+        appendFeedback(
+          nextFeedbackId('hz-import-skip'),
+          `"${file.name}" doc ${skip.documentIndex + 1}: skipped — kind "${skip.kind}" is not a hazard document.`,
+          'info'
+        );
+      }
+
+      for (const issue of issues) {
+        const where = issue.path ? ` at "${issue.path}"` : '';
+        const lineHint = issue.line !== undefined ? ` (line ${issue.line})` : '';
+        appendFeedback(
+          nextFeedbackId('hz-import-issue'),
+          `"${file.name}" doc ${issue.documentIndex + 1}${where}${lineHint}: ${issue.message}`
+        );
+      }
+
+      if (
+        persistResult.added.length === 0 &&
+        persistResult.rejected.length === 0 &&
+        issues.length === 0 &&
+        skipped.length === 0 &&
+        hazards.length === 0
+      ) {
+        appendFeedback(
+          nextFeedbackId('hz-import-empty'),
+          `"${file.name}" contained no hazard documents.`
+        );
+      }
+    }
+  }
+
+  async function handleRemoveHazard(id: string) {
+    const result = await removeHazard(id);
+    if (!result.ok) {
+      appendFeedback(
+        nextFeedbackId('hz-remove-fail'),
+        result.reason === 'unavailable'
+          ? 'Could not remove hazard: storage is unavailable.'
+          : 'Could not remove hazard: storage write failed.'
+      );
+      return;
+    }
+    storedHazards = storedHazards.filter((h) => h.id !== id);
   }
 
   async function handleImportPartyMemberYamlFiles(files: File[]) {
@@ -872,6 +1035,7 @@
       <LibraryPane
         {canStart}
         creatures={availableCreatures}
+        hazards={storedHazards}
         partyMembers={storedPartyMembers}
         {conditionOptions}
         {encounterCounts}
@@ -880,6 +1044,10 @@
         onAddManual={handleAddManual}
         onImportCreatureFiles={handleImportCreatureFiles}
         onRemoveCreature={handleRemoveCreature}
+        onAddOneFromHazards={handleAddOneFromHazards}
+        onRemoveOneFromHazardsCount={handleRemoveOneFromHazardsCount}
+        onImportHazardFiles={handleImportHazardFiles}
+        onRemoveHazard={handleRemoveHazard}
         onAddPartyMemberToEncounter={handleAddPartyMemberToEncounter}
         onRemovePartyMember={handleRemovePartyMember}
         onSavePartyMember={handleSavePartyMember}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [sveltekit(), svelteTesting()],
+  // Pin the dev server to a project-dedicated port so it never collides with
+  // other local services. strictPort fails loudly instead of drifting to a
+  // random port if 2137 is already taken.
+  server: {
+    port: 2137,
+    strictPort: true
+  },
   test: {
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     environment: 'jsdom',


### PR DESCRIPTION
## What

Adds support for **complex hazards** (traps, environmental dangers) as encounter participants. Hazards can be imported from the Foundry pf2e module — the same source as monsters — stored in a library, and added to encounters as combatants that act in initiative.

This is a redesign-from-scratch replacement for the stale **PR #111** (19 commits behind master; predated the Foundry importer and the `baseSnapshot` redesign). It should be merged instead of #111.

## Design

A hazard is a plain `CombatantState` with `sourceType: "hazard"` plus an optional `hazardData` display bag. The domain reducer, effects engine, initiative, HP, and stat derivation treat it **identically to a creature** — no new domain commands, no new domain events.

Foundry stores a hazard's routine and disable instructions as **free-form HTML**, not structured data. They are HTML-stripped into plain text the GM reads at the table. There is no structured disable-progress tracking — the source data cannot populate it. Defensive stats stay plain numbers (no nullability ripple through derivation/UI); a genuinely-absent value defaults to `0` with an import warning.

A complex hazard rolls Stealth for initiative, so the factory stores `stealth` in the snapshot `perception` slot and the UI labels that stat "Stealth" for hazards.

## Changes

- **domain** — `Hazard` + `HazardData` types; `createCombatantFromHazard` factory (`src/domain/hazards/`)
- **foundry** — `hazard` actor JSON importer that rejects non-complex hazards; shared item-mapping helpers extracted into `foundry/shared.ts` and reused by the NPC and hazard mappers
- **yaml** — `kind: hazard` validator + `importHazardYaml` (parity with creatures)
- **storage** — `hazardLibrary` IndexedDB store; `DB_VERSION` 4 → 5
- **ui** — Hazards library section, hazard stat block in the details panel (Stealth, Hardness, routine/disable text), manage-modal support
- **specs** — `pf2e-hazards-spec.md` rewritten to v0.2 to match the implemented design; ROADMAP updated

## Verification

Pre-PR gate passes: `npm run check && npm run test:run && npm run audit && npm run build` — 0 type errors, 1108 tests pass, audit clean, build succeeds.

New tests cover the hazard factory, Foundry hazard mapper, YAML validator, IndexedDB library, `HazardsSection`, `HazardStatBlock`, and the hazard branch of the details panel.

Manual end-to-end: import a complex-hazard actor JSON from the Foundry pf2e module (`packs/hazards/`), confirm it appears in the Hazards library section, add it to an encounter, and verify the card badge, details panel (Stealth/Hardness/routine/disable), damage/effects/`MARK_DEAD`, and persistence across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
