### PR TITLE
feat(conditions): Dying/Wounded/Doomed death-tracking subsystem

### DIFF
--- a/src/domain/effects/death.test.ts
+++ b/src/domain/effects/death.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'vitest';
+import type { AppliedEffect, CombatantState, CommandResult, DomainEvent, EncounterState } from '../types';
+import { effectLibrary } from './library';
+import { conditionValue, dyingDeathThreshold, findConditionInstance } from './death';
+import { applyCommand } from '../reducer';
+import { combatant, command, encounter, expectSerializable } from '../test-support';
+
+function pc(appliedEffects: AppliedEffect[] = []): CombatantState {
+  return combatant('pc-1', { name: 'Valeros', sourceType: 'partyMember', appliedEffects });
+}
+
+function preparing(appliedEffects: AppliedEffect[] = []): EncounterState {
+  return encounter({ combatants: { 'pc-1': pc(appliedEffects) } });
+}
+
+function effectOf(result: CommandResult, effectId: string): AppliedEffect | undefined {
+  return findConditionInstance(result.newState.combatants['pc-1'], effectId);
+}
+
+function effectIds(result: CommandResult): string[] {
+  return result.newState.combatants['pc-1'].appliedEffects.map((effect) => effect.effectId);
+}
+
+function applyDying(state: EncounterState, payload: { value?: number } = {}): CommandResult {
+  const result = applyCommand(
+    state,
+    command('APPLY_EFFECT', { effectId: 'dying', targetId: 'pc-1', ...payload }),
+    effectLibrary
+  );
+  expectSerializable(result);
+  return result;
+}
+
+describe('death subsystem — pure helpers', () => {
+  test('conditionValue reads the value of a value condition, 0 when absent', () => {
+    const target = pc([{ instanceId: 'w', effectId: 'wounded', value: 2, duration: { type: 'unlimited' } }]);
+    expect(conditionValue(target, 'wounded')).toBe(2);
+    expect(conditionValue(target, 'doomed')).toBe(0);
+  });
+
+  test('dyingDeathThreshold is 4 − Doomed, floored at 1', () => {
+    expect(dyingDeathThreshold(0)).toBe(4);
+    expect(dyingDeathThreshold(1)).toBe(3);
+    expect(dyingDeathThreshold(3)).toBe(1);
+    expect(dyingDeathThreshold(5)).toBe(1);
+  });
+});
+
+describe('gaining Dying (spec §3.2)', () => {
+  test('applies Dying with implied Unconscious (and Off-Guard) when below the threshold', () => {
+    const result = applyDying(preparing(), { value: 1 });
+
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 1 });
+    expect(effectIds(result)).toEqual(expect.arrayContaining(['dying', 'unconscious', 'off-guard']));
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(true);
+    expect(result.events.some((e) => e.type === 'combatant-died')).toBe(false);
+    expect(result.newState.recentEffectIds).toContain('dying');
+  });
+
+  test('folds the Wounded value into the gained Dying value', () => {
+    const result = applyDying(preparing([{ instanceId: 'w', effectId: 'wounded', value: 2, duration: { type: 'unlimited' } }]), {
+      value: 1
+    });
+
+    // Dying 1 + Wounded 2 → Dying 3, still below the threshold of 4.
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 3 });
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(true);
+  });
+
+  test('Wounded pushing effective Dying to the threshold kills the combatant', () => {
+    const result = applyDying(preparing([{ instanceId: 'w', effectId: 'wounded', value: 2, duration: { type: 'unlimited' } }]), {
+      value: 2
+    });
+
+    // 2 + 2 = 4 ≥ threshold 4 → dead, Dying capped at the threshold, no Unconscious.
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 4 });
+    expect(effectIds(result)).not.toContain('unconscious');
+    expect(result.events).toContainEqual({ type: 'combatant-died', combatantId: 'pc-1', cause: 'dying-threshold' });
+  });
+
+  test('Doomed lowers the death threshold so a small Dying is fatal', () => {
+    const result = applyDying(preparing([{ instanceId: 'd', effectId: 'doomed', value: 3, duration: { type: 'unlimited' } }]), {
+      value: 1
+    });
+
+    // Threshold 4 − 3 = 1, Dying 1 ≥ 1 → dead.
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 1 });
+    expect(result.events).toContainEqual({ type: 'combatant-died', combatantId: 'pc-1', cause: 'dying-threshold' });
+  });
+
+  test('rejects re-applying Dying to a combatant that is already Dying', () => {
+    const dying = applyDying(preparing(), { value: 1 });
+    const again = applyDying(dying.newState, { value: 1 });
+
+    expect(again.events).toEqual([
+      {
+        type: 'command-rejected',
+        commandType: 'APPLY_EFFECT',
+        reason: 'Combatant pc-1 is already Dying; adjust the existing Dying value instead'
+      }
+    ]);
+  });
+
+  test('rejects a non-positive Dying value', () => {
+    const result = applyDying(preparing(), { value: 0 });
+    expect(result.events[0]).toMatchObject({ type: 'command-rejected', commandType: 'APPLY_EFFECT' });
+  });
+});
+
+describe('increasing Dying (spec §3.3)', () => {
+  function increase(delta: number, seed: AppliedEffect[] = []): CommandResult {
+    const dying = applyDying(preparing(seed), { value: 1 });
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('MODIFY_EFFECT_VALUE', { targetId: 'pc-1', instanceId, delta }),
+      effectLibrary
+    );
+    expectSerializable(result);
+    return result;
+  }
+
+  test('raises the value without adding Wounded again', () => {
+    const result = increase(1);
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 2 });
+    expect(effectIds(result)).not.toContain('wounded');
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(true);
+    expect(result.events).toContainEqual({
+      type: 'effect-value-changed',
+      combatantId: 'pc-1',
+      effectId: 'dying',
+      effectName: 'Dying',
+      instanceId: effectOf(result, 'dying')!.instanceId,
+      from: 1,
+      to: 2
+    });
+  });
+
+  test('crossing the threshold marks the combatant dead with Dying capped', () => {
+    // Dying 1 → +3 would be 4 ≥ threshold 4.
+    const result = increase(3);
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 4 });
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+    expect(result.events).toContainEqual({ type: 'combatant-died', combatantId: 'pc-1', cause: 'dying-threshold' });
+  });
+
+  test('Doomed shifts the threshold for the increase check', () => {
+    // Seeded Doomed 2 → threshold 2; Dying 1 → +1 = 2 ≥ 2 → dead.
+    const result = increase(1, [{ instanceId: 'd', effectId: 'doomed', value: 2, duration: { type: 'unlimited' } }]);
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 2 });
+  });
+
+  test('SET_EFFECT_VALUE above the threshold caps and kills', () => {
+    const dying = applyDying(preparing(), { value: 1 });
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('SET_EFFECT_VALUE', { targetId: 'pc-1', instanceId, newValue: 9 }),
+      effectLibrary
+    );
+
+    expect(effectOf(result, 'dying')).toMatchObject({ value: 4 });
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+  });
+});
+
+describe('recovering from Dying (spec §3.4)', () => {
+  test('MODIFY to 0 removes Dying (and implied conditions) and grants Wounded 1', () => {
+    const dying = applyDying(preparing(), { value: 1 });
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('MODIFY_EFFECT_VALUE', { targetId: 'pc-1', instanceId, delta: -1 }),
+      effectLibrary
+    );
+    expectSerializable(result);
+
+    expect(effectIds(result)).toEqual(['wounded']);
+    expect(effectOf(result, 'wounded')).toMatchObject({ value: 1 });
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(true);
+
+    const types = result.events.map((e: DomainEvent) => e.type);
+    expect(types).toContain('effect-removed');
+    expect(types).toContain('effect-applied');
+  });
+
+  test('recovering with existing Wounded raises it by one', () => {
+    const dying = applyDying(preparing([{ instanceId: 'w', effectId: 'wounded', value: 1, duration: { type: 'unlimited' } }]), {
+      value: 1
+    });
+    // Gained Dying folded Wounded 1 → Dying 2.
+    expect(effectOf(dying, 'dying')).toMatchObject({ value: 2 });
+
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('MODIFY_EFFECT_VALUE', { targetId: 'pc-1', instanceId, delta: -2 }),
+      effectLibrary
+    );
+
+    expect(effectIds(result)).toEqual(['wounded']);
+    expect(effectOf(result, 'wounded')).toMatchObject({ value: 2 });
+    expect(result.events).toContainEqual({
+      type: 'effect-value-changed',
+      combatantId: 'pc-1',
+      effectId: 'wounded',
+      effectName: 'Wounded',
+      instanceId: 'w',
+      from: 1,
+      to: 2
+    });
+  });
+
+  test('REMOVE_EFFECT on Dying recovers and grants Wounded', () => {
+    const dying = applyDying(preparing(), { value: 1 });
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('REMOVE_EFFECT', { targetId: 'pc-1', instanceId }),
+      effectLibrary
+    );
+
+    expect(effectIds(result)).toEqual(['wounded']);
+    expect(effectOf(result, 'wounded')).toMatchObject({ value: 1 });
+  });
+
+  test('Wounded does not exceed its maximum on repeated recovery', () => {
+    const dying = applyDying(preparing([{ instanceId: 'w', effectId: 'wounded', value: 3, duration: { type: 'unlimited' } }]), {
+      value: 1
+    });
+    const instanceId = effectOf(dying, 'dying')!.instanceId;
+    const result = applyCommand(
+      dying.newState,
+      command('REMOVE_EFFECT', { targetId: 'pc-1', instanceId }),
+      effectLibrary
+    );
+
+    expect(effectOf(result, 'wounded')).toMatchObject({ value: 3 });
+    expect(result.events.some((e) => e.type === 'effect-value-changed')).toBe(false);
+  });
+
+  test('removing Dying from a dead combatant is plain cleanup (no Wounded)', () => {
+    // 2 + Wounded 2 = 4 → dead.
+    const fatal = applyDying(preparing([{ instanceId: 'w', effectId: 'wounded', value: 2, duration: { type: 'unlimited' } }]), {
+      value: 2
+    });
+    expect(fatal.newState.combatants['pc-1'].isAlive).toBe(false);
+
+    const instanceId = effectOf(fatal, 'dying')!.instanceId;
+    const result = applyCommand(
+      fatal.newState,
+      command('REMOVE_EFFECT', { targetId: 'pc-1', instanceId }),
+      effectLibrary
+    );
+
+    expect(effectIds(result)).not.toContain('dying');
+    expect(conditionValue(result.newState.combatants['pc-1'], 'wounded')).toBe(2);
+  });
+});
+
+describe('Doomed changes recheck the threshold (spec §3.5)', () => {
+  test('raising Doomed under the current Dying value kills the combatant', () => {
+    const dying = applyDying(preparing([{ instanceId: 'd', effectId: 'doomed', value: 1, duration: { type: 'unlimited' } }]), {
+      value: 2
+    });
+    // Threshold 3, Dying 2 → alive.
+    expect(dying.newState.combatants['pc-1'].isAlive).toBe(true);
+
+    const result = applyCommand(
+      dying.newState,
+      command('SET_EFFECT_VALUE', { targetId: 'pc-1', instanceId: 'd', newValue: 2 }),
+      effectLibrary
+    );
+    expectSerializable(result);
+
+    // Threshold now 2, Dying 2 ≥ 2 → dead.
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(false);
+    expect(result.events).toContainEqual({ type: 'combatant-died', combatantId: 'pc-1', cause: 'dying-threshold' });
+  });
+
+  test('lowering Doomed raises the threshold and never kills', () => {
+    const dying = applyDying(preparing([{ instanceId: 'd', effectId: 'doomed', value: 1, duration: { type: 'unlimited' } }]), {
+      value: 2
+    });
+    const result = applyCommand(
+      dying.newState,
+      command('MODIFY_EFFECT_VALUE', { targetId: 'pc-1', instanceId: 'd', delta: -1 }),
+      effectLibrary
+    );
+
+    expect(effectIds(result)).not.toContain('doomed');
+    expect(result.newState.combatants['pc-1'].isAlive).toBe(true);
+  });
+});
+
+describe('recovery check at turn start (spec §3.6)', () => {
+  test('a Dying combatant gets a recovery prompt; accepting it recovers and grants Wounded', () => {
+    const base = encounter({
+      phase: 'ACTIVE',
+      round: 1,
+      combatants: {
+        'goblin-1': combatant('goblin-1'),
+        'pc-1': pc()
+      },
+      initiative: { order: ['goblin-1', 'pc-1'], currentIndex: 0, delaying: [], scores: {} }
+    });
+
+    const dying = applyCommand(base, command('APPLY_EFFECT', { effectId: 'dying', targetId: 'pc-1', value: 1 }), effectLibrary);
+
+    const ended = applyCommand(dying.newState, command('END_TURN'), effectLibrary);
+    expect(ended.newState.phase).toBe('RESOLVING');
+    const prompt = ended.newState.pendingPrompts.find((p) => p.effectName === 'Dying');
+    expect(prompt).toBeDefined();
+
+    const resolved = applyCommand(
+      ended.newState,
+      command('RESOLVE_PROMPT', { promptId: prompt!.id, resolution: { type: 'accept' } }),
+      effectLibrary
+    );
+    expectSerializable(resolved);
+
+    const pcAfter = resolved.newState.combatants['pc-1'];
+    expect(pcAfter.appliedEffects.map((e) => e.effectId)).toEqual(['wounded']);
+    expect(pcAfter.isAlive).toBe(true);
+    expect(resolved.newState.phase).toBe('ACTIVE');
+  });
+});

