### PR TITLE
fix(library): count hazard combatants in per-source-id counts

### DIFF
--- a/src/lib/page-helpers.test.ts
+++ b/src/lib/page-helpers.test.ts
@@ -126,12 +126,27 @@ describe('computeEncounterCounts', () => {
     expect(computeEncounterCounts({})).toEqual({});
   });
 
-  test('skips combatants whose sourceType is not "creature"', () => {
+  test('skips combatants whose sourceType is neither "creature" nor "hazard"', () => {
     const result = computeEncounterCounts({
       'aric-1': combatant('aric-1', { sourceType: 'partyMember', sourceId: 'aric' }),
       'goblin-1': combatant('goblin-1', { sourceType: 'creature', sourceId: 'goblin' })
     });
     expect(result).toEqual({ goblin: 1 });
+  });
+
+  test('counts hazard combatants alongside creatures', () => {
+    const result = computeEncounterCounts({
+      'goblin-1': combatant('goblin-1', { sourceType: 'creature', sourceId: 'goblin' }),
+      'dart-gallery-1': combatant('dart-gallery-1', {
+        sourceType: 'hazard',
+        sourceId: 'dart-gallery'
+      }),
+      'dart-gallery-2': combatant('dart-gallery-2', {
+        sourceType: 'hazard',
+        sourceId: 'dart-gallery'
+      })
+    });
+    expect(result).toEqual({ goblin: 1, 'dart-gallery': 2 });
   });
 
   test('aggregates multiple combatants sharing a sourceId', () => {

--- a/src/lib/page-helpers.ts
+++ b/src/lib/page-helpers.ts
@@ -47,7 +47,9 @@ export function computeEncounterCounts(
 ): CountsBySourceId {
   const counts: CountsBySourceId = {};
   for (const combatant of Object.values(combatants)) {
-    if (combatant.sourceType !== 'creature') continue;
+    // Creatures and hazards are added from the library in repeatable
+    // instances, so each library section needs a per-source-id count.
+    if (combatant.sourceType !== 'creature' && combatant.sourceType !== 'hazard') continue;
     counts[combatant.sourceId] = (counts[combatant.sourceId] ?? 0) + 1;
   }
   return counts;


### PR DESCRIPTION
## What

`computeEncounterCounts` only tallied combatants with `sourceType === "creature"`, so the **Hazards** library section never reflected how many instances of a given hazard were already in the encounter. Hazards are added from the library in repeatable instances just like creatures, so they belong in the same per-source-id count.

## Change

- `src/lib/page-helpers.ts` — include `sourceType === "hazard"` in the tally.
- `src/lib/page-helpers.test.ts` — add a case for counting hazards alongside creatures; rename the exclusion test to reflect that party members (not hazards) are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)