### PR TITLE
chore(dev): pin Vite dev server to port 2137

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [sveltekit(), svelteTesting()],
+  // Pin the dev server to a project-dedicated port so it never collides with
+  // other local services. strictPort fails loudly instead of drifting to a
+  // random port if 2137 is already taken.
+  server: {
+    port: 2137,
+    strictPort: true
+  },
   test: {
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     environment: 'jsdom',


### PR DESCRIPTION
## What

Pins the Vite dev server to a project-dedicated port **2137** via `server.port` in `vite.config.ts`. `npm run dev` now always binds 2137 instead of the default 5173, so the project has a stable port that won't collide with other local services running on 5173.

`strictPort: true` makes Vite fail loudly if 2137 is already taken, rather than silently drifting to a random port.

## Why

Running multiple projects locally, the shared default port 5173 collides. A fixed per-project port removes the guesswork.

## Verification

Pre-PR gate passes: `npm run check && npm run test:run && npm run audit && npm run build` — 0 type errors, 1057 tests pass, audit clean, build succeeds. Confirmed a plain `npm run dev` binds `http://localhost:2137`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)