--- a/src/domain/effects/death.ts
+++ b/src/domain/effects/death.ts
@@ -1,0 +1,42 @@
+import type { AppliedEffect, CombatantState } from '../types';
+
+/**
+ * Death-tracking subsystem helpers (PF2e conditions library spec §3).
+ *
+ * Dying, Wounded, and Doomed interact mechanically and unambiguously, so the
+ * reducer resolves them automatically (no prompts) — the same justification as
+ * stacking rules and hard-clock expiry. These are the pure queries the reducer
+ * builds that automation on; the orchestration (creating/removing effects,
+ * marking dead, emitting events) lives in `reducer.ts`, which owns the effect
+ * instance machinery.
+ */
+
+/** Base death threshold. A creature dies at Dying >= (4 − Doomed). */
+export const DYING_DEATH_BASE = 4;
+
+/**
+ * The first applied instance of `effectId` on a combatant, or undefined.
+ *
+ * Dying, Wounded, and Doomed are single-instance, directly-applied conditions
+ * in practice, so scanning for the first match is sufficient.
+ */
+export function findConditionInstance(
+  combatant: CombatantState,
+  effectId: string
+): AppliedEffect | undefined {
+  return combatant.appliedEffects.find((effect) => effect.effectId === effectId);
+}
+
+/** Current value of a value condition (Dying/Wounded/Doomed), or 0 if absent. */
+export function conditionValue(combatant: CombatantState, effectId: string): number {
+  return findConditionInstance(combatant, effectId)?.value ?? 0;
+}
+
+/**
+ * Death threshold given a Doomed value: 4 − Doomed, floored at 1 so a creature
+ * always dies *at* some positive Dying value even if Doomed is pushed past its
+ * nominal max of 3.
+ */
+export function dyingDeathThreshold(doomedValue: number): number {
+  return Math.max(1, DYING_DEATH_BASE - doomedValue);
+}

