### PR TITLE
feat(clock): add in-game time tracker to the top bar

### DIFF
--- a/src/components/GameClock.svelte
+++ b/src/components/GameClock.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import {
+    formatGameClock,
+    fromParts,
+    stepClock,
+    toParts,
+    STEP_TEN_MINUTES,
+    STEP_HOUR,
+    STEP_DAY
+  } from '$lib/game-clock';
+
+  export let minutes: number;
+  export let onChange: (minutes: number) => void;
+
+  let editing = false;
+  let dayBuffer = '';
+  let hourBuffer = '';
+  let minuteBuffer = '';
+  let dayInputEl: HTMLInputElement | null = null;
+
+  $: display = formatGameClock(minutes);
+
+  async function startEdit() {
+    const parts = toParts(minutes);
+    dayBuffer = String(parts.day);
+    hourBuffer = String(parts.hour);
+    minuteBuffer = String(parts.minute);
+    editing = true;
+    await tick();
+    dayInputEl?.select();
+  }
+
+  function cancelEdit() {
+    editing = false;
+  }
+
+  function commitEdit() {
+    const next = fromParts({
+      day: Number(dayBuffer),
+      hour: Number(hourBuffer),
+      minute: Number(minuteBuffer)
+    });
+    editing = false;
+    onChange(next);
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitEdit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEdit();
+    }
+  }
+
+  function step(delta: number) {
+    onChange(stepClock(minutes, delta));
+  }
+</script>
+
+<div class="clock" aria-label="In-game time">
+  <span class="clock__label">Time</span>
+  <div class="clock__controls">
+    <div class="clock__group" aria-label="Subtract time">
+      <button type="button" onclick={() => step(-STEP_DAY)} aria-label="Minus one day">−1d</button>
+      <button type="button" onclick={() => step(-STEP_HOUR)} aria-label="Minus one hour">−1h</button>
+      <button type="button" onclick={() => step(-STEP_TEN_MINUTES)} aria-label="Minus ten minutes">−10m</button>
+    </div>
+
+    {#if editing}
+      <span class="clock__edit">
+        <input
+          bind:this={dayInputEl}
+          bind:value={dayBuffer}
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          aria-label="Day"
+          onkeydown={onKeydown}
+        />
+        <span class="clock__sep">·</span>
+        <input
+          bind:value={hourBuffer}
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          aria-label="Hour"
+          onkeydown={onKeydown}
+        />
+        <span class="clock__colon">:</span>
+        <input
+          bind:value={minuteBuffer}
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          aria-label="Minute"
+          onkeydown={onKeydown}
+        />
+        <button type="button" class="clock__ok" onclick={commitEdit} aria-label="Set time">Set</button>
+      </span>
+    {:else}
+      <button type="button" class="clock__value" onclick={startEdit} aria-label="Set time, currently {display}">
+        {display}
+      </button>
+    {/if}
+
+    <div class="clock__group" aria-label="Add time">
+      <button type="button" onclick={() => step(STEP_TEN_MINUTES)} aria-label="Plus ten minutes">+10m</button>
+      <button type="button" onclick={() => step(STEP_HOUR)} aria-label="Plus one hour">+1h</button>
+      <button type="button" onclick={() => step(STEP_DAY)} aria-label="Plus one day">+1d</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .clock {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .clock__label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs, 11px);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wider, 0.06em);
+    text-transform: uppercase;
+    color: var(--color-ink-soft);
+    line-height: 1;
+  }
+
+  .clock__controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 6px);
+  }
+
+  .clock__group {
+    display: flex;
+    gap: 2px;
+  }
+
+  .clock__group button {
+    font: inherit;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm, 13px);
+    font-weight: 600;
+    color: var(--color-ink);
+    background: transparent;
+    border: var(--border-thin, 1px solid #cfd6d1);
+    border-radius: var(--radius-sm, 4px);
+    padding: 2px 6px;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+  }
+
+  .clock__group button:hover {
+    background: var(--color-panel-2, #eef1ee);
+    border-color: var(--color-ink);
+  }
+
+  .clock__value {
+    font-family: var(--font-mono);
+    font-size: var(--text-lg, 16px);
+    font-weight: 700;
+    color: var(--color-ink);
+    background: transparent;
+    border: 0;
+    padding: 2px 4px;
+    min-width: 11ch;
+    text-align: center;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 3px;
+    text-decoration-color: rgba(0, 0, 0, 0.25);
+  }
+
+  .clock__value:hover,
+  .clock__value:focus-visible {
+    text-decoration-color: currentColor;
+  }
+
+  .clock__edit {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+  }
+
+  .clock__edit input {
+    width: 3ch;
+    padding: 1px 4px;
+    font: inherit;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    border: 1px solid var(--input-border, #888);
+    border-radius: 3px;
+    background: var(--color-panel-up, #fff);
+    color: inherit;
+  }
+
+  .clock__sep,
+  .clock__colon {
+    color: var(--color-ink-soft);
+    font-family: var(--font-mono);
+  }
+
+  .clock__ok {
+    font: inherit;
+    font-size: var(--text-xs, 11px);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider, 0.06em);
+    color: var(--color-ink);
+    background: transparent;
+    border: var(--border-thin, 1px solid #cfd6d1);
+    border-radius: var(--radius-sm, 4px);
+    padding: 2px 6px;
+    cursor: pointer;
+  }
+
+  button:focus-visible {
+    outline: 2px solid var(--color-blue, #b88a2c);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/components/GameClock.test.ts
+++ b/src/components/GameClock.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import GameClock from './GameClock.svelte';
+
+describe('GameClock', () => {
+  test('renders the formatted time', () => {
+    render(GameClock, { props: { minutes: 14 * 60 + 30, onChange: () => {} } });
+    expect(screen.getByText('Day 1 · 14:30')).toBeInTheDocument();
+  });
+
+  test('step buttons emit the new total minutes', async () => {
+    const onChange = vi.fn();
+    render(GameClock, { props: { minutes: 0, onChange } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Plus one hour' }));
+    expect(onChange).toHaveBeenCalledWith(60);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Plus one day' }));
+    expect(onChange).toHaveBeenCalledWith(24 * 60);
+  });
+
+  test('decrement never goes below zero', async () => {
+    const onChange = vi.fn();
+    render(GameClock, { props: { minutes: 5, onChange } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Minus one hour' }));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  test('clicking the value lets you set it directly', async () => {
+    const onChange = vi.fn();
+    render(GameClock, { props: { minutes: 0, onChange } });
+
+    await fireEvent.click(screen.getByRole('button', { name: /Set time, currently/ }));
+    await fireEvent.input(screen.getByLabelText('Day'), { target: { value: '3' } });
+    await fireEvent.input(screen.getByLabelText('Hour'), { target: { value: '8' } });
+    await fireEvent.input(screen.getByLabelText('Minute'), { target: { value: '15' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Set time' }));
+
+    expect(onChange).toHaveBeenCalledWith(2 * 24 * 60 + 8 * 60 + 15);
+  });
+});

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -2,11 +2,14 @@
   import type { EncounterState } from '../domain';
   import Chip from './ui/Chip.svelte';
   import SectionLabel from './ui/SectionLabel.svelte';
+  import GameClock from './GameClock.svelte';
 
   export let name: string;
   export let phase: EncounterState['phase'];
   export let round: number;
   export let activeName: string | undefined;
+  export let clockMinutes: number;
+  export let onClockChange: (minutes: number) => void;
 </script>
 
 <header class="topbar">
@@ -15,6 +18,7 @@
     <h1>{name}</h1>
   </div>
   <div class="topbar__status" aria-label="Encounter status">
+    <GameClock minutes={clockMinutes} onChange={onClockChange} />
     <Chip variant={phase === 'ACTIVE' ? 'success' : 'default'}>{phase}</Chip>
     <div class="topbar__round">
       <SectionLabel>Round</SectionLabel>

--- a/src/components/TopBar.test.ts
+++ b/src/components/TopBar.test.ts
@@ -8,6 +8,8 @@ function baseProps(overrides: Record<string, unknown> = {}) {
     phase: 'PREPARING' as const,
     round: 0,
     activeName: undefined,
+    clockMinutes: 0,
+    onClockChange: () => {},
     ...overrides
   };
 }

--- a/src/lib/game-clock.test.ts
+++ b/src/lib/game-clock.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampClock,
+  formatGameClock,
+  fromParts,
+  stepClock,
+  toParts,
+  MINUTES_PER_DAY,
+  STEP_DAY,
+  STEP_HOUR,
+  STEP_TEN_MINUTES
+} from './game-clock';
+
+describe('clampClock', () => {
+  it('floors at zero', () => {
+    expect(clampClock(-5)).toBe(0);
+  });
+
+  it('rounds to whole minutes', () => {
+    expect(clampClock(10.6)).toBe(11);
+  });
+
+  it('treats non-finite input as zero', () => {
+    expect(clampClock(NaN)).toBe(0);
+    expect(clampClock(Infinity)).toBe(0);
+  });
+});
+
+describe('toParts / fromParts', () => {
+  it('reads zero minutes as Day 1, 00:00', () => {
+    expect(toParts(0)).toEqual({ day: 1, hour: 0, minute: 0 });
+  });
+
+  it('splits a multi-day value', () => {
+    const minutes = 2 * MINUTES_PER_DAY + 14 * 60 + 30;
+    expect(toParts(minutes)).toEqual({ day: 3, hour: 14, minute: 30 });
+  });
+
+  it('round-trips through fromParts', () => {
+    const parts = { day: 4, hour: 9, minute: 45 };
+    expect(toParts(fromParts(parts))).toEqual(parts);
+  });
+
+  it('clamps out-of-range parts when combining', () => {
+    expect(fromParts({ day: 0, hour: 99, minute: -3 })).toBe(23 * 60);
+  });
+});
+
+describe('stepClock', () => {
+  it('advances by the given step', () => {
+    expect(stepClock(0, STEP_TEN_MINUTES)).toBe(10);
+    expect(stepClock(0, STEP_HOUR)).toBe(60);
+    expect(stepClock(0, STEP_DAY)).toBe(MINUTES_PER_DAY);
+  });
+
+  it('never drops below zero', () => {
+    expect(stepClock(5, -STEP_HOUR)).toBe(0);
+  });
+});
+
+describe('formatGameClock', () => {
+  it('pads hours and minutes', () => {
+    expect(formatGameClock(0)).toBe('Day 1 · 00:00');
+    expect(formatGameClock(9 * 60 + 5)).toBe('Day 1 · 09:05');
+  });
+
+  it('formats later days', () => {
+    expect(formatGameClock(MINUTES_PER_DAY + 60)).toBe('Day 2 · 01:00');
+  });
+});

--- a/src/lib/game-clock.ts
+++ b/src/lib/game-clock.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers for the in-game clock. The clock is stored as a single integer:
+ * total minutes elapsed since the start of Day 1 at 00:00. Days are 1-based for
+ * display, so 0 minutes reads as "Day 1 · 00:00". The value is clamped at 0 — the
+ * clock never runs before the start of the campaign's first day.
+ */
+
+export const MINUTES_PER_HOUR = 60;
+export const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+
+/** Step sizes for the increment/decrement buttons, in minutes. */
+export const STEP_TEN_MINUTES = 10;
+export const STEP_HOUR = MINUTES_PER_HOUR;
+export const STEP_DAY = MINUTES_PER_DAY;
+
+export interface GameClockParts {
+  /** 1-based day number (Day 1 is the first day). */
+  day: number;
+  /** Hour of day, 0–23. */
+  hour: number;
+  /** Minute of hour, 0–59. */
+  minute: number;
+}
+
+/** Clamps to a non-negative whole number of minutes. Non-finite input becomes 0. */
+export function clampClock(minutes: number): number {
+  if (!Number.isFinite(minutes)) return 0;
+  return Math.max(0, Math.round(minutes));
+}
+
+/** Adds a (possibly negative) step and clamps the result at 0. */
+export function stepClock(minutes: number, delta: number): number {
+  return clampClock(clampClock(minutes) + delta);
+}
+
+export function toParts(minutes: number): GameClockParts {
+  const total = clampClock(minutes);
+  const day = Math.floor(total / MINUTES_PER_DAY) + 1;
+  const rem = total % MINUTES_PER_DAY;
+  return {
+    day,
+    hour: Math.floor(rem / MINUTES_PER_HOUR),
+    minute: rem % MINUTES_PER_HOUR
+  };
+}
+
+/**
+ * Combines day/hour/minute into total minutes. Day is clamped to at least 1;
+ * hour and minute are clamped to their valid ranges so out-of-range inputs from
+ * a manual edit can't produce a negative or malformed clock.
+ */
+export function fromParts(parts: GameClockParts): number {
+  const day = Math.max(1, Math.floor(parts.day) || 1);
+  const hour = Math.min(23, Math.max(0, Math.floor(parts.hour) || 0));
+  const minute = Math.min(59, Math.max(0, Math.floor(parts.minute) || 0));
+  return (day - 1) * MINUTES_PER_DAY + hour * MINUTES_PER_HOUR + minute;
+}
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+/** Formats the clock as "Day N · HH:MM" for display. */
+export function formatGameClock(minutes: number): string {
+  const { day, hour, minute } = toParts(minutes);
+  return `Day ${day} · ${pad(hour)}:${pad(minute)}`;
+}

--- a/src/lib/storage/game-clock.ts
+++ b/src/lib/storage/game-clock.ts
@@ -1,0 +1,18 @@
+import { getDb, SETTINGS_STORE } from './db';
+
+const KEY = 'gameClockMinutes';
+
+export async function saveGameClock(minutes: number): Promise<void> {
+  const promise = getDb();
+  if (!promise) return;
+  const db = await promise;
+  await db.put(SETTINGS_STORE, minutes, KEY);
+}
+
+export async function loadGameClock(): Promise<number | null> {
+  const promise = getDb();
+  if (!promise) return null;
+  const db = await promise;
+  const stored = (await db.get(SETTINGS_STORE, KEY)) as unknown;
+  return typeof stored === 'number' && Number.isFinite(stored) ? stored : null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,6 +77,8 @@
     savePartyMember
   } from '$lib/storage/party-members';
   import { createPersistenceController } from '$lib/storage/persistence-controller';
+  import { loadGameClock, saveGameClock } from '$lib/storage/game-clock';
+  import { clampClock } from '$lib/game-clock';
   import { importCreatureYaml, importHazardYaml, importPartyMemberYaml } from '$lib/yaml';
   import { importCreatureFoundryJson, importHazardFoundryJson } from '$lib/foundry';
   import {
@@ -109,6 +111,12 @@
   let storedCreatures: Creature[] = [];
   let storedHazards: Hazard[] = [];
   let storedPartyMembers: PartyMember[] = [];
+  let clockMinutes = 0;
+
+  function setClock(minutes: number) {
+    clockMinutes = clampClock(minutes);
+    void saveGameClock(clockMinutes);
+  }
 
   $: availableCreatures = storedCreatures;
 
@@ -189,12 +197,16 @@
   }
 
   onMount(async () => {
-    const [restored, loadResult, hazardResult, partyResult] = await Promise.all([
+    const [restored, loadResult, hazardResult, partyResult, clock] = await Promise.all([
       persistence.restore(),
       loadCreatures(),
       loadHazards(),
-      loadPartyMembers()
+      loadPartyMembers(),
+      loadGameClock()
     ]);
+    if (clock !== null) {
+      clockMinutes = clampClock(clock);
+    }
     if (restored) {
       encounter = { ...restored, combatLog: dedupeLogById(restored.combatLog) };
       commandCounter = nextCommandCounterFor(encounter.combatLog);
@@ -1019,6 +1031,8 @@
     phase={encounter.phase}
     round={encounter.round}
     activeName={activeCombatant?.name}
+    {clockMinutes}
+    onClockChange={setClock}
   />
 
   <EncounterDifficultyMeter summary={xpSummary} />


### PR DESCRIPTION
## What

Adds an in-game **time tracker** to the existing top bar — no new row is created; it slots into the same header row alongside the phase/round/turn status.

### Features
- **Step buttons**: `−1d −1h −10m` and `+10m +1h +1d` around the value.
- **Click to set**: clicking the `Day N · HH:MM` value opens inline Day / Hour / Minute fields with a **Set** button (Enter commits, Esc cancels).
- **Persisted in the browser**: stored as total minutes in the IndexedDB settings store and restored on load. Clamped at 0 so the clock never runs before Day 1 · 00:00.

## Architecture

Respects the project's unidirectional layering:
- `src/lib/game-clock.ts` — pure formatting/stepping helpers (`toParts`, `fromParts`, `stepClock`, `formatGameClock`).
- `src/lib/storage/game-clock.ts` — IndexedDB load/save in the existing settings store.
- `src/components/GameClock.svelte` — presentational; receives `minutes`, emits via `onChange`.
- `src/routes/+page.svelte` — owns the value, loads on mount, persists on change, passes through `TopBar`.

## Tests

- `src/lib/game-clock.test.ts` — clamp, parts round-trip, stepping, formatting.
- `src/components/GameClock.test.ts` — step buttons, floor-at-zero, click-to-set flow.
- Updated `TopBar.test.ts` for the two new props.

Verified manually in the browser: stepping, click-to-edit, and persistence across reload all work.

## Pre-PR gate

`npm run check` ✅ · `npm run test:run` ✅ (1124 passed) · `npm run build` ✅. `npm run audit` fails on pre-existing advisories present on `master` (no dependencies were added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)