--- a/src/domain/reducer.ts
+++ b/src/domain/reducer.ts
@@ -23,6 +23,7 @@ import type {
   UseSpellSlotPayload
 } from './types';
 import { getAdjustedView } from './creatures/adjusted-view';
+import { conditionValue, dyingDeathThreshold, findConditionInstance } from './effects/death';
 
 const allowedPhases: Record<CommandType, EncounterPhase[]> = {
   START_ENCOUNTER: ['PREPARING'],
@@ -961,6 +962,10 @@ function applyEffect(
     return reject(state, 'APPLY_EFFECT', `Effect ${command.payload.effectId} not found`);
   }
 
+  if (effect.id === 'dying') {
+    return applyDying(state, command, target, source, effect, effectLibrary);
+  }
+
   const duration = command.payload.duration ?? { type: 'unlimited' };
   if (!isValidDuration(state, duration)) {
     return reject(state, 'APPLY_EFFECT', 'APPLY_EFFECT duration is invalid');
@@ -995,6 +1000,290 @@ function applyEffect(
       recentEffectIds: pushRecent(state.recentEffectIds, command.payload.effectId)
     }
   };
+}
+
+function withRecentEffect(result: CommandResult, priorRecent: readonly string[], effectId: string): CommandResult {
+  return {
+    ...result,
+    newState: { ...result.newState, recentEffectIds: pushRecent(priorRecent, effectId) }
+  };
+}
+
+/**
+ * Apply the Dying condition (death-tracking spec §3.2). Gaining Dying folds in
+ * the combatant's Wounded value and checks the Doomed-adjusted death threshold.
+ * Re-applying Dying to a combatant that already has it is rejected — the GM
+ * raises the existing value via MODIFY_EFFECT_VALUE (spec §3.3) instead.
+ */
+function applyDying(
+  state: EncounterState,
+  command: Extract<Command, { type: 'APPLY_EFFECT' }>,
+  target: CombatantState,
+  source: CombatantState | undefined,
+  dyingDef: EffectDefinition,
+  effectLibrary: EffectLibrary
+): CommandResult {
+  const requested = command.payload.value ?? 1;
+  if (!isPositive(requested)) {
+    return reject(state, 'APPLY_EFFECT', `APPLY_EFFECT value must be >= 1 for ${dyingDef.name}`);
+  }
+
+  if (findConditionInstance(target, 'dying')) {
+    return reject(
+      state,
+      'APPLY_EFFECT',
+      `Combatant ${target.id} is already Dying; adjust the existing Dying value instead`
+    );
+  }
+
+  const woundedValue = conditionValue(target, 'wounded');
+  const doomedValue = conditionValue(target, 'doomed');
+  const threshold = dyingDeathThreshold(doomedValue);
+  const effectiveValue = requested + woundedValue;
+
+  if (effectiveValue >= threshold) {
+    return applyFatalDying(state, command, target, source, dyingDef, threshold);
+  }
+
+  const appliedEffects = [...target.appliedEffects];
+  const events: DomainEvent[] = [];
+  const created = appendAppliedEffect({
+    target,
+    effectLibrary,
+    appliedEffects,
+    events,
+    commandId: command.id,
+    effect: dyingDef,
+    sourceId: command.payload.sourceId,
+    sourceLabel: source?.name,
+    value: effectiveValue,
+    duration: { type: 'unlimited' },
+    note: command.payload.note,
+    seenEffectIds: new Set()
+  });
+
+  if (created.error) {
+    return reject(state, 'APPLY_EFFECT', created.error);
+  }
+
+  return withRecentEffect(
+    updateCombatant(state, { ...target, appliedEffects }, events),
+    state.recentEffectIds,
+    'dying'
+  );
+}
+
+/**
+ * Gaining Dying at or beyond the death threshold (spec §3.2 step 5): record
+ * Dying capped at the threshold and mark the combatant dead. No implied
+ * Unconscious — the combatant is dead, not merely unconscious.
+ */
+function applyFatalDying(
+  state: EncounterState,
+  command: Extract<Command, { type: 'APPLY_EFFECT' }>,
+  target: CombatantState,
+  source: CombatantState | undefined,
+  dyingDef: EffectDefinition,
+  threshold: number
+): CommandResult {
+  const instanceId = nextEffectInstanceId(command.id, target.appliedEffects);
+  const dyingEffect: AppliedEffect = {
+    instanceId,
+    effectId: 'dying',
+    value: threshold,
+    ...(command.payload.sourceId ? { sourceId: command.payload.sourceId } : {}),
+    ...(source ? { sourceLabel: source.name } : {}),
+    duration: { type: 'unlimited' }
+  };
+
+  const updated: CombatantState = {
+    ...target,
+    appliedEffects: [...target.appliedEffects, dyingEffect],
+    isAlive: false
+  };
+
+  const events: DomainEvent[] = [
+    {
+      type: 'effect-applied',
+      combatantId: target.id,
+      effectId: 'dying',
+      effectName: dyingDef.name,
+      instanceId,
+      value: threshold
+    },
+    { type: 'combatant-died', combatantId: target.id, cause: 'dying-threshold' }
+  ];
+
+  return withRecentEffect(updateCombatant(state, updated, events), state.recentEffectIds, 'dying');
+}
+
+/**
+ * Recovering from Dying (spec §3.4): remove Dying (cascading to its implied
+ * Unconscious / Off-Guard), then add Wounded 1 or raise existing Wounded by 1.
+ */
+function recoverFromDying(
+  state: EncounterState,
+  target: CombatantState,
+  dyingInstanceId: string,
+  effectLibrary: EffectLibrary,
+  commandType: CommandType
+): CommandResult {
+  const removal = removeExistingEffect(state, target, dyingInstanceId, effectLibrary, 'removed', commandType);
+  if (removal.events.some((event) => event.type === 'command-rejected')) {
+    return removal;
+  }
+
+  const woundedDef = effectLibrary['wounded'];
+  const updatedTarget = removal.newState.combatants[target.id];
+  if (!woundedDef || !updatedTarget) {
+    return removal;
+  }
+
+  const existingWounded = findConditionInstance(updatedTarget, 'wounded');
+  if (existingWounded) {
+    const from = existingWounded.value ?? 1;
+    const to = woundedDef.maxValue !== undefined ? Math.min(from + 1, woundedDef.maxValue) : from + 1;
+    if (to === from) {
+      return removal;
+    }
+    return updateCombatant(removal.newState, replaceEffect(updatedTarget, { ...existingWounded, value: to }), [
+      ...removal.events,
+      {
+        type: 'effect-value-changed',
+        combatantId: updatedTarget.id,
+        effectId: 'wounded',
+        effectName: woundedDef.name,
+        instanceId: existingWounded.instanceId,
+        from,
+        to
+      }
+    ]);
+  }
+
+  const appliedEffects = [...updatedTarget.appliedEffects];
+  const events: DomainEvent[] = [...removal.events];
+  const created = appendAppliedEffect({
+    target: updatedTarget,
+    effectLibrary,
+    appliedEffects,
+    events,
+    commandId: `${dyingInstanceId}:recover`,
+    effect: woundedDef,
+    value: 1,
+    duration: { type: 'unlimited' },
+    seenEffectIds: new Set()
+  });
+
+  if (created.error) {
+    return reject(state, commandType, created.error);
+  }
+
+  return updateCombatant(removal.newState, { ...updatedTarget, appliedEffects }, events);
+}
+
+/**
+ * Resolve a change to an existing Dying value (spec §3.3 increase / §3.4
+ * recovery). Reaching 0 recovers (adding Wounded); reaching the threshold marks
+ * the combatant dead with Dying capped at the threshold.
+ */
+function applyDyingTransition(
+  state: EncounterState,
+  target: CombatantState,
+  dyingEffect: AppliedEffect,
+  dyingDef: EffectDefinition,
+  fromValue: number,
+  newValue: number,
+  effectLibrary: EffectLibrary,
+  commandType: CommandType
+): CommandResult {
+  if (newValue <= 0) {
+    return recoverFromDying(state, target, dyingEffect.instanceId, effectLibrary, commandType);
+  }
+
+  const threshold = dyingDeathThreshold(conditionValue(target, 'doomed'));
+  const dead = newValue >= threshold;
+  const finalValue = dead ? threshold : newValue;
+
+  const events: DomainEvent[] = [
+    {
+      type: 'effect-value-changed',
+      combatantId: target.id,
+      effectId: 'dying',
+      effectName: dyingDef.name,
+      instanceId: dyingEffect.instanceId,
+      from: fromValue,
+      to: finalValue
+    }
+  ];
+
+  let updated = replaceEffect(target, { ...dyingEffect, value: finalValue });
+  if (dead) {
+    updated = { ...updated, isAlive: false };
+    events.push({ type: 'combatant-died', combatantId: target.id, cause: 'dying-threshold' });
+  }
+
+  return updateCombatant(state, updated, events);
+}
+
+/**
+ * Resolve a change to Doomed (spec §3.5): apply the new Doomed value, then, if
+ * the combatant is currently Dying, re-check the death threshold and mark dead
+ * if the now-lower threshold has been crossed.
+ */
+function applyDoomedChange(
+  state: EncounterState,
+  target: CombatantState,
+  doomedEffect: AppliedEffect,
+  doomedDef: EffectDefinition,
+  fromValue: number,
+  newValue: number,
+  effectLibrary: EffectLibrary,
+  commandType: CommandType
+): CommandResult {
+  let base: CommandResult;
+  let effectiveDoomed: number;
+
+  if (newValue <= 0) {
+    base = removeExistingEffect(state, target, doomedEffect.instanceId, effectLibrary, 'auto-decremented', commandType);
+    effectiveDoomed = 0;
+  } else {
+    base = updateCombatant(state, replaceEffect(target, { ...doomedEffect, value: newValue }), [
+      {
+        type: 'effect-value-changed',
+        combatantId: target.id,
+        effectId: 'doomed',
+        effectName: doomedDef.name,
+        instanceId: doomedEffect.instanceId,
+        from: fromValue,
+        to: newValue
+      }
+    ]);
+    effectiveDoomed = newValue;
+  }
+
+  if (base.events.some((event) => event.type === 'command-rejected')) {
+    return base;
+  }
+
+  const updatedTarget = base.newState.combatants[target.id];
+  if (!updatedTarget?.isAlive) {
+    return base;
+  }
+
+  const dyingEffect = findConditionInstance(updatedTarget, 'dying');
+  if (!dyingEffect) {
+    return base;
+  }
+
+  const dyingValue = dyingEffect.value ?? 1;
+  if (dyingValue < dyingDeathThreshold(effectiveDoomed)) {
+    return base;
+  }
+
+  return updateCombatant(base.newState, { ...updatedTarget, isAlive: false }, [
+    ...base.events,
+    { type: 'combatant-died', combatantId: updatedTarget.id, cause: 'dying-threshold' }
+  ]);
 }
 
 interface AppendAppliedEffectInput {
@@ -1113,6 +1402,12 @@ function removeEffect(
   const effect = target.appliedEffects.find((appliedEffect) => appliedEffect.instanceId === instanceId);
   if (!effect) {
     return reject(state, 'REMOVE_EFFECT', `Effect instance ${instanceId} not found on ${targetId}`);
+  }
+
+  // Removing Dying from a living combatant is a recovery (spec §3.4): it grants
+  // Wounded. Removing it from a corpse is plain cleanup — no Wounded.
+  if (effect.effectId === 'dying' && target.isAlive) {
+    return recoverFromDying(state, target, instanceId, effectLibrary, 'REMOVE_EFFECT');
   }
 
   return removeExistingEffect(state, target, instanceId, effectLibrary, reason, 'REMOVE_EFFECT');
@@ -1275,6 +1570,13 @@ function setEffectValue(
     return reject(state, 'SET_EFFECT_VALUE', 'SET_EFFECT_VALUE newValue must be >= 1');
   }
 
+  if (effect.effectId === 'dying' && target.isAlive) {
+    return applyDyingTransition(state, target, effect, definition, effect.value ?? 1, newValue, effectLibrary, 'SET_EFFECT_VALUE');
+  }
+  if (effect.effectId === 'doomed') {
+    return applyDoomedChange(state, target, effect, definition, effect.value ?? 1, newValue, effectLibrary, 'SET_EFFECT_VALUE');
+  }
+
   const from = effect.value ?? 1;
   const updatedEffect = { ...effect, value: newValue };
 
@@ -1318,6 +1620,14 @@ function modifyEffectValue(
 
   const from = effect.value ?? 1;
   const to = from + delta;
+
+  if (effect.effectId === 'dying' && target.isAlive) {
+    return applyDyingTransition(state, target, effect, definition, from, to, effectLibrary, 'MODIFY_EFFECT_VALUE');
+  }
+  if (effect.effectId === 'doomed') {
+    return applyDoomedChange(state, target, effect, definition, from, to, effectLibrary, 'MODIFY_EFFECT_VALUE');
+  }
+
   if (to <= 0) {
     return removeExistingEffect(state, target, instanceId, effectLibrary, 'auto-decremented', 'MODIFY_EFFECT_VALUE');
   }

--- a/src/lib/encounter-app.test.ts
+++ b/src/lib/encounter-app.test.ts
@@ -674,7 +674,11 @@ describe('end-to-end condition dispatches', () => {
       }, 'cmd-remove')
     );
 
-    expect(removed.state.combatants['fighter-1'].appliedEffects).toEqual([]);
+    // Removing Dying cascades away its implied Unconscious / Off-Guard, and
+    // recovering from Dying grants Wounded 1 (death-tracking spec §3.4).
+    const remaining = removed.state.combatants['fighter-1'].appliedEffects;
+    expect(remaining.map((e) => e.effectId)).toEqual(['wounded']);
+    expect(remaining[0]).toMatchObject({ effectId: 'wounded', value: 1 });
   });
 });
 


### PR DESCRIPTION
## What

Implements the PF2e death-tracking subsystem (conditions-library spec §3) so **Dying / Wounded / Doomed** interact mechanically and automatically. These conditions previously existed in the effect library but were inert — applying Dying did nothing beyond adding the effect, recovery never granted Wounded, and the death threshold was never enforced.

The subsystem is combatant-agnostic; in practice it's the PCs who gain Dying, which is the use case this targets.

## Behavior (spec §3.2–3.6)

- **Gaining Dying** folds in the combatant's Wounded value and checks the Doomed-adjusted threshold (`4 − Doomed`). Below threshold → Dying + implied Unconscious/Off-Guard. At/over threshold → Dying capped at the threshold and the combatant is marked dead (`combatant-died`, cause `dying-threshold`).
- **Increasing Dying** re-checks the threshold (Wounded is *not* re-added on increase).
- **Recovery** (REMOVE_EFFECT on a living combatant, or decrementing Dying to 0) cascades away the implied conditions and grants Wounded 1 / raises existing Wounded by 1 (capped at max). Removing Dying from a corpse is plain cleanup — no Wounded.
- **Changing Doomed** re-checks the threshold for a currently-Dying combatant.
- Re-applying Dying to someone already Dying is rejected (raise the existing value instead).
- The existing turn-start recovery prompt now routes through these paths, so resolving it recovers the combatant and grants Wounded.

## Implementation

- New `src/domain/effects/death.ts` — pure queries (`conditionValue`, `findConditionInstance`, `dyingDeathThreshold`).
- Orchestration in `reducer.ts` (it owns the effect-instance machinery): `applyDying`, `applyFatalDying`, `recoverFromDying`, `applyDyingTransition`, `applyDoomedChange`, branched into `APPLY_EFFECT`, `MODIFY_EFFECT_VALUE`, `SET_EFFECT_VALUE`, `REMOVE_EFFECT`.
- Respects domain purity; no UI/orchestrator API changes (the combat-log formatter and `combatant-died` event already anticipated `dying-threshold`).

## Tests

- New `death.test.ts`: pure helpers + integration coverage of §3.2–3.6 (Wounded fold-in, threshold death, Doomed-lowered threshold, increase-to-death, recovery → Wounded, Wounded cap, dead-combatant cleanup, Doomed re-check, and the turn-start recovery-prompt flow).
- Updated the existing `REMOVE_EFFECT`-cascades test to assert the new recovery → Wounded behavior.

## Gate status

`npm run check` ✅ · `npm run test:run` ✅ (1128 passed, 1 skipped) · `npm run build` ✅

`npm run audit` ❌ — **pre-existing** high-severity vite advisory; `package.json`/`package-lock.json` are untouched by this PR (also red on `master`). Being handled in a separate dependency-bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)